### PR TITLE
Add option to prevent cursor warping when switching outputs

### DIFF
--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -103,6 +103,7 @@ input {
     // warp-mouse-to-focus
     // focus-follows-mouse max-scroll-amount="0%"
     // workspace-auto-back-and-forth
+    // disable-mouse-warps
 
     // mod-key "Super"
     // mod-key-nested "Alt"
@@ -363,6 +364,19 @@ input {
     workspace-auto-back-and-forth
 }
 ```
+
+#### `disable-mouse-warps`
+
+<sup>Since: 25.??</sup>
+
+Disables moving the cursor to a different monitor when switching monitors.
+
+```kdl
+input {
+    disable-mouse-warps
+}
+```
+
 
 #### `mod-key`, `mod-key-nested`
 

--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -367,7 +367,7 @@ input {
 
 #### `disable-mouse-warps`
 
-<sup>Since: 25.??</sup>
+<sup>Since: next release</sup>
 
 Disables moving the cursor to a different monitor when switching monitors.
 
@@ -376,7 +376,6 @@ input {
     disable-mouse-warps
 }
 ```
-
 
 #### `mod-key`, `mod-key-nested`
 

--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -103,7 +103,7 @@ input {
     // warp-mouse-to-focus
     // focus-follows-mouse max-scroll-amount="0%"
     // workspace-auto-back-and-forth
-    // disable-mouse-warps
+    // disable-mouse-warp-to-focused-output
 
     // mod-key "Super"
     // mod-key-nested "Alt"
@@ -365,15 +365,15 @@ input {
 }
 ```
 
-#### `disable-mouse-warps`
+#### `disable-mouse-warp-to-focused-output`
 
 <sup>Since: next release</sup>
 
-Disables moving the cursor to a different monitor when switching monitors.
+Prevents warping the cursor to a different output when switching monitors.
 
 ```kdl
 input {
-    disable-mouse-warps
+    disable-mouse-warp-to-focused-output
 }
 ```
 

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -23,6 +23,7 @@ pub struct Input {
     pub workspace_auto_back_and_forth: bool,
     pub mod_key: Option<ModKey>,
     pub mod_key_nested: Option<ModKey>,
+    pub disable_mouse_warps: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
@@ -53,6 +54,8 @@ pub struct InputPart {
     pub mod_key: Option<ModKey>,
     #[knuffel(child, unwrap(argument, str))]
     pub mod_key_nested: Option<ModKey>,
+    #[knuffel(child)]
+    pub disable_mouse_warps: Option<Flag>,
 }
 
 impl MergeWith<InputPart> for Input {
@@ -62,6 +65,7 @@ impl MergeWith<InputPart> for Input {
             keyboard,
             disable_power_key_handling,
             workspace_auto_back_and_forth,
+            disable_mouse_warps,
         );
 
         merge_clone!(

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -23,7 +23,7 @@ pub struct Input {
     pub workspace_auto_back_and_forth: bool,
     pub mod_key: Option<ModKey>,
     pub mod_key_nested: Option<ModKey>,
-    pub disable_mouse_warps: bool,
+    pub disable_mouse_warp_to_focused_output: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
@@ -55,7 +55,7 @@ pub struct InputPart {
     #[knuffel(child, unwrap(argument, str))]
     pub mod_key_nested: Option<ModKey>,
     #[knuffel(child)]
-    pub disable_mouse_warps: Option<Flag>,
+    pub disable_mouse_warp_to_focused_output: Option<Flag>,
 }
 
 impl MergeWith<InputPart> for Input {
@@ -65,7 +65,7 @@ impl MergeWith<InputPart> for Input {
             keyboard,
             disable_power_key_handling,
             workspace_auto_back_and_forth,
-            disable_mouse_warps,
+            disable_mouse_warp_to_focused_output,
         );
 
         merge_clone!(

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1024,6 +1024,7 @@ mod tests {
                 mod_key_nested: Some(
                     Super,
                 ),
+                disable_mouse_warps: false,
             },
             outputs: Outputs(
                 [

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1024,7 +1024,7 @@ mod tests {
                 mod_key_nested: Some(
                     Super,
                 ),
-                disable_mouse_warps: false,
+                disable_mouse_warp_to_focused_output: false,
             },
             outputs: Outputs(
                 [

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -813,7 +813,7 @@ impl State {
                     if self.niri.layout.move_column_left_or_to_output(&output)
                         && !self.maybe_warp_cursor_to_focus_centered()
                     {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     } else {
                         self.maybe_warp_cursor_to_focus();
                     }
@@ -832,7 +832,7 @@ impl State {
                     if self.niri.layout.move_column_right_or_to_output(&output)
                         && !self.maybe_warp_cursor_to_focus_centered()
                     {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     } else {
                         self.maybe_warp_cursor_to_focus();
                     }
@@ -1000,7 +1000,7 @@ impl State {
                     if self.niri.layout.focus_window_up_or_output(&output)
                         && !self.maybe_warp_cursor_to_focus_centered()
                     {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     } else {
                         self.maybe_warp_cursor_to_focus();
                     }
@@ -1018,7 +1018,7 @@ impl State {
                     if self.niri.layout.focus_window_down_or_output(&output)
                         && !self.maybe_warp_cursor_to_focus_centered()
                     {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     } else {
                         self.maybe_warp_cursor_to_focus();
                     }
@@ -1036,7 +1036,7 @@ impl State {
                     if self.niri.layout.focus_column_left_or_output(&output)
                         && !self.maybe_warp_cursor_to_focus_centered()
                     {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     } else {
                         self.maybe_warp_cursor_to_focus();
                     }
@@ -1054,7 +1054,7 @@ impl State {
                     if self.niri.layout.focus_column_right_or_output(&output)
                         && !self.maybe_warp_cursor_to_focus_centered()
                     {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     } else {
                         self.maybe_warp_cursor_to_focus();
                     }
@@ -1188,7 +1188,7 @@ impl State {
 
                         if focus {
                             if !self.maybe_warp_cursor_to_focus_centered() {
-                                self.move_cursor_to_output(&output);
+                                self.maybe_warp_cursor_to_output(&output);
                             }
                         } else {
                             self.maybe_warp_cursor_to_focus();
@@ -1239,7 +1239,7 @@ impl State {
                                 && self.niri.layout.active_output() == Some(&output)
                             {
                                 if !self.maybe_warp_cursor_to_focus_centered() {
-                                    self.move_cursor_to_output(&output);
+                                    self.maybe_warp_cursor_to_output(&output);
                                 }
                             }
                         } else {
@@ -1286,7 +1286,7 @@ impl State {
                             .layout
                             .move_column_to_output(&output, Some(index), focus);
                         if focus && !self.maybe_warp_cursor_to_focus_centered() {
-                            self.move_cursor_to_output(&output);
+                            self.maybe_warp_cursor_to_output(&output);
                         }
                     } else {
                         self.niri.layout.move_column_to_workspace(index, focus);
@@ -1353,7 +1353,7 @@ impl State {
                         self.niri.layout.focus_output(&output);
                         self.niri.layout.switch_workspace(index);
                         if !self.maybe_warp_cursor_to_focus_centered() {
-                            self.move_cursor_to_output(&output);
+                            self.maybe_warp_cursor_to_output(&output);
                         }
                     } else {
                         let config = &self.niri.config;
@@ -1548,7 +1548,7 @@ impl State {
                 if let Some(output) = self.niri.output_left() {
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                     self.niri.layer_shell_on_demand_focus = None;
                 }
@@ -1557,7 +1557,7 @@ impl State {
                 if let Some(output) = self.niri.output_right() {
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                     self.niri.layer_shell_on_demand_focus = None;
                 }
@@ -1566,7 +1566,7 @@ impl State {
                 if let Some(output) = self.niri.output_down() {
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                     self.niri.layer_shell_on_demand_focus = None;
                 }
@@ -1575,7 +1575,7 @@ impl State {
                 if let Some(output) = self.niri.output_up() {
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                     self.niri.layer_shell_on_demand_focus = None;
                 }
@@ -1584,7 +1584,7 @@ impl State {
                 if let Some(output) = self.niri.output_previous() {
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                     self.niri.layer_shell_on_demand_focus = None;
                 }
@@ -1593,7 +1593,7 @@ impl State {
                 if let Some(output) = self.niri.output_next() {
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                     self.niri.layer_shell_on_demand_focus = None;
                 }
@@ -1602,7 +1602,7 @@ impl State {
                 if let Some(output) = self.niri.output_by_name_match(&output).cloned() {
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                     self.niri.layer_shell_on_demand_focus = None;
                 }
@@ -1610,7 +1610,7 @@ impl State {
             Action::MoveWindowToMonitorLeft => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_left_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_left() {
@@ -1619,14 +1619,14 @@ impl State {
                         .move_to_output(None, &output, None, ActivateWindow::Smart);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveWindowToMonitorRight => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_right_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_right() {
@@ -1635,14 +1635,14 @@ impl State {
                         .move_to_output(None, &output, None, ActivateWindow::Smart);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveWindowToMonitorDown => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_down_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_down() {
@@ -1651,14 +1651,14 @@ impl State {
                         .move_to_output(None, &output, None, ActivateWindow::Smart);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveWindowToMonitorUp => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_up_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_up() {
@@ -1667,14 +1667,14 @@ impl State {
                         .move_to_output(None, &output, None, ActivateWindow::Smart);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveWindowToMonitorPrevious => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_previous_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_previous() {
@@ -1683,14 +1683,14 @@ impl State {
                         .move_to_output(None, &output, None, ActivateWindow::Smart);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveWindowToMonitorNext => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_next_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_next() {
@@ -1699,14 +1699,14 @@ impl State {
                         .move_to_output(None, &output, None, ActivateWindow::Smart);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveWindowToMonitor(output) => {
                 if let Some(output) = self.niri.output_by_name_match(&output).cloned() {
                     if self.niri.screenshot_ui.is_open() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                         self.niri.screenshot_ui.move_to_output(output);
                     } else {
                         self.niri
@@ -1714,7 +1714,7 @@ impl State {
                             .move_to_output(None, &output, None, ActivateWindow::Smart);
                         self.niri.layout.focus_output(&output);
                         if !self.maybe_warp_cursor_to_focus_centered() {
-                            self.move_cursor_to_output(&output);
+                            self.maybe_warp_cursor_to_output(&output);
                         }
                     }
                 }
@@ -1742,7 +1742,7 @@ impl State {
                         #[allow(clippy::collapsible_if)]
                         if !target_was_active && self.niri.layout.active_output() == Some(&output) {
                             if !self.maybe_warp_cursor_to_focus_centered() {
-                                self.move_cursor_to_output(&output);
+                                self.maybe_warp_cursor_to_output(&output);
                             }
                         }
                     }
@@ -1751,97 +1751,97 @@ impl State {
             Action::MoveColumnToMonitorLeft => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_left_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_left() {
                     self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveColumnToMonitorRight => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_right_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_right() {
                     self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveColumnToMonitorDown => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_down_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_down() {
                     self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveColumnToMonitorUp => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_up_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_up() {
                     self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveColumnToMonitorPrevious => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_previous_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_previous() {
                     self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveColumnToMonitorNext => {
                 if let Some(current_output) = self.niri.screenshot_ui.selection_output() {
                     if let Some(target_output) = self.niri.output_next_of(current_output) {
-                        self.move_cursor_to_output(&target_output);
+                        self.maybe_warp_cursor_to_output(&target_output);
                         self.niri.screenshot_ui.move_to_output(target_output);
                     }
                 } else if let Some(output) = self.niri.output_next() {
                     self.niri.layout.move_column_to_output(&output, None, true);
                     self.niri.layout.focus_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
             Action::MoveColumnToMonitor(output) => {
                 if let Some(output) = self.niri.output_by_name_match(&output).cloned() {
                     if self.niri.screenshot_ui.is_open() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                         self.niri.screenshot_ui.move_to_output(output);
                     } else {
                         self.niri.layout.move_column_to_output(&output, None, true);
                         self.niri.layout.focus_output(&output);
                         if !self.maybe_warp_cursor_to_focus_centered() {
-                            self.move_cursor_to_output(&output);
+                            self.maybe_warp_cursor_to_output(&output);
                         }
                     }
                 }
@@ -1915,7 +1915,7 @@ impl State {
                 if let Some(output) = self.niri.output_left() {
                     self.niri.layout.move_workspace_to_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
@@ -1923,7 +1923,7 @@ impl State {
                 if let Some(output) = self.niri.output_right() {
                     self.niri.layout.move_workspace_to_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
@@ -1931,7 +1931,7 @@ impl State {
                 if let Some(output) = self.niri.output_down() {
                     self.niri.layout.move_workspace_to_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
@@ -1939,7 +1939,7 @@ impl State {
                 if let Some(output) = self.niri.output_up() {
                     self.niri.layout.move_workspace_to_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
@@ -1947,7 +1947,7 @@ impl State {
                 if let Some(output) = self.niri.output_previous() {
                     self.niri.layout.move_workspace_to_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
@@ -1955,7 +1955,7 @@ impl State {
                 if let Some(output) = self.niri.output_next() {
                     self.niri.layout.move_workspace_to_output(&output);
                     if !self.maybe_warp_cursor_to_focus_centered() {
-                        self.move_cursor_to_output(&output);
+                        self.maybe_warp_cursor_to_output(&output);
                     }
                 }
             }
@@ -1964,7 +1964,7 @@ impl State {
                     if self.niri.layout.move_workspace_to_output(&new_output)
                         && !self.maybe_warp_cursor_to_focus_centered()
                     {
-                        self.move_cursor_to_output(&new_output);
+                        self.maybe_warp_cursor_to_output(&new_output);
                     }
                 }
             }
@@ -1984,7 +1984,7 @@ impl State {
                         ) {
                             // Cursor warp already calls `queue_redraw_all`
                             if !self.maybe_warp_cursor_to_focus_centered() {
-                                self.move_cursor_to_output(&new_output);
+                                self.maybe_warp_cursor_to_output(&new_output);
                             }
                         }
                     }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -929,7 +929,7 @@ impl State {
         #[allow(clippy::collapsible_if)]
         if new_active != active_output {
             if !self.maybe_warp_cursor_to_focus_centered() {
-                self.move_cursor_to_output(&new_active.unwrap());
+                self.maybe_warp_cursor_to_output(&new_active.unwrap());
             }
         } else {
             self.maybe_warp_cursor_to_focus();
@@ -1042,12 +1042,17 @@ impl State {
     }
 
     pub fn move_cursor_to_output(&mut self, output: &Output) {
-        if self.niri.config.borrow().input.disable_mouse_warps {
-            return;
-        }
-
         let geo = self.niri.global_space.output_geometry(output).unwrap();
         self.move_cursor(center(geo).to_f64());
+    }
+
+    pub fn maybe_warp_cursor_to_output(&mut self, output: &Output) -> bool {
+        if self.niri.config.borrow().input.disable_mouse_warps {
+            return false;
+        }
+
+        self.move_cursor_to_output(output);
+        true
     }
 
     pub fn refresh_popup_grab(&mut self) {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1047,7 +1047,7 @@ impl State {
     }
 
     pub fn maybe_warp_cursor_to_output(&mut self, output: &Output) -> bool {
-        if self.niri.config.borrow().input.disable_mouse_warps {
+        if self.niri.config.borrow().input.disable_mouse_warp_to_focused_output {
             return false;
         }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1042,6 +1042,10 @@ impl State {
     }
 
     pub fn move_cursor_to_output(&mut self, output: &Output) {
+        if self.niri.config.borrow().input.disable_mouse_warps {
+            return;
+        }
+
         let geo = self.niri.global_space.output_geometry(output).unwrap();
         self.move_cursor(center(geo).to_f64());
     }


### PR DESCRIPTION
This PR adds a `disable-mouse-warp-to-focused-output` option which prevents warping the cursor to another monitor. See https://github.com/YaLTeR/niri/discussions/2704.