### PR TITLE
Add ToggleForceShortcutsInhibit action

### DIFF
--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -405,3 +405,18 @@ binds {
     Super+Alt+L allow-inhibiting=false { spawn "swaylock"; }
 }
 ```
+
+#### `toggle-force-shortcuts-inhibit`
+
+<sup>Since: next release</sup>
+
+Some applications require specific key combinations that might interfere with your choice of `Mod` key. For example if you use `Alt`.
+This action will stop _all_ shortcuts and instead forward them to the focused surface.
+
+Note: This shortcut can not be inhibited as otherwise it means that you could not toggle it back off.
+
+```kdl
+binds {
+    Mod+Escape { toggle-force-shortcuts-inhibit; }
+}
+```

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -129,6 +129,7 @@ pub enum Action {
         id: u64,
         write_to_disk: bool,
     },
+    ToggleForceShortcutsInhibit,
     ToggleKeyboardShortcutsInhibit,
     CloseWindow,
     #[knuffel(skip)]
@@ -374,6 +375,9 @@ impl From<niri_ipc::Action> for Action {
                 id: Some(id),
                 write_to_disk,
             } => Self::ScreenshotWindowById { id, write_to_disk },
+            niri_ipc::Action::ToggleForceShortcutsInhibit {} => {
+                Self::ToggleForceShortcutsInhibit
+            }
             niri_ipc::Action::ToggleKeyboardShortcutsInhibit {} => {
                 Self::ToggleKeyboardShortcutsInhibit
             }
@@ -867,7 +871,11 @@ where
 
                     // The toggle-inhibit action must always be uninhibitable.
                     // Otherwise, it would be impossible to trigger it.
-                    if matches!(action, Action::ToggleKeyboardShortcutsInhibit) {
+                    if matches!(
+                        action,
+                        Action::ToggleKeyboardShortcutsInhibit
+                            | Action::ToggleForceShortcutsInhibit
+                    ) {
                         allow_inhibiting = false;
                     }
 

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -247,6 +247,8 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(short = 'd', long, action = clap::ArgAction::Set, default_value_t = true))]
         write_to_disk: bool,
     },
+    /// Enable or disable keyboard shortcuts for niri
+    ToggleForceShortcutsInhibit {},
     /// Enable or disable the keyboard shortcuts inhibitor (if any) for the focused surface.
     ToggleKeyboardShortcutsInhibit {},
     /// Close a window.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2467,6 +2467,8 @@ impl State {
 
         let mod_key = self.backend.mod_key(&self.niri.config.borrow());
 
+        let not_inhibited = !self.niri.is_force_inhibited;
+
         // Ignore release events for mouse clicks that triggered a bind.
         if self.niri.suppressed_buttons.remove(&button_code) {
             return;
@@ -2502,7 +2504,11 @@ impl State {
 
             let is_overview_open = self.niri.layout.is_overview_open();
 
-            if is_overview_open && !pointer.is_grabbed() && button == Some(MouseButton::Right) {
+            if is_overview_open
+                && !pointer.is_grabbed()
+                && button == Some(MouseButton::Right)
+                && not_inhibited
+            {
                 if let Some((output, ws)) = self.niri.workspace_under_cursor(true) {
                     let ws_id = ws.id();
                     let ws_idx = self.niri.layout.find_workspace_by_id(ws_id).unwrap().0;
@@ -2530,7 +2536,7 @@ impl State {
                 }
             }
 
-            if button == Some(MouseButton::Middle) && !pointer.is_grabbed() {
+            if button == Some(MouseButton::Middle) && !pointer.is_grabbed() && not_inhibited {
                 let mod_down = modifiers_from_state(mods).contains(mod_key.to_modifiers());
                 if mod_down {
                     let output_ws = if is_overview_open {
@@ -2575,7 +2581,7 @@ impl State {
                 let window = mapped.window.clone();
 
                 // Check if we need to start an interactive move.
-                if button == Some(MouseButton::Left) && !pointer.is_grabbed() {
+                if button == Some(MouseButton::Left) && !pointer.is_grabbed() && not_inhibited {
                     let mod_down = modifiers_from_state(mods).contains(mod_key.to_modifiers());
                     if is_overview_open || mod_down {
                         let location = pointer.current_location();
@@ -2608,7 +2614,10 @@ impl State {
                     }
                 }
                 // Check if we need to start an interactive resize.
-                else if button == Some(MouseButton::Right) && !pointer.is_grabbed() {
+                else if button == Some(MouseButton::Right)
+                    && !pointer.is_grabbed()
+                    && not_inhibited
+                {
                     let mod_down = modifiers_from_state(mods).contains(mod_key.to_modifiers());
                     if mod_down {
                         let location = pointer.current_location();

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -322,15 +322,17 @@ impl State {
     }
 
     fn is_inhibiting_shortcuts(&self) -> bool {
-        self.niri
-            .keyboard_focus
-            .surface()
-            .and_then(|surface| {
-                self.niri
-                    .keyboard_shortcuts_inhibiting_surfaces
-                    .get(surface)
-            })
-            .is_some_and(KeyboardShortcutsInhibitor::is_active)
+        self.niri.is_force_inhibited
+            || self
+                .niri
+                .keyboard_focus
+                .surface()
+                .and_then(|surface| {
+                    self.niri
+                        .keyboard_shortcuts_inhibiting_surfaces
+                        .get(surface)
+                })
+                .is_some_and(KeyboardShortcutsInhibitor::is_active)
     }
 
     fn on_keyboard<I: InputBackend>(
@@ -666,6 +668,9 @@ impl State {
                         }
                     });
                 }
+            }
+            Action::ToggleForceShortcutsInhibit => {
+                self.niri.is_force_inhibited = !self.niri.is_force_inhibited;
             }
             Action::ToggleKeyboardShortcutsInhibit => {
                 if let Some(inhibitor) = self.niri.keyboard_focus.surface().and_then(|surface| {
@@ -4220,6 +4225,7 @@ fn allowed_when_locked(action: &Action) -> bool {
             | Action::PowerOnMonitors
             | Action::SwitchLayout(_)
             | Action::ToggleKeyboardShortcutsInhibit
+            | Action::ToggleForceShortcutsInhibit
     )
 }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -259,6 +259,8 @@ pub struct Niri {
     /// startup, libinput will immediately send a closed event.
     pub is_lid_closed: bool,
 
+    pub is_force_inhibited: bool,
+
     pub devices: HashSet<input::Device>,
     pub tablets: HashMap<input::Device, TabletData>,
     pub touch: HashSet<input::Device>,
@@ -2598,6 +2600,7 @@ impl Niri {
             blocker_cleared_rx,
             monitors_active: true,
             is_lid_closed: false,
+            is_force_inhibited: false,
 
             devices: HashSet::new(),
             tablets: HashMap::new(),


### PR DESCRIPTION
I use `Alt` as my Mod key, and some applications force you to use `Alt` for actions. With this feature, I can now disable global shortcuts and use them normally. 

This is mainly intended for long-running usage, eg. games or editing software.


I tried to follow the conventions in the repo and mainly reflected the 'toggle-inhibitors' action here. I'm open ofc to any change requests etc