### PR TITLE
CI: automatically update flake.lock

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,17 @@
+name: Update lockfile
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 2"
+
+jobs:
+  lockfile:
+    name: "Update lockfile"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v19
+      - name: Update flake.lock
+        id: update
+        uses: DeterminateSystems/update-flake-lock@v27


### PR DESCRIPTION
Update Nix flake.lock weekly via GitHub Actions. This requires GitHub actions to have write access and to be allowed to create pull requests in the repository settings.

I've set the cron to every tuesday midnight GMT. This can be changed as desired.