### PR TITLE
Per-device touch and tablet config

### DIFF
--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -4,7 +4,8 @@ In this section you can configure input devices like keyboard and mouse, and som
 
 There's a section for each device type: `keyboard`, `touchpad`, `mouse`, `trackpoint`, `trackball`, `tablet`, `touch`.
 Settings in those sections will apply to every device of that type.
-Currently, there's no way to configure specific devices individually (but that is planned).
+Currently, there's no way to configure specific `keyboard`, `touchpad`, `mouse`, or `trackpoint` devices
+individually (but that is planned).
 
 All settings at a glance:
 
@@ -280,6 +281,35 @@ input {
 Valid output names are the same as the ones used for output configuration.
 
 <sup>Since: 0.1.7</sup> When a tablet is not mapped to any output, it will map to the union of all connected outputs, without aspect ratio correction.
+
+> [!TIP]
+>
+> <sup>Since: next release</sup>
+>
+> It is possible to configure specific `tablet` and `touch` devices by name.
+>
+> Any non‑device‑specific settings will apply as a fallback when no matching device‑specific block exists:
+>
+> ```kdl
+> input {
+>     tablet {
+>         map-to-output "eDP-1";
+>     }
+>
+>     // Map this specific tablet to a different output.
+>     tablet "ELAN9009:00 04F3:2F2A Stylus" {
+>         map-to-output "DP-1";
+>     }
+>
+>     // Map this specific touchscreen to DP-1.
+>     touch "ELAN9009:00 04F3:2F2A" {
+>         map-to-output "DP-1";
+>     }
+> }
+> ```
+>
+> The device name is case-insensitive.
+> Device names are taken from libinput; you can find them by running `sudo libinput list-devices` or `sudo libinput debug-events`.
 
 ### General Settings
 

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -777,6 +777,47 @@ mod tests {
     }
 
     #[test]
+    fn parse_touch_screens_name() {
+        // Test no name and name provided
+        let parsed = do_parse(
+            r#"
+            touch {
+                map-to-output "eDP-1"
+            }
+
+            touch "ELAN9009:00 04F3:2F2A" {
+                map-to-output "DP-1"
+            }
+            "#,
+        );
+
+        assert_debug_snapshot!(parsed.touch_screens, @r#"
+        TouchScreens(
+            [
+                Touch {
+                    name: None,
+                    off: false,
+                    calibration_matrix: None,
+                    map_to_output: Some(
+                        "eDP-1",
+                    ),
+                },
+                Touch {
+                    name: Some(
+                        "ELAN9009:00 04F3:2F2A",
+                    ),
+                    off: false,
+                    calibration_matrix: None,
+                    map_to_output: Some(
+                        "DP-1",
+                    ),
+                },
+            ],
+        )
+        "#);
+    }
+
+    #[test]
     fn scroll_factor_h_v_factors() {
         let sf = ScrollFactor {
             base: Some(FloatOrInt(2.0)),

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -16,7 +16,7 @@ pub struct Input {
     pub trackpoint: Trackpoint,
     pub trackball: Trackball,
     pub tablet: Tablet,
-    pub touch: Touch,
+    pub touch_screens: TouchScreens,
     pub disable_power_key_handling: bool,
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
@@ -39,8 +39,8 @@ pub struct InputPart {
     pub trackball: Option<Trackball>,
     #[knuffel(child)]
     pub tablet: Option<Tablet>,
-    #[knuffel(child)]
-    pub touch: Option<Touch>,
+    #[knuffel(children(name = "touch"))]
+    pub touch_screens: TouchScreens,
     #[knuffel(child)]
     pub disable_power_key_handling: Option<Flag>,
     #[knuffel(child)]
@@ -64,15 +64,7 @@ impl MergeWith<InputPart> for Input {
             workspace_auto_back_and_forth,
         );
 
-        merge_clone!(
-            (self, part),
-            touchpad,
-            mouse,
-            trackpoint,
-            trackball,
-            tablet,
-            touch,
-        );
+        merge_clone!((self, part), touchpad, mouse, trackpoint, trackball, tablet);
 
         merge_clone_opt!(
             (self, part),
@@ -81,6 +73,10 @@ impl MergeWith<InputPart> for Input {
             mod_key,
             mod_key_nested,
         );
+
+        self.touch_screens
+            .0
+            .extend(part.touch_screens.0.iter().cloned());
     }
 }
 

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -15,7 +15,7 @@ pub struct Input {
     pub mouse: Mouse,
     pub trackpoint: Trackpoint,
     pub trackball: Trackball,
-    pub tablet: Tablet,
+    pub tablets: Tablets,
     pub touch_screens: TouchScreens,
     pub disable_power_key_handling: bool,
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
@@ -37,8 +37,8 @@ pub struct InputPart {
     pub trackpoint: Option<Trackpoint>,
     #[knuffel(child)]
     pub trackball: Option<Trackball>,
-    #[knuffel(child)]
-    pub tablet: Option<Tablet>,
+    #[knuffel(children(name = "tablet"))]
+    pub tablets: Tablets,
     #[knuffel(children(name = "touch"))]
     pub touch_screens: TouchScreens,
     #[knuffel(child)]
@@ -64,7 +64,7 @@ impl MergeWith<InputPart> for Input {
             workspace_auto_back_and_forth,
         );
 
-        merge_clone!((self, part), touchpad, mouse, trackpoint, trackball, tablet);
+        merge_clone!((self, part), touchpad, mouse, trackpoint, trackball);
 
         merge_clone_opt!(
             (self, part),
@@ -74,6 +74,7 @@ impl MergeWith<InputPart> for Input {
             mod_key_nested,
         );
 
+        self.tablets.0.extend(part.tablets.0.iter().cloned());
         self.touch_screens
             .0
             .extend(part.touch_screens.0.iter().cloned());

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -351,8 +351,10 @@ impl From<TapButtonMap> for input::TapButtonMap {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, PartialEq)]
 pub struct Tablet {
+    #[knuffel(argument)]
+    pub name: Option<String>,
     #[knuffel(child)]
     pub off: bool,
     #[knuffel(child, unwrap(arguments))]
@@ -361,6 +363,42 @@ pub struct Tablet {
     pub map_to_output: Option<String>,
     #[knuffel(child)]
     pub left_handed: bool,
+}
+
+const DEFAULT_TABLET: Tablet = Tablet {
+    name: None,
+    off: false,
+    calibration_matrix: None,
+    map_to_output: None,
+    left_handed: false,
+};
+impl Default for Tablet {
+    fn default() -> Self {
+        DEFAULT_TABLET
+    }
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct Tablets(pub Vec<Tablet>);
+
+impl FromIterator<Tablet> for Tablets {
+    fn from_iter<T: IntoIterator<Item = Tablet>>(iter: T) -> Self {
+        Self(Vec::from_iter(iter))
+    }
+}
+
+impl Tablets {
+    pub fn find<'a>(&'a self, name: Option<&str>) -> &'a Tablet {
+        name.and_then(|name| {
+            self.0.iter().find(|t| {
+                t.name
+                    .as_deref()
+                    .is_some_and(|n| n.eq_ignore_ascii_case(name))
+            })
+        })
+        .or_else(|| self.0.iter().find(|t| t.name.is_none()))
+        .unwrap_or(&DEFAULT_TABLET)
+    }
 }
 
 #[derive(knuffel::Decode, Debug, Clone, PartialEq)]

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -777,6 +777,49 @@ mod tests {
     }
 
     #[test]
+    fn parse_tablets_name() {
+        // Test no name and name provided
+        let parsed = do_parse(
+            r#"
+            tablet {
+                map-to-output "eDP-1"
+            }
+
+            tablet "ELAN9009:00 04F3:2F2A Stylus" {
+                map-to-output "DP-1"
+            }
+            "#,
+        );
+
+        assert_debug_snapshot!(parsed.tablets, @r#"
+        Tablets(
+            [
+                Tablet {
+                    name: None,
+                    off: false,
+                    calibration_matrix: None,
+                    map_to_output: Some(
+                        "eDP-1",
+                    ),
+                    left_handed: false,
+                },
+                Tablet {
+                    name: Some(
+                        "ELAN9009:00 04F3:2F2A Stylus",
+                    ),
+                    off: false,
+                    calibration_matrix: None,
+                    map_to_output: Some(
+                        "DP-1",
+                    ),
+                    left_handed: false,
+                },
+            ],
+        )
+        "#);
+    }
+
+    #[test]
     fn parse_touch_screens_name() {
         // Test no name and name provided
         let parsed = do_parse(

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1099,13 +1099,18 @@ mod tests {
                     ),
                     left_handed: false,
                 },
-                touch: Touch {
-                    off: false,
-                    calibration_matrix: None,
-                    map_to_output: Some(
-                        "eDP-1",
-                    ),
-                },
+                touch_screens: TouchScreens(
+                    [
+                        Touch {
+                            name: None,
+                            off: false,
+                            calibration_matrix: None,
+                            map_to_output: Some(
+                                "eDP-1",
+                            ),
+                        },
+                    ],
+                ),
                 disable_power_key_handling: true,
                 warp_mouse_to_focus: Some(
                     WarpMouseToFocus {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1082,23 +1082,28 @@ mod tests {
                     left_handed: true,
                     middle_emulation: true,
                 },
-                tablet: Tablet {
-                    off: false,
-                    calibration_matrix: Some(
-                        [
-                            1.0,
-                            2.0,
-                            3.0,
-                            4.0,
-                            5.0,
-                            6.0,
-                        ],
-                    ),
-                    map_to_output: Some(
-                        "eDP-1",
-                    ),
-                    left_handed: false,
-                },
+                tablets: Tablets(
+                    [
+                        Tablet {
+                            name: None,
+                            off: false,
+                            calibration_matrix: Some(
+                                [
+                                    1.0,
+                                    2.0,
+                                    3.0,
+                                    4.0,
+                                    5.0,
+                                    6.0,
+                                ],
+                            ),
+                            map_to_output: Some(
+                                "eDP-1",
+                            ),
+                            left_handed: false,
+                        },
+                    ],
+                ),
                 touch_screens: TouchScreens(
                     [
                         Touch {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -129,7 +129,7 @@ impl SeatHandler for State {
         let keyboards = self
             .niri
             .devices
-            .iter()
+            .keys()
             .filter(|device| device.has_capability(input::DeviceCapability::Keyboard))
             .cloned();
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -69,6 +69,11 @@ use backend_ext::{NiriInputBackend as InputBackend, NiriInputDevice as _};
 
 pub const DOUBLE_CLICK_TIME: Duration = Duration::from_millis(400);
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeviceData {
+    pub name: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TabletData {
     pub aspect_ratio: f64,
@@ -198,7 +203,9 @@ impl State {
 
         match event {
             InputEvent::DeviceAdded { device } => {
-                self.niri.devices.insert(device.clone());
+                let name = device.name().to_string();
+                let data = DeviceData { name };
+                self.niri.devices.insert(device.clone(), data);
 
                 if device.has_capability(input::DeviceCapability::TabletTool) {
                     match device.size() {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4057,11 +4057,23 @@ impl State {
     fn compute_touch_location<I: InputBackend>(
         &self,
         evt: &impl AbsolutePositionEvent<I>,
-    ) -> Option<Point<f64, Logical>> {
-        self.compute_absolute_location(evt, self.niri.output_for_touch())
+    ) -> Option<Point<f64, Logical>>
+    where
+        I::Device: 'static,
+    {
+        let data = (&evt.device() as &dyn Any)
+            .downcast_ref::<input::Device>()
+            .and_then(|device| self.niri.devices.get(device));
+        self.compute_absolute_location(
+            evt,
+            self.niri.output_for_touch(data.map(|d| d.name.as_str())),
+        )
     }
 
-    fn on_touch_down<I: InputBackend>(&mut self, evt: I::TouchDownEvent) {
+    fn on_touch_down<I: InputBackend>(&mut self, evt: I::TouchDownEvent)
+    where
+        I::Device: 'static,
+    {
         let Some(handle) = self.niri.seat.get_touch() else {
             return;
         };
@@ -4216,7 +4228,10 @@ impl State {
             },
         )
     }
-    fn on_touch_motion<I: InputBackend>(&mut self, evt: I::TouchMotionEvent) {
+    fn on_touch_motion<I: InputBackend>(&mut self, evt: I::TouchMotionEvent)
+    where
+        I::Device: 'static,
+    {
         let Some(handle) = self.niri.seat.get_touch() else {
             return;
         };
@@ -4933,7 +4948,7 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
     let is_touch = device.has_capability(input::DeviceCapability::Touch);
     if is_touch {
-        let c = &config.touch;
+        let c = config.touch_screens.find(Some(device.name()));
         let _ = device.config_send_events_set_mode(if c.off {
             input::SendEventsMode::DISABLED
         } else {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -299,27 +299,32 @@ impl State {
     where
         I::Device: 'static,
     {
-        let device_output = event.device().output(self);
+        let device = event.device();
+        let device_output = device.output(self);
         let device_output = device_output.as_ref();
-        let (target_geo, keep_ratio, px, transform) =
-            if let Some(output) = device_output.or_else(|| self.niri.output_for_tablet()) {
-                (
-                    self.niri.global_space.output_geometry(output).unwrap(),
-                    true,
-                    1. / output.current_scale().fractional_scale(),
-                    output.current_transform(),
-                )
-            } else {
-                let geo = self.global_bounding_rectangle()?;
+        let data = (&device as &dyn Any)
+            .downcast_ref::<input::Device>()
+            .and_then(|device| self.niri.devices.get(device));
+        let (target_geo, keep_ratio, px, transform) = if let Some(output) =
+            device_output.or_else(|| self.niri.output_for_tablet(data.map(|d| d.name.as_ref())))
+        {
+            (
+                self.niri.global_space.output_geometry(output).unwrap(),
+                true,
+                1. / output.current_scale().fractional_scale(),
+                output.current_transform(),
+            )
+        } else {
+            let geo = self.global_bounding_rectangle()?;
 
-                // FIXME: this 1 px size should ideally somehow be computed for the rightmost output
-                // corresponding to the position on the right when clamping.
-                let output = self.niri.global_space.outputs().next().unwrap();
-                let scale = output.current_scale().fractional_scale();
+            // FIXME: this 1 px size should ideally somehow be computed for the rightmost output
+            // corresponding to the position on the right when clamping.
+            let output = self.niri.global_space.outputs().next().unwrap();
+            let scale = output.current_scale().fractional_scale();
 
-                // Do not keep ratio for the unified mode as this is what OpenTabletDriver expects.
-                (geo, false, 1. / scale, Transform::Normal)
-            };
+            // Do not keep ratio for the unified mode as this is what OpenTabletDriver expects.
+            (geo, false, 1. / scale, Transform::Normal)
+        };
 
         let mut pos = {
             let size = transform.invert().transform_size(target_geo.size);
@@ -4922,7 +4927,7 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
 
     let is_tablet = device.has_capability(input::DeviceCapability::TabletTool);
     if is_tablet {
-        let c = &config.tablet;
+        let c = config.tablets.find(Some(device.name()));
         let _ = device.config_send_events_set_mode(if c.off {
             input::SendEventsMode::DISABLED
         } else {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -132,7 +132,7 @@ use crate::input::scroll_swipe_gesture::ScrollSwipeGesture;
 use crate::input::scroll_tracker::ScrollTracker;
 use crate::input::{
     apply_libinput_settings, mods_with_finger_scroll_binds, mods_with_mouse_binds,
-    mods_with_wheel_binds, TabletData,
+    mods_with_wheel_binds, DeviceData, TabletData,
 };
 use crate::ipc::server::IpcServer;
 use crate::layer::mapped::LayerSurfaceRenderElement;
@@ -265,7 +265,7 @@ pub struct Niri {
     /// startup, libinput will immediately send a closed event.
     pub is_lid_closed: bool,
 
-    pub devices: HashSet<input::Device>,
+    pub devices: HashMap<input::Device, DeviceData>,
     pub tablets: HashMap<input::Device, TabletData>,
     pub touch: HashSet<input::Device>,
 
@@ -1633,7 +1633,7 @@ impl State {
 
         if libinput_config_changed {
             let config = self.niri.config.borrow();
-            for mut device in self.niri.devices.iter().cloned() {
+            for mut device in self.niri.devices.keys().cloned() {
                 apply_libinput_settings(&config.input, &mut device);
             }
         }
@@ -2500,7 +2500,7 @@ impl Niri {
             monitors_active: true,
             is_lid_closed: false,
 
-            devices: HashSet::new(),
+            devices: HashMap::new(),
             tablets: HashMap::new(),
             touch: HashSet::new(),
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1495,7 +1495,7 @@ impl State {
             || config.input.trackball != old_config.input.trackball
             || config.input.trackpoint != old_config.input.trackpoint
             || config.input.tablet != old_config.input.tablet
-            || config.input.touch != old_config.input.touch
+            || config.input.touch_screens != old_config.input.touch_screens
         {
             libinput_config_changed = true;
         }
@@ -3584,9 +3584,9 @@ impl Niri {
         map_to_output.and_then(|name| self.output_by_name_match(name))
     }
 
-    pub fn output_for_touch(&self) -> Option<&Output> {
+    pub fn output_for_touch(&self, name: Option<&str>) -> Option<&Output> {
         let config = self.config.borrow();
-        let map_to_output = config.input.touch.map_to_output.as_ref();
+        let map_to_output = config.input.touch_screens.find(name).map_to_output.as_ref();
         map_to_output
             .and_then(|name| self.output_by_name_match(name))
             .or_else(|| self.global_space.outputs().next())

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1494,7 +1494,7 @@ impl State {
             || config.input.mouse != old_config.input.mouse
             || config.input.trackball != old_config.input.trackball
             || config.input.trackpoint != old_config.input.trackpoint
-            || config.input.tablet != old_config.input.tablet
+            || config.input.tablets != old_config.input.tablets
             || config.input.touch_screens != old_config.input.touch_screens
         {
             libinput_config_changed = true;
@@ -3578,9 +3578,9 @@ impl Niri {
             .map(|(_, m)| m.window.clone())
     }
 
-    pub fn output_for_tablet(&self) -> Option<&Output> {
+    pub fn output_for_tablet(&self, name: Option<&str>) -> Option<&Output> {
         let config = self.config.borrow();
-        let map_to_output = config.input.tablet.map_to_output.as_ref();
+        let map_to_output = config.input.tablets.find(name).map_to_output.as_ref();
         map_to_output.and_then(|name| self.output_by_name_match(name))
     }
 


### PR DESCRIPTION
Allows configuring `touch` and `tablet` by device name, which can be found with  `libinput list-devices` or `libinput debug-events`:

```kdl
input {
    tablet { map-to-output "eDP-1"; }
    tablet "ELAN9009:00 04F3:2F2A Stylus" { map-to-output "DP-1"; }
    touch { map-to-output "eDP-1"; }
    touch "ELAN9009:00 04F3:2F2A" { map-to-output "DP-1"; }
}
```

My Asus Zenbook Duo has dual touchscreens which are also tables, so I have locally tested this change.

Related to #371, Closes #1231