### PR TITLE
feat: add window alignment actions

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1778,6 +1778,15 @@ pub enum Action {
     CenterWindow,
     #[knuffel(skip)]
     CenterWindowById(u64),
+    AlignWindowLeft,
+    #[knuffel(skip)]
+    AlignWindowLeftById(u64),
+    AlignWindowCenter,
+    #[knuffel(skip)]
+    AlignWindowCenterById(u64),
+    AlignWindowRight,
+    #[knuffel(skip)]
+    AlignWindowRightById(u64),
     CenterVisibleColumns,
     FocusWorkspaceDown,
     #[knuffel(skip)]
@@ -2022,6 +2031,12 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::CenterColumn {} => Self::CenterColumn,
             niri_ipc::Action::CenterWindow { id: None } => Self::CenterWindow,
             niri_ipc::Action::CenterWindow { id: Some(id) } => Self::CenterWindowById(id),
+            niri_ipc::Action::AlignWindowLeft { id: None } => Self::AlignWindowLeft,
+            niri_ipc::Action::AlignWindowLeft { id: Some(id) } => Self::AlignWindowLeftById(id),
+            niri_ipc::Action::AlignWindowCenter { id: None } => Self::AlignWindowCenter,
+            niri_ipc::Action::AlignWindowCenter { id: Some(id) } => Self::AlignWindowCenterById(id),
+            niri_ipc::Action::AlignWindowRight { id: None } => Self::AlignWindowRight,
+            niri_ipc::Action::AlignWindowRight { id: Some(id) } => Self::AlignWindowRightById(id),
             niri_ipc::Action::CenterVisibleColumns {} => Self::CenterVisibleColumns,
             niri_ipc::Action::FocusWorkspaceDown {} => Self::FocusWorkspaceDown,
             niri_ipc::Action::FocusWorkspaceUp {} => Self::FocusWorkspaceUp,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -426,6 +426,42 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         id: Option<u64>,
     },
+    /// Align a window to the left edge of the screen.
+    #[cfg_attr(
+        feature = "clap",
+        clap(about = "Align the focused window to the left edge of the screen")
+    )]
+    AlignWindowLeft {
+        /// Id of the window to align.
+        ///
+        /// If `None`, uses the focused window.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+    },
+    /// Align a window to the center of the screen.
+    #[cfg_attr(
+        feature = "clap",
+        clap(about = "Align the focused window to the center of the screen")
+    )]
+    AlignWindowCenter {
+        /// Id of the window to align.
+        ///
+        /// If `None`, uses the focused window.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+    },
+    /// Align a window to the right edge of the screen.
+    #[cfg_attr(
+        feature = "clap",
+        clap(about = "Align the focused window to the right edge of the screen")
+    )]
+    AlignWindowRight {
+        /// Id of the window to align.
+        ///
+        /// If `None`, uses the focused window.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+    },
     /// Center all fully visible columns on the screen.
     CenterVisibleColumns {},
     /// Focus the workspace below.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1467,6 +1467,48 @@ impl State {
                     self.niri.queue_redraw_all();
                 }
             }
+            Action::AlignWindowLeft => {
+                self.niri.layout.left_align_window(None);
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::AlignWindowLeftById(id) => {
+                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
+                let window = window.map(|(_, m)| m.window.clone());
+                if let Some(window) = window {
+                    self.niri.layout.left_align_window(Some(&window));
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
+            Action::AlignWindowCenter => {
+                self.niri.layout.center_window(None);
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::AlignWindowCenterById(id) => {
+                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
+                let window = window.map(|(_, m)| m.window.clone());
+                if let Some(window) = window {
+                    self.niri.layout.center_window(Some(&window));
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
+            Action::AlignWindowRight => {
+                self.niri.layout.right_align_window(None);
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::AlignWindowRightById(id) => {
+                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
+                let window = window.map(|(_, m)| m.window.clone());
+                if let Some(window) = window {
+                    self.niri.layout.right_align_window(Some(&window));
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
             Action::CenterVisibleColumns => {
                 self.niri.layout.center_visible_columns();
                 // FIXME: granular

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2336,6 +2336,44 @@ impl<W: LayoutElement> Layout<W> {
         workspace.center_window(id);
     }
 
+    pub fn left_align_window(&mut self, id: Option<&W::Id>) {
+        if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
+            if id.is_none() || id == Some(move_.tile.window().id()) {
+                return;
+            }
+        }
+
+        let workspace = if let Some(id) = id {
+            Some(self.workspaces_mut().find(|ws| ws.has_window(id)).unwrap())
+        } else {
+            self.active_workspace_mut()
+        };
+
+        let Some(workspace) = workspace else {
+            return;
+        };
+        workspace.left_align_window(id);
+    }
+
+    pub fn right_align_window(&mut self, id: Option<&W::Id>) {
+        if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
+            if id.is_none() || id == Some(move_.tile.window().id()) {
+                return;
+            }
+        }
+
+        let workspace = if let Some(id) = id {
+            Some(self.workspaces_mut().find(|ws| ws.has_window(id)).unwrap())
+        } else {
+            self.active_workspace_mut()
+        };
+
+        let Some(workspace) = workspace else {
+            return;
+        };
+        workspace.right_align_window(id);
+    }
+
     pub fn center_visible_columns(&mut self) {
         let Some(workspace) = self.active_workspace_mut() else {
             return;

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -558,6 +558,42 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         -(self.working_area.size.w - width) / 2. - self.working_area.loc.x
     }
 
+    fn compute_new_view_offset_left_aligned(
+        &self,
+        target_x: Option<f64>,
+        col_x: f64,
+        width: f64,
+        is_fullscreen: bool,
+    ) -> f64 {
+        if is_fullscreen {
+            return self.compute_new_view_offset_fit(target_x, col_x, width, is_fullscreen);
+        }
+
+        // Account for gaps when left-aligning
+        -self.working_area.loc.x - self.options.gaps
+    }
+
+    fn compute_new_view_offset_right_aligned(
+        &self,
+        target_x: Option<f64>,
+        col_x: f64,
+        width: f64,
+        is_fullscreen: bool,
+    ) -> f64 {
+        if is_fullscreen {
+            return self.compute_new_view_offset_fit(target_x, col_x, width, is_fullscreen);
+        }
+
+        // Columns wider than the view are left-aligned (the fit code can deal with that).
+        if self.working_area.size.w <= width {
+            return self.compute_new_view_offset_fit(target_x, col_x, width, is_fullscreen);
+        }
+
+        // Account for gaps when right-aligning (similar to how they're handled in other calculations)
+        let available_width = self.working_area.size.w - self.options.gaps;
+        -(available_width - width) - self.working_area.loc.x
+    }
+
     fn compute_new_view_offset_for_column_fit(&self, target_x: Option<f64>, idx: usize) -> f64 {
         let col = &self.columns[idx];
         self.compute_new_view_offset_fit(
@@ -575,6 +611,34 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     ) -> f64 {
         let col = &self.columns[idx];
         self.compute_new_view_offset_centered(
+            target_x,
+            self.column_x(idx),
+            col.width(),
+            col.is_fullscreen,
+        )
+    }
+
+    fn compute_new_view_offset_for_column_left_aligned(
+        &self,
+        target_x: Option<f64>,
+        idx: usize,
+    ) -> f64 {
+        let col = &self.columns[idx];
+        self.compute_new_view_offset_left_aligned(
+            target_x,
+            self.column_x(idx),
+            col.width(),
+            col.is_fullscreen,
+        )
+    }
+
+    fn compute_new_view_offset_for_column_right_aligned(
+        &self,
+        target_x: Option<f64>,
+        idx: usize,
+    ) -> f64 {
+        let col = &self.columns[idx];
+        self.compute_new_view_offset_right_aligned(
             target_x,
             self.column_x(idx),
             col.width(),
@@ -701,6 +765,26 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         config: niri_config::Animation,
     ) {
         let new_view_offset = self.compute_new_view_offset_for_column_centered(target_x, idx);
+        self.animate_view_offset_with_config(idx, new_view_offset, config);
+    }
+
+    fn animate_view_offset_to_column_left_aligned(
+        &mut self,
+        target_x: Option<f64>,
+        idx: usize,
+        config: niri_config::Animation,
+    ) {
+        let new_view_offset = self.compute_new_view_offset_for_column_left_aligned(target_x, idx);
+        self.animate_view_offset_with_config(idx, new_view_offset, config);
+    }
+
+    fn animate_view_offset_to_column_right_aligned(
+        &mut self,
+        target_x: Option<f64>,
+        idx: usize,
+        config: niri_config::Animation,
+    ) {
+        let new_view_offset = self.compute_new_view_offset_for_column_right_aligned(target_x, idx);
         self.animate_view_offset_with_config(idx, new_view_offset, config);
     }
 
@@ -2133,6 +2217,36 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         cancel_resize_for_column(&mut self.interactive_resize, col);
     }
 
+    pub fn left_align_column(&mut self) {
+        if self.columns.is_empty() {
+            return;
+        }
+
+        self.animate_view_offset_to_column_left_aligned(
+            None,
+            self.active_column_idx,
+            self.options.animations.horizontal_view_movement.0,
+        );
+
+        let col = &mut self.columns[self.active_column_idx];
+        cancel_resize_for_column(&mut self.interactive_resize, col);
+    }
+
+    pub fn right_align_column(&mut self) {
+        if self.columns.is_empty() {
+            return;
+        }
+
+        self.animate_view_offset_to_column_right_aligned(
+            None,
+            self.active_column_idx,
+            self.options.animations.horizontal_view_movement.0,
+        );
+
+        let col = &mut self.columns[self.active_column_idx];
+        cancel_resize_for_column(&mut self.interactive_resize, col);
+    }
+
     pub fn center_window(&mut self, window: Option<&W::Id>) {
         if self.columns.is_empty() {
             return;
@@ -2153,6 +2267,50 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         self.center_column();
+    }
+
+    pub fn left_align_window(&mut self, window: Option<&W::Id>) {
+        if self.columns.is_empty() {
+            return;
+        }
+
+        let col_idx = if let Some(window) = window {
+            self.columns
+                .iter()
+                .position(|col| col.contains(window))
+                .unwrap()
+        } else {
+            self.active_column_idx
+        };
+
+        // We can reasonably left-align only the active column.
+        if col_idx != self.active_column_idx {
+            return;
+        }
+
+        self.left_align_column();
+    }
+
+    pub fn right_align_window(&mut self, window: Option<&W::Id>) {
+        if self.columns.is_empty() {
+            return;
+        }
+
+        let col_idx = if let Some(window) = window {
+            self.columns
+                .iter()
+                .position(|col| col.contains(window))
+                .unwrap()
+        } else {
+            self.active_column_idx
+        };
+
+        // We can reasonably right-align only the active column.
+        if col_idx != self.active_column_idx {
+            return;
+        }
+
+        self.right_align_column();
     }
 
     pub fn center_visible_columns(&mut self) {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -465,6 +465,18 @@ enum Op {
         id: Option<usize>,
     },
     CenterVisibleColumns,
+    AlignWindowLeft {
+        #[proptest(strategy = "proptest::option::of(1..=5usize)")]
+        id: Option<usize>,
+    },
+    AlignWindowCenter {
+        #[proptest(strategy = "proptest::option::of(1..=5usize)")]
+        id: Option<usize>,
+    },
+    AlignWindowRight {
+        #[proptest(strategy = "proptest::option::of(1..=5usize)")]
+        id: Option<usize>,
+    },
     FocusWorkspaceDown,
     FocusWorkspaceUp,
     FocusWorkspace(#[proptest(strategy = "0..=4usize")] usize),
@@ -1070,6 +1082,18 @@ impl Op {
                 layout.center_window(id.as_ref());
             }
             Op::CenterVisibleColumns => layout.center_visible_columns(),
+            Op::AlignWindowLeft { id } => {
+                let id = id.filter(|id| layout.has_window(id));
+                layout.left_align_window(id.as_ref());
+            }
+            Op::AlignWindowCenter { id } => {
+                let id = id.filter(|id| layout.has_window(id));
+                layout.center_window(id.as_ref());
+            }
+            Op::AlignWindowRight { id } => {
+                let id = id.filter(|id| layout.has_window(id));
+                layout.right_align_window(id.as_ref());
+            }
             Op::FocusWorkspaceDown => layout.switch_workspace_down(),
             Op::FocusWorkspaceUp => layout.switch_workspace_up(),
             Op::FocusWorkspace(idx) => layout.switch_workspace(idx),

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1100,6 +1100,26 @@ impl<W: LayoutElement> Workspace<W> {
         }
     }
 
+    pub fn left_align_window(&mut self, id: Option<&W::Id>) {
+        if id.map_or(self.floating_is_active.get(), |id| {
+            self.floating.has_window(id)
+        }) {
+            self.floating.left_align_window(id);
+        } else {
+            self.scrolling.left_align_window(id);
+        }
+    }
+
+    pub fn right_align_window(&mut self, id: Option<&W::Id>) {
+        if id.map_or(self.floating_is_active.get(), |id| {
+            self.floating.has_window(id)
+        }) {
+            self.floating.right_align_window(id);
+        } else {
+            self.scrolling.right_align_window(id);
+        }
+    }
+
     pub fn center_visible_columns(&mut self) {
         if self.floating_is_active.get() {
             return;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -398,6 +398,32 @@ pub fn center_preferring_top_left_in_area(
     area.loc + offset
 }
 
+pub fn right_align_preferring_top_left_in_area(
+    area: Rectangle<f64, Logical>,
+    size: Size<f64, Logical>,
+) -> Point<f64, Logical> {
+    let area_size = area.size.to_point();
+    let size = size.to_point();
+    let mut offset = area_size - size;
+    // For right alignment, we want maximum X offset but still keep Y centered
+    offset.x = f64::max(offset.x, 0.);
+    offset.y = f64::max(offset.y, 0.).downscale(2.);
+    area.loc + offset
+}
+
+pub fn left_align_preferring_top_left_in_area(
+    area: Rectangle<f64, Logical>,
+    size: Size<f64, Logical>,
+) -> Point<f64, Logical> {
+    let area_size = area.size.to_point();
+    let size = size.to_point();
+    let mut offset = Point::from((0., (area_size.y - size.y).downscale(2.)));
+    // For left alignment, X offset is 0 (left edge), Y is centered
+    offset.x = f64::max(offset.x, 0.);
+    offset.y = f64::max(offset.y, 0.);
+    area.loc + offset
+}
+
 pub fn baba_is_float_offset(now: Duration, view_height: f64) -> f64 {
     let now = now.as_secs_f64();
     let amplitude = view_height / 96.;


### PR DESCRIPTION
I use two relatively large monitors side-by-side, and I sit near the middle of them. I often want my primary working windows to be on the right side of the left monitor, or the left side of the right monitor. 

There was no easy way to do this previously, other than moving focus back-and-forth between adjacent windows to nudge the view into the desired position, or using the mouse+middle-click-dragging to move the view. And, if I wanted the first window to be on the right side of the screen, or the last window to be on the left side, there was no way to do that.

This PR adds actions for aligning windows to the left, center, and right edge of the screen:

- `AlignWindowLeft`: Aligns the focused window so it's at the left edge of the screen
- `AlignWindowCenter`: Aligns the focused window to the center of the screen (same as `CenterWindow`)
- `AlignWindowRight`: Aligns focused window to the right side of the screen

As mentioned, `AlignWindowCenter` does the exact same thing as the existing `CenterWindow`. I'm not sure how to handle this. Either:

1. Keep both for backward compatibility
2. Deprecate `CenterWindow` in favor of `AlignWindowCenter` 
3. Something else?

Also adds variants to do this by ID, but not sure how useful that really is. Happy to remove and just operate on the focused window. 

Final question, not sure if these should really be `AlignColumn{Left,Right,Center}`? Functionally, I think they would behave the same, whether it's operating on windows or columns.

<details>
  <summary>Demo Video</summary>

  https://github.com/user-attachments/assets/8607c704-f5a8-4a3b-b63f-11b36d4f0e78

</details>