### PR TITLE
Add scratchpad functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Here are some points you may have questions about:
 - **Multi-monitor**: yes, a core part of the design from the very start. Mixed DPI works.
 - **Fractional scaling**: yes, plus all niri UI stays pixel-perfect.
 - **NVIDIA**: seems to work fine.
-- **Floating windows**: yes, starting from niri 25.01.
+- **Floating windows**: yes, starting from niri 25.01. Includes [scratchpad](https://yalter.github.io/niri/Floating-Windows.html#scratchpad) support (25.09).
 - **Input devices**: niri supports tablets, touchpads, and touchscreens.
 You can map the tablet to a specific monitor, or use [OpenTabletDriver].
 We have touchpad gestures, but no touchscreen gestures yet.

--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -430,7 +430,7 @@ If you call `scratchpad-show` again while a scratchpad window is focused, it wil
 
 **Behavior:**
 - Scratchpad windows are always **floating** when visible
-- Scratchpads are **per-workspace**: hidden windows stay on the workspace where they were hidden
+- Scratchpad windows **follow you** across workspaces: when you show a scratchpad, it appears on your current workspace
 - Multiple scratchpad windows are shown in **LIFO order** (last hidden, first shown)
 - Works with both tiling and floating windows
 

--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -405,3 +405,52 @@ binds {
     Super+Alt+L allow-inhibiting=false { spawn "swaylock"; }
 }
 ```
+
+#### `move-scratchpad`, `scratchpad-show`
+
+<sup>Since: 25.09</sup>
+
+Scratchpad actions allow you to quickly hide and show windows, similar to i3's scratchpad feature.
+
+`move-scratchpad` moves the focused window (or a window by ID) to the scratchpad, hiding it from view.
+`scratchpad-show` toggles the visibility of scratchpad windows.
+
+```kdl
+binds {
+    // Hide the focused window in scratchpad
+    Mod+Shift+Minus { move-scratchpad; }
+
+    // Toggle scratchpad visibility
+    Mod+Minus { scratchpad-show; }
+}
+```
+
+When you show a scratchpad window with `scratchpad-show`, it will appear centered on your current workspace as a floating window.
+If you call `scratchpad-show` again while a scratchpad window is focused, it will hide that window again.
+
+**Behavior:**
+- Scratchpad windows are always **floating** when visible
+- Scratchpads are **per-workspace**: hidden windows stay on the workspace where they were hidden
+- Multiple scratchpad windows are shown in **LIFO order** (last hidden, first shown)
+- Works with both tiling and floating windows
+
+**IPC usage:**
+
+```bash
+# Move focused window to scratchpad
+niri msg action move-scratchpad
+
+# Move specific window to scratchpad
+niri msg action move-scratchpad --id 12345
+
+# Toggle most recently hidden scratchpad visibility
+niri msg action scratchpad-show
+
+# Toggle specific scratchpad window by ID
+niri msg action scratchpad-show --id 12345
+```
+
+You can use `niri msg windows` to get window IDs, then show/hide specific scratchpad windows by ID.
+This is useful when you have multiple scratchpad windows and want to control which one appears.
+
+See the [Floating Windows](./Floating-Windows.md#scratchpad) page for more details.

--- a/docs/wiki/Floating-Windows.md
+++ b/docs/wiki/Floating-Windows.md
@@ -14,3 +14,69 @@ Use `switch-focus-between-floating-and-tiling` to switch the focus between the t
 When focused on the floating layout, binds (like `focus-column-right`) will operate on the floating window.
 
 You can precisely position a floating window with a command like `niri msg action move-floating-window -x 100 -y 200`.
+
+### Scratchpad
+
+<sup>Since: 25.09</sup>
+
+A scratchpad is a way to quickly hide and show windows, similar to i3's scratchpad feature.
+Scratchpad windows are floating windows that can be toggled between hidden and visible states.
+
+To move a window to the scratchpad (hide it), use the `move-scratchpad` action:
+
+```kdl
+binds {
+    Mod+Shift+Minus { move-scratchpad; }
+}
+```
+
+To show the most recently hidden scratchpad window, use the `scratchpad-show` action:
+
+```kdl
+binds {
+    Mod+Minus { scratchpad-show; }
+}
+```
+
+When you show a scratchpad window, it will appear centered on your current workspace as a floating window.
+If you call `scratchpad-show` again while a scratchpad window is focused, it will hide that window.
+
+**Key behaviors:**
+- Scratchpad windows are always **floating** when visible
+- Scratchpads are **per-workspace**: hidden windows stay on the workspace where they were hidden
+- You can have **multiple scratchpad windows** on each workspace
+- Windows are shown in **LIFO order** (last hidden, first shown)
+- Works with both tiling and floating windows
+
+**Example usage:**
+
+```kdl
+binds {
+    // Hide the focused window in scratchpad
+    Mod+Shift+Minus { move-scratchpad; }
+
+    // Toggle scratchpad visibility
+    Mod+Minus { scratchpad-show; }
+}
+```
+
+**IPC commands:**
+
+```bash
+# Move focused window to scratchpad
+niri msg action move-scratchpad
+
+# Move specific window by ID to scratchpad
+niri msg action move-scratchpad --id 12345
+
+# Show/hide most recently hidden scratchpad
+niri msg action scratchpad-show
+
+# Show/hide specific scratchpad window by ID
+niri msg action scratchpad-show --id 12345
+```
+
+You can use the window ID to toggle specific scratchpad windows, which is useful when you have multiple scratchpad windows and want to show a particular one.
+To get window IDs, use `niri msg windows`.
+
+Common use cases include keeping a terminal, music player, or notes app always at hand without cluttering your workspace.

--- a/docs/wiki/Floating-Windows.md
+++ b/docs/wiki/Floating-Windows.md
@@ -43,8 +43,8 @@ If you call `scratchpad-show` again while a scratchpad window is focused, it wil
 
 **Key behaviors:**
 - Scratchpad windows are always **floating** when visible
-- Scratchpads are **per-workspace**: hidden windows stay on the workspace where they were hidden
-- You can have **multiple scratchpad windows** on each workspace
+- Scratchpad windows **follow you** across workspaces: when you show a scratchpad, it appears on your current workspace
+- You can have **multiple scratchpad windows**
 - Windows are shown in **LIFO order** (last hidden, first shown)
 - Works with both tiling and floating windows
 

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -339,6 +339,12 @@ pub enum Action {
     FocusFloating,
     FocusTiling,
     SwitchFocusBetweenFloatingAndTiling,
+    MoveScratchpad,
+    #[knuffel(skip)]
+    MoveScratchpadById(u64),
+    ScratchpadShow,
+    #[knuffel(skip)]
+    ScratchpadShowById(u64),
     #[knuffel(skip)]
     MoveFloatingWindowById {
         id: Option<u64>,
@@ -649,6 +655,10 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::SwitchFocusBetweenFloatingAndTiling {} => {
                 Self::SwitchFocusBetweenFloatingAndTiling
             }
+            niri_ipc::Action::MoveScratchpad { id: None } => Self::MoveScratchpad,
+            niri_ipc::Action::MoveScratchpad { id: Some(id) } => Self::MoveScratchpadById(id),
+            niri_ipc::Action::ScratchpadShow { id: None } => Self::ScratchpadShow,
+            niri_ipc::Action::ScratchpadShow { id: Some(id) } => Self::ScratchpadShowById(id),
             niri_ipc::Action::MoveFloatingWindow { id, x, y } => {
                 Self::MoveFloatingWindowById { id, x, y }
             }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1314,6 +1314,8 @@ pub struct Window {
     ///
     /// If the window isn't floating then it is in the tiling layout.
     pub is_floating: bool,
+    /// Whether this window is hidden in the scratchpad.
+    pub is_in_scratchpad: bool,
     /// Whether this window requests your attention.
     pub is_urgent: bool,
     /// Position- and size-related properties of the window.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -825,6 +825,26 @@ pub enum Action {
     FocusTiling {},
     /// Toggles the focus between the floating and the tiling layout.
     SwitchFocusBetweenFloatingAndTiling {},
+    /// Move the focused window to the scratchpad.
+    MoveScratchpad {
+        /// Id of the window to move.
+        ///
+        /// If `None`, uses the focused window.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+    },
+    /// Show a scratchpad window.
+    ///
+    /// If `id` is provided, shows the scratchpad with that window ID.
+    /// Otherwise, shows the most recently hidden scratchpad.
+    /// If a scratchpad window is already visible and focused, hide it.
+    ScratchpadShow {
+        /// Id of the specific scratchpad window to show.
+        ///
+        /// If `None`, shows the most recently hidden scratchpad.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+    },
     /// Move a floating window on screen.
     #[cfg_attr(feature = "clap", clap(about = "Move the floating window on screen"))]
     MoveFloatingWindow {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2050,6 +2050,36 @@ impl State {
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
+            Action::MoveScratchpad => {
+                self.niri.layout.move_scratchpad(None);
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::MoveScratchpadById(id) => {
+                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
+                let window = window.map(|(_, m)| m.window.clone());
+                if let Some(window) = window {
+                    self.niri.layout.move_scratchpad(Some(&window));
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
+            Action::ScratchpadShow => {
+                self.niri.layout.scratchpad_show(None);
+                self.maybe_warp_cursor_to_focus();
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::ScratchpadShowById(id) => {
+                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
+                let window = window.map(|(_, m)| m.window.clone());
+                if let Some(window) = window {
+                    self.niri.layout.scratchpad_show(Some(&window));
+                    self.maybe_warp_cursor_to_focus();
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
             Action::MoveFloatingWindowById { id, x, y } => {
                 let window = if let Some(id) = id {
                     let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -77,6 +77,9 @@ pub struct Tile<W: LayoutElement> {
     /// Currently selected preset height index when this tile is floating.
     pub(super) floating_preset_height_idx: Option<usize>,
 
+    /// Whether this window is marked as a scratchpad window.
+    pub(super) is_scratchpad: bool,
+
     /// The animation upon opening a window.
     open_animation: Option<OpenAnimation>,
 
@@ -195,6 +198,7 @@ impl<W: LayoutElement> Tile<W> {
             floating_pos: None,
             floating_preset_width_idx: None,
             floating_preset_height_idx: None,
+            is_scratchpad: false,
             open_animation: None,
             resize_animation: None,
             move_x_animation: None,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2314,7 +2314,7 @@ impl State {
             },
         );
 
-        self.niri.layout.with_windows(|mapped, _, _, _| {
+        self.niri.layout.with_windows(|mapped, _, _, _, _| {
             let id = mapped.id().get();
             let props = with_toplevel_role(mapped.toplevel(), |role| {
                 gnome_shell_introspect::WindowProperties {
@@ -4144,7 +4144,7 @@ impl Niri {
         let mut seen = HashSet::new();
         let mut output_changed = vec![];
 
-        self.layout.with_windows(|mapped, output, _, _| {
+        self.layout.with_windows(|mapped, output, _, _, _| {
             seen.insert(mapped.window.clone());
 
             let Some(output) = output else {

--- a/src/protocols/foreign_toplevel.rs
+++ b/src/protocols/foreign_toplevel.rs
@@ -97,7 +97,7 @@ pub fn refresh(state: &mut State) {
     // Save the focused window for last, this way when the focus changes, we will first deactivate
     // the previous window and only then activate the newly focused window.
     let mut focused = None;
-    state.niri.layout.with_windows(|mapped, output, _, _| {
+    state.niri.layout.with_windows(|mapped, output, _, _, _| {
         let toplevel = mapped.toplevel();
         let wl_surface = toplevel.wl_surface();
         with_toplevel_role_and_current(toplevel, |role, cur| {

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -257,6 +257,8 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
         &Action::ConsumeOrExpelWindowRight,
         &Action::ToggleWindowFloating,
         &Action::SwitchFocusBetweenFloatingAndTiling,
+        &Action::MoveScratchpad,
+        &Action::ScratchpadShow,
         &Action::ToggleOverview,
     ]);
 
@@ -478,6 +480,10 @@ fn action_name(action: &Action) -> String {
         Action::SwitchFocusBetweenFloatingAndTiling => {
             String::from("Switch Focus Between Floating and Tiling")
         }
+        Action::MoveScratchpad => String::from("Move Window to Scratchpad"),
+        Action::MoveScratchpadById(_) => String::from("Move Window to Scratchpad"),
+        Action::ScratchpadShow => String::from("Toggle Scratchpad Window"),
+        Action::ScratchpadShowById(_) => String::from("Show Specific Scratchpad Window"),
         Action::ToggleOverview => String::from("Open the Overview"),
         Action::Screenshot(_, _) => String::from("Take a Screenshot"),
         Action::Spawn(args) => format!(


### PR DESCRIPTION
## Summary

Implements i3-like scratchpad functionality that allows users to quickly hide and show windows.

## Features

- **`move-scratchpad` action**: Hide the focused window (or specific window by ID) to scratchpad
- **`scratchpad-show` action**: Show the most recently hidden scratchpad window (or specific window by ID)
- **Cross-workspace support**: Scratchpad windows follow you across workspaces
- **LIFO ordering**: Multiple scratchpad windows are shown in last-hidden, first-shown order
- **Always floating**: Scratchpad windows appear as centered floating windows when shown
- **Full IPC support**: Both actions support optional `--id` parameter for managing specific windows
- **IPC visibility**: Hidden scratchpad windows appear in `niri msg windows` with `is_in_scratchpad: true`

## Real-World Example: Dropdown Terminal

A common use case is a dropdown terminal that you can quickly toggle with a keybinding:

### Configuration

```kdl
// Window rule for dropdown terminal
window-rule {
  match app-id=r#"^dropdown$"#
  open-floating true
  default-window-height { proportion 0.3; }
  default-column-width { proportion 0.20; }
}

binds {
    // Toggle dropdown terminal
    Alt+U { spawn-sh "~/.config/niri/scripts/scratchpad-toggle.sh dropdown kitty --class dropdown"; }
}
```

### Toggle Script

The script spawns the terminal on first use, then toggles it between visible and hidden:

```bash
#!/bin/bash
APP_ID="$1"
shift
SPAWN_CMD="$@"

# Get window info (includes both visible and scratchpad windows)
WINDOW_INFO=$(niri msg --json windows | jq ".[] | select(.app_id == \"$APP_ID\") | {id, is_in_scratchpad}")

if [ -n "$WINDOW_INFO" ]; then
    # Window exists - check if it's in scratchpad
    WINDOW_ID=$(echo "$WINDOW_INFO" | jq -r '.id')
    IS_IN_SCRATCHPAD=$(echo "$WINDOW_INFO" | jq -r '.is_in_scratchpad')

    if [ "$IS_IN_SCRATCHPAD" = "true" ]; then
        # Hidden in scratchpad - show it
        niri msg action scratchpad-show --id "$WINDOW_ID"
    else
        # Visible - hide it to scratchpad
        niri msg action move-scratchpad --id "$WINDOW_ID"
    fi
else
    # Window doesn't exist - spawn it
    niri msg action spawn -- $SPAWN_CMD
fi
```

This provides seamless toggle behavior:
- First press: Spawns dropdown terminal
- Second press: Hides to scratchpad
- Third press: Shows from scratchpad (on current workspace)
- Works across workspaces - terminal follows you wherever you go

### Manual IPC Usage

You can also manage scratchpads manually via IPC:

```bash
# Get window IDs
niri msg --json windows | jq '.[] | select(.app_id == "dropdown")'

# Move specific window to scratchpad
niri msg action move-scratchpad --id 12345

# Show specific scratchpad window
niri msg action scratchpad-show --id 12345

# Check if window is in scratchpad
niri msg --json windows | jq '.[] | select(.id == 12345) | .is_in_scratchpad'
```

## Simple Keybinding Usage

For basic usage without scripting:

```kdl
binds {
    // Hide the focused window in scratchpad
    Mod+Shift+Minus { move-scratchpad; }

    // Toggle scratchpad visibility
    Mod+Minus { scratchpad-show; }
}
```

## Implementation Details

- Added `is_scratchpad: bool` field to `Tile` to mark scratchpad windows
- Added `hidden_scratchpad: Vec<Tile<W>>` to `Workspace` to store hidden windows
- Scratchpad windows are removed from layout and truly hidden (not just on a different workspace)
- When showing a scratchpad on a different workspace, it moves to the active workspace
- Scratchpad windows are included in IPC response with `is_in_scratchpad` flag
- Prevents crashes when updating windows that are in scratchpad
- Includes comprehensive unit tests (7 scratchpad-specific tests)

## Testing

- Comprehensive unit tests in `src/layout/tests.rs`
- Real-world testing with dropdown terminal across multiple workspaces
- Tested with both direct IPC commands and scripted toggle behavior
- All existing tests pass

## Documentation

- Updated `docs/wiki/Configuration:-Key-Bindings.md` with scratchpad actions
- Updated `docs/wiki/Floating-Windows.md` with scratchpad behavior
- Updated `README.md` to mention scratchpad support