### PR TITLE
window: allow to set per-window view offset

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -385,6 +385,11 @@ pub enum Action {
     MruSetScope(MruScope),
     #[knuffel(skip)]
     MruCycleScope,
+    #[knuffel(skip)]
+    ViewOffset {
+        id: Option<u64>,
+        offset: f64,
+    },
 }
 
 impl From<niri_ipc::Action> for Action {
@@ -692,6 +697,7 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::SetWindowUrgent { id } => Self::SetWindowUrgent(id),
             niri_ipc::Action::UnsetWindowUrgent { id } => Self::UnsetWindowUrgent(id),
             niri_ipc::Action::LoadConfigFile {} => Self::LoadConfigFile,
+            niri_ipc::Action::ViewOffset { id, offset } => Self::ViewOffset { id, offset },
         }
     }
 }

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -390,6 +390,11 @@ pub enum Action {
     MruSetScope(MruScope),
     #[knuffel(skip)]
     MruCycleScope,
+    #[knuffel(skip)]
+    ViewOffset {
+        id: Option<u64>,
+        offset: f64,
+    },
 }
 
 impl From<niri_ipc::Action> for Action {
@@ -701,6 +706,7 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::SetWindowUrgent { id } => Self::SetWindowUrgent(id),
             niri_ipc::Action::UnsetWindowUrgent { id } => Self::UnsetWindowUrgent(id),
             niri_ipc::Action::LoadConfigFile { path } => Self::LoadConfigFile(path),
+            niri_ipc::Action::ViewOffset { id, offset } => Self::ViewOffset { id, offset },
         }
     }
 }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1318,6 +1318,8 @@ pub struct Window {
     ///
     /// The timestamp comes from the monotonic clock.
     pub focus_timestamp: Option<Timestamp>,
+    /// Offset of screen for this window
+    pub view_offset: f64,
 }
 
 /// A moment in time.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -916,6 +916,17 @@ pub enum Action {
     /// Can be useful for scripts changing the config file, to avoid waiting the small duration for
     /// niri's config file watcher to notice the changes.
     LoadConfigFile {},
+    /// Set view offset of window.
+    ViewOffset {
+        /// Id of the window to set view offset.
+        ///
+        /// If `None`, uses the focused window.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+        /// View offset to set
+        #[cfg_attr(feature = "clap", arg(long))]
+        offset: f64,
+    },
 }
 
 /// Change in window or column size.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -943,6 +943,17 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         path: Option<String>,
     },
+    /// Set view offset of window.
+    ViewOffset {
+        /// Id of the window to set view offset.
+        ///
+        /// If `None`, uses the focused window.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+        /// View offset to set
+        #[cfg_attr(feature = "clap", arg(long))]
+        offset: f64,
+    },
 }
 
 /// Change in window or column size.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1345,6 +1345,8 @@ pub struct Window {
     ///
     /// The timestamp comes from the monotonic clock.
     pub focus_timestamp: Option<Timestamp>,
+    /// Offset of screen for this window
+    pub view_offset: f64,
 }
 
 /// A moment in time.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2374,6 +2374,23 @@ impl State {
                     self.niri.queue_redraw_mru_output();
                 }
             }
+            Action::ViewOffset{ id, offset, } => {
+                let window = if let Some(id) = id {
+                    self.niri
+                        .layout
+                        .workspaces_mut()
+                        .find_map(|ws| ws.windows_mut().find(|w| w.id().get() == id))
+                } else {
+                    self.niri
+                        .layout
+                        .active_workspace_mut()
+                        .and_then(|ws| ws.active_window_mut())
+                };
+                if let Some(window) = window {
+                    window.set_view_offset(offset);
+                }
+                self.niri.queue_redraw_all();
+            }
         }
     }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2382,6 +2382,23 @@ impl State {
                     self.niri.queue_redraw_mru_output();
                 }
             }
+            Action::ViewOffset{ id, offset, } => {
+                let window = if let Some(id) = id {
+                    self.niri
+                        .layout
+                        .workspaces_mut()
+                        .find_map(|ws| ws.windows_mut().find(|w| w.id().get() == id))
+                } else {
+                    self.niri
+                        .layout
+                        .active_workspace_mut()
+                        .and_then(|ws| ws.active_window_mut())
+                };
+                if let Some(window) = window {
+                    window.set_view_offset(offset);
+                }
+                self.niri.queue_redraw_all();
+            }
         }
     }
 

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -515,6 +515,7 @@ fn make_ipc_window(
         is_urgent: mapped.is_urgent(),
         layout,
         focus_timestamp: mapped.get_focus_timestamp().map(Timestamp::from),
+        view_offset: mapped.get_view_offset(),
     })
 }
 
@@ -705,8 +706,9 @@ impl State {
             };
 
             let workspace_id = ws_id.map(|id| id.get());
-            let mut changed =
-                ipc_win.workspace_id != workspace_id || ipc_win.is_floating != mapped.is_floating();
+            let mut changed = ipc_win.workspace_id != workspace_id
+                || ipc_win.is_floating != mapped.is_floating()
+                || ipc_win.view_offset != mapped.get_view_offset();
 
             changed |= with_toplevel_role(mapped.toplevel(), |role| {
                 ipc_win.title != role.title || ipc_win.app_id != role.app_id

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -528,6 +528,7 @@ fn make_ipc_window(
         is_urgent: mapped.is_urgent(),
         layout,
         focus_timestamp: mapped.get_focus_timestamp().map(Timestamp::from),
+        view_offset: mapped.get_view_offset(),
     })
 }
 
@@ -718,8 +719,9 @@ impl State {
             };
 
             let workspace_id = ws_id.map(|id| id.get());
-            let mut changed =
-                ipc_win.workspace_id != workspace_id || ipc_win.is_floating != mapped.is_floating();
+            let mut changed = ipc_win.workspace_id != workspace_id
+                || ipc_win.is_floating != mapped.is_floating()
+                || ipc_win.view_offset != mapped.get_view_offset();
 
             changed |= with_toplevel_role(mapped.toplevel(), |role| {
                 ipc_win.title != role.title || ipc_win.app_id != role.app_id

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -218,6 +218,11 @@ pub trait LayoutElement {
 
     fn is_urgent(&self) -> bool;
 
+    fn get_view_offset(&self) -> f64
+    {
+        0.0
+    }
+
     fn configure_intent(&self) -> ConfigureIntent;
     fn send_pending_configure(&mut self);
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -246,6 +246,11 @@ pub trait LayoutElement {
 
     fn is_urgent(&self) -> bool;
 
+    fn get_view_offset(&self) -> f64
+    {
+        0.0
+    }
+
     fn configure_intent(&self) -> ConfigureIntent;
     fn send_pending_configure(&mut self);
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -599,7 +599,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             self.column_x(idx),
             col.width(),
             col.sizing_mode(),
-        )
+        ) + col.get_view_offset()
     }
 
     fn compute_new_view_offset_for_column_centered(
@@ -613,7 +613,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             self.column_x(idx),
             col.width(),
             col.sizing_mode(),
-        )
+        ) + col.get_view_offset()
     }
 
     fn compute_new_view_offset_for_column(
@@ -5434,6 +5434,13 @@ impl<W: LayoutElement> Column<W> {
                  (total height {total_height} > max height {max_height})"
             );
         }
+    }
+
+    pub fn get_view_offset(&self) -> f64
+    {
+        self.tiles.iter().fold(0.0, |offset, tile| {
+            offset + tile.window().get_view_offset()
+        })
     }
 }
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -600,7 +600,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             self.column_x(idx),
             col.width(),
             col.sizing_mode(),
-        )
+        ) + col.get_view_offset()
     }
 
     fn compute_new_view_offset_for_column_centered(
@@ -614,7 +614,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             self.column_x(idx),
             col.width(),
             col.sizing_mode(),
-        )
+        ) + col.get_view_offset()
     }
 
     fn compute_new_view_offset_for_column(
@@ -5451,6 +5451,13 @@ impl<W: LayoutElement> Column<W> {
                  (total height {total_height} > max height {max_height})"
             );
         }
+    }
+
+    pub fn get_view_offset(&self) -> f64
+    {
+        self.tiles.iter().fold(0.0, |offset, tile| {
+            offset + tile.window().get_view_offset()
+        })
     }
 }
 

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -84,6 +84,11 @@ pub struct Mapped {
     /// Whether this has an urgent indicator.
     is_urgent: bool,
 
+    /// View offset of window.
+    ///
+    /// This field makes view to be shifted while current window is focused.
+    view_offset: f64,
+
     /// Whether this window has the keyboard focus.
     is_focused: bool,
 
@@ -262,6 +267,7 @@ impl Mapped {
             needs_frame_callback: false,
             offscreen_data: RefCell::new(None),
             is_urgent: false,
+            view_offset: 0.0,
             is_focused: false,
             is_active_in_column: true,
             is_floating: false,
@@ -572,6 +578,14 @@ impl Mapped {
 
     pub fn is_urgent(&self) -> bool {
         self.is_urgent
+    }
+
+    pub fn set_view_offset(&mut self, offset: f64) {
+        self.view_offset = offset;
+    }
+
+    pub fn get_view_offset(&self) -> f64 {
+        self.view_offset
     }
 }
 
@@ -916,6 +930,10 @@ impl LayoutElement for Mapped {
 
     fn is_urgent(&self) -> bool {
         self.is_urgent
+    }
+
+    fn get_view_offset(&self) -> f64 {
+        self.view_offset
     }
 
     fn set_activated(&mut self, active: bool) {

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -88,6 +88,11 @@ pub struct Mapped {
     /// Whether this has an urgent indicator.
     is_urgent: bool,
 
+    /// View offset of window.
+    ///
+    /// This field makes view to be shifted while current window is focused.
+    view_offset: f64,
+
     /// Whether this window has the keyboard focus.
     is_focused: bool,
 
@@ -286,6 +291,7 @@ impl Mapped {
             needs_frame_callback: false,
             offscreen_data: RefCell::new(None),
             is_urgent: false,
+            view_offset: 0.0,
             is_focused: false,
             is_active_in_column: true,
             is_floating: false,
@@ -610,6 +616,14 @@ impl Mapped {
 
     pub fn is_urgent(&self) -> bool {
         self.is_urgent
+    }
+
+    pub fn set_view_offset(&mut self, offset: f64) {
+        self.view_offset = offset;
+    }
+
+    pub fn get_view_offset(&self) -> f64 {
+        self.view_offset
     }
 }
 
@@ -976,6 +990,10 @@ impl LayoutElement for Mapped {
 
     fn is_urgent(&self) -> bool {
         self.is_urgent
+    }
+
+    fn get_view_offset(&self) -> f64 {
+        self.view_offset
     }
 
     fn set_activated(&mut self, active: bool) {


### PR DESCRIPTION
This allows to set view_offset for window, which makes workspace to shift it view while window is focused.

## Rationale

While vim still does not fully supports external windows, I'm working on workaround, which allows me to create windows with no limit. Niri implements ideal concept of no-limit tape of windows for this workaround. So, in theory I can create os-window of no limit width and place there no limit number of vim-windows of fixed width side-by-side.

For this Niri lucks of single one functionality: the dynamic focus on special offset of os-window which is wider then screen. 

Here is video which demonstrates work of my current setup with vim, my [integration utility](https://github.com/ein-shved/niri-integration) and Niri, patched with this PR.

https://github.com/user-attachments/assets/f57ac773-f4c7-4818-93b7-0e79dda080c5

