### PR TITLE
Clarified how to make it run in Nixos

### DIFF
--- a/wiki/Configuration:-Named-Workspaces.md
+++ b/wiki/Configuration:-Named-Workspaces.md
@@ -31,7 +31,8 @@ window-rule {
 }
 ```
 
-Named workspaces initially appear in the order they are declared in the config file.
+Named workspaces initially appear in the order they are declared in the config file and that's the number they are assigned implicitely. If you modify them or create them while using Niri the order would not be assigned correctly, you'll need to restart Niri for their ordering to take effect. 
+
 When editing the config while niri is running, newly declared named workspaces will appear at the very top of a monitor.
 
 If you delete some named workspace from the config, the workspace will become normal (unnamed), and if there are no windows on it, it will be removed (as any other normal workspace).

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -66,6 +66,25 @@ When this happens, you usually see a black screen when trying to start niri from
 
 Also, on Intel graphics, you may need a workaround described [here](https://nixos.wiki/wiki/Intel_Graphics).
 
+To run Niri on NixOS is as simple as editing your configuration.nix to add
+
+```nix
+{
+    programs.niri.enable = true;
+}
+```
+
+For your Electron-based apps to not fail it is highly recommendable you also add on that file
+
+```
+{
+  environment = {
+    sessionVariables.NIXOS_OZONE_WL = "1";
+    sessionVariables.ELECTRON_OZONE_PLATFORM_HINT = "auto";
+  };
+}
+```
+
 ### Virtual Machines
 
 To run niri in a VM, make sure to enable 3D acceleration.


### PR DESCRIPTION
There seems to be an excess of information on how to run a flake but not on how to basically get it up and running in configuration.nix on Nixos when it is mostly programs.niri.enable = true; and that's it. 

So I modified a page in Getting Started to make this clearer. Including how to fix the Electron problem. 