### PR TITLE
Implement `wp_single_pixel_buffer_manager_v1` in render helpers

### DIFF
--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -989,23 +989,27 @@ impl<W: LayoutElement> Tile<W> {
                                         // program shader. To work around this, we can use a
                                         // `BorderRenderElement` when we detect that we need to clip
                                         // a solid color texture.
-                                        return BorderRenderElement::new(
-                                            geo.size,
-                                            Rectangle::from_size(geo.size),
-                                            GradientInterpolation::default(),
-                                            // color32_f uses premultiplied alpha which matches
-                                            // what `BorderRenderElement` expects
-                                            Color::from_color32f(*color32_f),
-                                            Color::from_color32f(*color32_f),
-                                            0.,
-                                            Rectangle::from_size(geo.size),
-                                            0.,
-                                            radius,
-                                            scale.x as f32,
-                                            1.,
-                                        )
-                                        .with_location(geo.loc)
-                                        .into();
+                                        let elem_geo =
+                                            elem.geometry(scale).to_f64().to_logical(scale);
+                                        if let Some(shader_geo) = geo.intersection(elem_geo) {
+                                            return BorderRenderElement::new(
+                                                shader_geo.size,
+                                                Rectangle::from_size(shader_geo.size),
+                                                GradientInterpolation::default(),
+                                                // color32_f uses premultiplied alpha which matches
+                                                // what `BorderRenderElement` expects
+                                                Color::from_color32f(*color32_f),
+                                                Color::from_color32f(*color32_f),
+                                                0.,
+                                                Rectangle::new(geo.loc - shader_geo.loc, geo.size),
+                                                0.,
+                                                radius,
+                                                scale.x as f32,
+                                                1.,
+                                            )
+                                            .with_location(shader_geo.loc)
+                                            .into();
+                                        }
                                     }
                                 }
                             }

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -993,6 +993,8 @@ impl<W: LayoutElement> Tile<W> {
                                             geo.size,
                                             Rectangle::from_size(geo.size),
                                             GradientInterpolation::default(),
+                                            // color32_f uses premultiplied alpha which matches
+                                            // what `BorderRenderElement` expects
                                             Color::from_color32f(*color32_f),
                                             Color::from_color32f(*color32_f),
                                             0.,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -100,7 +100,6 @@ use smithay::wayland::shell::wlr_layer::{self, Layer, WlrLayerShellState};
 use smithay::wayland::shell::xdg::decoration::XdgDecorationState;
 use smithay::wayland::shell::xdg::XdgShellState;
 use smithay::wayland::shm::ShmState;
-#[cfg(test)]
 use smithay::wayland::single_pixel_buffer::SinglePixelBufferState;
 use smithay::wayland::socket::ListeningSocketSource;
 use smithay::wayland::tablet_manager::TabletManagerState;
@@ -298,13 +297,6 @@ pub struct Niri {
     pub activation_state: XdgActivationState,
     pub mutter_x11_interop_state: MutterX11InteropManagerState,
 
-    // This will not work as is outside of tests, so it is gated with #[cfg(test)] for now. In
-    // particular, shaders will need to learn about the single pixel buffer. Also, it must be
-    // verified that a black single-pixel-buffer background lets the foreground surface to be
-    // unredirected.
-    //
-    // https://github.com/YaLTeR/niri/issues/619
-    #[cfg(test)]
     pub single_pixel_buffer_state: SinglePixelBufferState,
 
     pub seat: Seat<State>,
@@ -2406,7 +2398,6 @@ impl Niri {
         let mutter_x11_interop_state =
             MutterX11InteropManagerState::new::<State, _>(&display_handle, move |_| true);
 
-        #[cfg(test)]
         let single_pixel_buffer_state = SinglePixelBufferState::new::<State>(&display_handle);
 
         let mut seat: Seat<State> = seat_state.new_wl_seat(&display_handle, backend.seat_name());
@@ -2608,7 +2599,6 @@ impl Niri {
             gamma_control_manager_state,
             activation_state,
             mutter_x11_interop_state,
-            #[cfg(test)]
             single_pixel_buffer_state,
 
             seat,

--- a/src/render_helpers/surface.rs
+++ b/src/render_helpers/surface.rs
@@ -68,13 +68,15 @@ pub fn render_snapshot_from_surface_tree(
                         .buffer()
                         .and_then(|buffer| get_single_pixel_buffer(buffer).ok())
                     {
-                        let pixel: [u8; 4] = single_pixel_buffer_user_data.rgba8888();
-                        let argb_pixel = [pixel[3], pixel[1], pixel[2], pixel[0]];
+                        let mut pixel: [u8; 4] = single_pixel_buffer_user_data.rgba8888();
+                        // Needs to be reversed since `GlesRenderer` supports importing memory in
+                        // Abgr8888 but not Rgba8888
+                        pixel.reverse();
 
                         TextureBuffer::from_memory(
                             renderer,
-                            &argb_pixel,
-                            Fourcc::Argb8888,
+                            &pixel,
+                            Fourcc::Abgr8888,
                             Size::from((1, 1)),
                             false,
                             f64::from(data.buffer_scale()),

--- a/src/render_helpers/surface.rs
+++ b/src/render_helpers/surface.rs
@@ -68,7 +68,10 @@ pub fn render_snapshot_from_surface_tree(
                         .buffer()
                         .and_then(|buffer| get_single_pixel_buffer(buffer).ok())
                     {
+                        // this pixel uses premultiplied alpha,
+                        // which is what `TextureBuffer` expects
                         let mut pixel: [u8; 4] = single_pixel_buffer_user_data.rgba8888();
+
                         // Needs to be reversed since `GlesRenderer` supports importing memory in
                         // Abgr8888 but not Rgba8888
                         pixel.reverse();


### PR DESCRIPTION
I wanted to take a crack at #619 but don't have much prior experience with GPU programming or wayland dev, so I'm putting up my first bits of progress to make sure I'm doing the right thing.

I'm not sure exactly how to test whether the results of `render_snapshot_from_surface_tree` are correct, at first glance it's used in parts of the logic for when surfaces are "animated" by resizing, becoming floating, closing, etc. So far I've just made sure that the code path I'm writing is being taken during float and that the texture buffer is created in a way that seems to make sense.

Thanks in advance for any review :smile: