### PR TITLE
Stop including broken LFS files in source tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,12 @@
+# LFS configuration for images from the wiki
 *.png filter=lfs diff=lfs merge=lfs -text
+
+# Exclude LFS-tracked files from the tarball
+/wiki/img/ export-ignore
+
+# exclude .gitattributes itself from the tarball
+.gitattributes export-ignore
+
+# tip: can be tested using
+# git archive --format=tar.gz --output=source.tar.gz HEAD && \
+# tar tfvz source.tar.gz | grep -e '.png' -e '.gitattributes'


### PR DESCRIPTION
The release tarball at https://github.com/YaLTeR/niri/tags contains broken files due to github using `git archive` without LFS support. This change prevents the LFS entities  and the .gitattributes file from being included (source tarballs should be git-agnostic).