### PR TITLE
Maintain a single empty workspace at the edges

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1134,6 +1134,32 @@ impl<W: LayoutElement> Layout<W> {
                                 mon.workspaces.remove(1);
                                 mon.active_workspace_idx = 0;
                             }
+
+                            // If the last two workspaces are empty unnamed, remove the last one.
+                            let len = mon.workspaces.len();
+                            if len >= 2
+                                // FIXME: Should `!ws.has_windows_or_name()` be checked here
+                                // or it will be redundant?
+                                && !mon.workspaces[len - 1].has_windows_or_name()
+                                && !mon.workspaces[len - 2].has_windows_or_name()
+                                && mon.active_workspace_idx != len - 1
+                                && mon.workspace_switch.is_none()
+                            {
+                                mon.workspaces.remove(len - 1);
+                            }
+
+                            // If empty_workspace_above_first is set and the first two workspaces are
+                            // empty unnamed, remove the first one.
+                            if mon.options.layout.empty_workspace_above_first
+                                && mon.workspaces.len() >= 2
+                                && !mon.workspaces[0].has_windows_or_name()
+                                && !mon.workspaces[1].has_windows_or_name()
+                                && mon.active_workspace_idx != 0
+                                && mon.workspace_switch.is_none()
+                            {
+                                mon.workspaces.remove(0);
+                                mon.active_workspace_idx -= 1;
+                            }
                             return Some(removed);
                         }
                     }

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -649,6 +649,28 @@ impl<W: LayoutElement> Monitor<W> {
             self.workspaces.remove(1);
             self.active_workspace_idx = 0;
         }
+
+        // If the last two workspaces are empty unnamed, remove the last one.
+        let len = self.workspaces.len();
+        if len >= 2
+            && !self.workspaces[len - 1].has_windows_or_name()
+            && !self.workspaces[len - 2].has_windows_or_name()
+            && self.active_workspace_idx != len - 1
+        {
+            self.workspaces.remove(len - 1);
+        }
+
+        // If empty_workspace_above_first is set and the first two workspaces are
+        // empty unnamed, remove the first one.
+        if self.options.layout.empty_workspace_above_first
+            && self.workspaces.len() >= 2
+            && !self.workspaces[0].has_windows_or_name()
+            && !self.workspaces[1].has_windows_or_name()
+            && self.active_workspace_idx != 0
+        {
+            self.workspaces.remove(0);
+            self.active_workspace_idx -= 1;
+        }
     }
 
     pub fn unname_workspace(&mut self, id: WorkspaceId) -> bool {
@@ -2113,10 +2135,36 @@ impl<W: LayoutElement> Monitor<W> {
         }
 
         if self.options.layout.empty_workspace_above_first {
-            assert!(
-                self.workspaces.len() != 2,
+            assert_ne!(
+                self.workspaces.len(),
+                2,
                 "if empty_workspace_above_first is set there must be just 1 or 3+ workspaces"
             )
+        }
+
+        // If there's no workspace switch in progress, there can't be any
+        // two consecutive empty unnamed workspaces at the end
+        if self.workspace_switch.is_none() && self.workspaces.len() >= 2 {
+            let len = self.workspaces.len();
+            assert!(
+                !(!self.workspaces[len - 1].has_windows_or_name()
+                    && !self.workspaces[len - 2].has_windows_or_name()),
+                "the last two workspaces cannot both be empty and unnamed"
+            );
+        }
+
+        // If there's no workspace switch in progress, and empty_workspace_above_first is set,
+        // there can't be any two consecutive empty unnamed workspaces at the beginning
+        if self.options.layout.empty_workspace_above_first
+            && self.workspace_switch.is_none()
+            && self.workspaces.len() >= 2
+        {
+            assert!(
+                !(!self.workspaces[0].has_windows_or_name()
+                    && !self.workspaces[1].has_windows_or_name()),
+                "when empty_workspace_above_first is set, the first two workspaces \
+         cannot both be empty and unnamed"
+            );
         }
 
         // If there's no workspace switch in progress, there can't be any non-last non-active

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -1973,6 +1973,24 @@ fn window_closed_on_previous_workspace() {
 }
 
 #[test]
+fn cleanup_trailing_workspace_on_window_close() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::CloseWindow(1),
+    ];
+
+    let layout = check_ops(ops);
+    let MonitorSet::Normal { monitors, .. } = layout.monitor_set else {
+        unreachable!()
+    };
+
+    assert_eq!(monitors[0].workspaces.len(), 1);
+}
+
+#[test]
 fn removing_output_must_keep_empty_focus_on_primary() {
     let ops = [
         Op::AddOutput(1),


### PR DESCRIPTION
This PR ensures that workspaces maintain only one empty unnamed workspace at the end (or at both edges if `empty_workspace_above_first` is enabled).

A simple scenario: if there is only one workspace and a window is opened (which creates a new workspace at the end), then after closing that window, the last workspace should be removed. This makes the workspace state consistent: before opening a window and after closing it, the number of workspaces remains the same.

Similarly, when `empty_workspace_above_first` is enabled, the same behavior applies to the first workspace. So, if there is only one workspace, opening a window will create leading and trailing workspaces. After closing the window, it should return to having just one workspace, instead of three.