### PR TITLE
Add `niri msg pointer` and `niri msg action set-pointer-location` commands

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -16,8 +16,8 @@ use knuffel::Decode as _;
 use layer_rule::LayerRule;
 use miette::{miette, Context, IntoDiagnostic};
 use niri_ipc::{
-    ColumnDisplay, ConfiguredMode, LayoutSwitchTarget, PositionChange, SizeChange, Transform,
-    WorkspaceReferenceArg,
+    ColumnDisplay, ConfiguredMode, LayoutSwitchTarget, Point, PositionChange, SizeChange,
+    Transform, WorkspaceReferenceArg,
 };
 use smithay::backend::renderer::Color32F;
 use smithay::input::keyboard::keysyms::KEY_NoSymbol;
@@ -1926,6 +1926,8 @@ pub enum Action {
     UnsetWindowUrgent(u64),
     #[knuffel(skip)]
     LoadConfigFile,
+    #[knuffel(skip)]
+    SetPointerLocation(Point),
 }
 
 impl From<niri_ipc::Action> for Action {
@@ -2202,6 +2204,9 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::SetWindowUrgent { id } => Self::SetWindowUrgent(id),
             niri_ipc::Action::UnsetWindowUrgent { id } => Self::UnsetWindowUrgent(id),
             niri_ipc::Action::LoadConfigFile {} => Self::LoadConfigFile,
+            niri_ipc::Action::SetPointerLocation { x, y } => {
+                Self::SetPointerLocation(Point { x, y })
+            }
         }
     }
 }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -178,6 +178,15 @@ pub struct PickedColor {
     pub rgb: [f64; 3],
 }
 
+/// Location coordinates.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd)]
+pub struct Point {
+    /// x coordinate
+    pub x: f64,
+    /// y coordinate
+    pub y: f64,
+}
+
 /// Actions that niri can perform.
 // Variants in this enum should match the spelling of the ones in niri-config. Most, but not all,
 // variants from niri-config should be present here.
@@ -845,6 +854,13 @@ pub enum Action {
     /// Can be useful for scripts changing the config file, to avoid waiting the small duration for
     /// niri's config file watcher to notice the changes.
     LoadConfigFile {},
+    /// Set pointer location
+    SetPointerLocation {
+        /// Desired x coordinate
+        x: f64,
+        /// Desired y coordinate
+        y: f64,
+    },
 }
 
 /// Change in window or column size.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -80,6 +80,8 @@ pub enum Request {
     FocusedOutput,
     /// Request information about the focused window.
     FocusedWindow,
+    /// Request information about the pointer.
+    Pointer,
     /// Request picking a window and get its information.
     PickWindow,
     /// Request picking a color from the screen.
@@ -156,6 +158,8 @@ pub enum Response {
     PickedWindow(Option<Window>),
     /// Information about the picked color.
     PickedColor(Option<PickedColor>),
+    /// Information about the pointer.
+    Pointer(Option<Pointer>),
     /// Output configuration change result.
     OutputConfigChanged(OutputConfigChanged),
     /// Information about the overview.
@@ -185,6 +189,14 @@ pub struct Point {
     pub x: f64,
     /// y coordinate
     pub y: f64,
+}
+
+/// Pointer information.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct Pointer {
+    /// Location of the pointer in the global space.
+    pub location: Point,
 }
 
 /// Actions that niri can perform.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,6 +79,8 @@ pub enum Msg {
     PickWindow,
     /// Pick a color from the screen with the mouse.
     PickColor,
+    /// Print information about the pointer.
+    Pointer,
     /// Perform an action.
     Action {
         #[command(subcommand)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2118,6 +2118,10 @@ impl State {
                     watcher.load_config();
                 }
             }
+            Action::SetPointerLocation(niri_ipc::Point { x, y }) => {
+                let pointer = &self.niri.seat.get_pointer().unwrap();
+                pointer.set_location(Point::new(x, y));
+            }
         }
     }
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -317,7 +317,7 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
 
             if let Some(pointer) = pointer {
                 println!(
-                    "Pointer position: {} {}",
+                    "Pointer location: {} {}",
                     pointer.location.x, pointer.location.y
                 );
             } else {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -22,6 +22,7 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::FocusedOutput => Request::FocusedOutput,
         Msg::PickWindow => Request::PickWindow,
         Msg::PickColor => Request::PickColor,
+        Msg::Pointer => Request::Pointer,
         Msg::Action { action } => Request::Action(action.clone()),
         Msg::Output { output, action } => Request::Output {
             output: output.clone(),
@@ -300,6 +301,27 @@ pub fn handle_msg(msg: Msg, json: bool) -> anyhow::Result<()> {
                 println!("Hex: #{r:02x}{g:02x}{b:02x}");
             } else {
                 println!("No color was picked.");
+            }
+        }
+        Msg::Pointer => {
+            let Response::Pointer(pointer) = response else {
+                bail!("unexpected response: expected PointerPos, got {response:?}");
+            };
+
+            if json {
+                let pointer =
+                    serde_json::to_string(&pointer).context("error formatting response")?;
+                println!("{pointer}");
+                return Ok(());
+            }
+
+            if let Some(pointer) = pointer {
+                println!(
+                    "Pointer position: {} {}",
+                    pointer.location.x, pointer.location.y
+                );
+            } else {
+                println!("No pointer.");
             }
         }
         Msg::Action { .. } => {


### PR DESCRIPTION
This PR implements the following two commands

- `niri msg pointer` which outputs information about the pointer. Currently that would only be the pointer coordinates, but more can be added later.
  - example usage
    ```
    $ niri msg -j pointer
    {"location":{"x":1916.0,"y":557.4905339686553}}

    $ niri msg pointer
    Pointer position: 1916 557.4905339686553
    ```
- `niri msg action set-pointer-location` which moves the pointer to the location specified by x and y coordinates
  - example usage
    ```
    $ niri msg set-pointer-location 1023.5 512
    ```

## Motivation

This feature also exists for Hyprland (`hyprctl cursorpos` and `hyprctl dispatch movecursor`).
It (more or less) solves the following issue of mine: https://github.com/YaLTeR/niri/discussions/1850
