### PR TITLE
Implement a four-finger swipe gesture to do an interactive move

### DIFF
--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -153,7 +153,7 @@ impl XdgShellHandler for State {
 
         match start_data {
             PointerOrTouchStartData::Pointer(start_data) => {
-                let grab = MoveGrab::new(start_data, window, false);
+                let grab = MoveGrab::new(start_data, window, false, false);
                 pointer.set_grab(self, grab, serial, Focus::Clear);
             }
             PointerOrTouchStartData::Touch(start_data) => {

--- a/src/input/move_grab.rs
+++ b/src/input/move_grab.rs
@@ -110,7 +110,7 @@ impl PointerGrab<State> for MoveGrab {
                     &self.window,
                     event_delta,
                     output,
-                    dbg!(pos_within_output),
+                    pos_within_output,
                 );
                 if ongoing {
                     // FIXME: only redraw the previous and the new output.

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -127,7 +127,7 @@ use crate::input::scroll_swipe_gesture::ScrollSwipeGesture;
 use crate::input::scroll_tracker::ScrollTracker;
 use crate::input::{
     apply_libinput_settings, mods_with_finger_scroll_binds, mods_with_mouse_binds,
-    mods_with_wheel_binds, TabletData,
+    mods_with_wheel_binds, SwipeDirectionDecider, TabletData,
 };
 use crate::ipc::server::IpcServer;
 use crate::layer::mapped::LayerSurfaceRenderElement;
@@ -346,7 +346,8 @@ pub struct Niri {
     pub notified_activity_this_iteration: bool,
     pub pointer_inside_hot_corner: bool,
     pub tablet_cursor_location: Option<Point<f64, Logical>>,
-    pub gesture_swipe_3f_cumulative: Option<(f64, f64)>,
+    pub gesture_swipe_3f_decider: SwipeDirectionDecider,
+    pub gesture_swipe_4f_decider: SwipeDirectionDecider,
     pub overview_scroll_swipe_gesture: ScrollSwipeGesture,
     pub vertical_wheel_tracker: ScrollTracker,
     pub horizontal_wheel_tracker: ScrollTracker,
@@ -2575,7 +2576,9 @@ impl Niri {
             notified_activity_this_iteration: false,
             pointer_inside_hot_corner: false,
             tablet_cursor_location: None,
-            gesture_swipe_3f_cumulative: None,
+            // Will become undecided once a gesture begins
+            gesture_swipe_3f_decider: SwipeDirectionDecider::decided(),
+            gesture_swipe_4f_decider: SwipeDirectionDecider::decided(),
             overview_scroll_swipe_gesture: ScrollSwipeGesture::new(),
             vertical_wheel_tracker: ScrollTracker::new(120),
             horizontal_wheel_tracker: ScrollTracker::new(120),


### PR DESCRIPTION

https://github.com/user-attachments/assets/485eb9de-71ee-44bd-95f8-1118c8b763e1

This PR implements a 4-finger swipe gesture which allows you to move the focused window with just your touchpad (no mod key). I've taken the same logic which decides the swipe direction for 3 finger swipes, and applied it to 4 finger swipes, this way the overview gesture can still be kept.

Please forgive me if the way I've implemented this isn't standard, I have very little experience with Smithay and Wayland Compositor design in general. That being said, there's couple of question marks in this PR.

- Is it possible for a focused window to be out of view? If so, my usage of `active_tile_visual_rectangle` in the `on_gesture_swipe_update` function is probably incorrect
- I *am* clamping the position of the window in the swipe gesture to the `global_bounding_rectangle`, but it's unclear why I need to shrink it by 1 logical pixel to avoid the window snapping to a weird position when it's all the way at the edge.

I've had so much fun using this window this window manager! Thanks for such an awesome project!
