### PR TITLE
feat(input): Add per-device keyboard and mouse configuration

### DIFF
--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -4,7 +4,9 @@ In this section you can configure input devices like keyboard and mouse, and som
 
 There's a section for each device type: `keyboard`, `touchpad`, `mouse`, `trackpoint`, `tablet`, `touch`.
 Settings in those sections will apply to every device of that type.
-Currently, there's no way to configure specific devices individually (but that is planned).
+Currently, there's no way to configure specific `touchpad`, `touch`, `tablet` or `trackpoint` devices
+individually (but that is planned).
+However, you can configure specific `keyboard` and `mouse` devices by name.
 
 All settings at a glance:
 
@@ -280,6 +282,47 @@ input {
 Valid output names are the same as the ones used for output configuration.
 
 <sup>Since: 0.1.7</sup> When a tablet is not mapped to any output, it will map to the union of all connected outputs, without aspect ratio correction.
+
+> [!TIP]
+>
+> <sup>Since: next release</sup>
+>
+> It is possible to configure specific `keyboard` and `mouse` devices by name.
+>
+> Any non‑device‑specific settings will apply as a fallback when no matching device‑specific block exists:
+>
+> ```kdl
+> input {
+>     keyboard {
+>         xkb {
+>             layout "us"
+>         }
+>     }
+>
+>     // Configure this specific keyboard with a different layout.
+>     keyboard "AT Translated Set 2 keyboard" {
+>         xkb {
+>             layout "us,ru"
+>             options "grp:alt_shift_toggle"
+>         }
+>     }
+>
+>     mouse {
+>         natural-scroll
+>         accel-speed 0.5
+>     }
+>
+>     // Configure this specific mouse with different settings.
+>     mouse "Logitech G Pro" {
+>         accel-speed -0.3
+>         accel-profile "flat"
+>     }
+> }
+> ```
+>
+> The device name is case-insensitive.
+> Device names are taken from libinput; you can find them by running `sudo libinput list-devices` or `sudo libinput debug-events`.
+> For keyboards without libinput support, check the evdev device name in the output of `libinput debug-events`.
 
 ### General Settings
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -576,8 +576,8 @@ mod tests {
     #[test]
     fn default_repeat_params() {
         let config = Config::parse_mem("").unwrap();
-        assert_eq!(config.input.keyboard.repeat_delay, 600);
-        assert_eq!(config.input.keyboard.repeat_rate, 25);
+        assert_eq!(config.input.keyboards.repeat_delay(), 600);
+        assert_eq!(config.input.keyboards.repeat_rate(), 25);
     }
 
     #[track_caller]
@@ -900,22 +900,35 @@ mod tests {
         assert_debug_snapshot!(parsed, @r#"
         Config {
             input: Input {
-                keyboard: Keyboard {
-                    xkb: Xkb {
-                        rules: "",
-                        model: "",
-                        layout: "us,ru",
-                        variant: "",
-                        options: Some(
-                            "grp:win_space_toggle",
-                        ),
-                        file: None,
-                    },
-                    repeat_delay: 600,
-                    repeat_rate: 25,
-                    track_layout: Window,
-                    numlock: false,
-                },
+                keyboards: Keyboards(
+                    [
+                        Keyboard {
+                            name: None,
+                            xkb: Some(
+                                Xkb {
+                                    rules: "",
+                                    model: "",
+                                    layout: "us,ru",
+                                    variant: "",
+                                    options: Some(
+                                        "grp:win_space_toggle",
+                                    ),
+                                    file: None,
+                                },
+                            ),
+                            repeat_delay: Some(
+                                600,
+                            ),
+                            repeat_rate: Some(
+                                25,
+                            ),
+                            track_layout: Some(
+                                Window,
+                            ),
+                            numlock: None,
+                        },
+                    ],
+                ),
                 touchpad: Touchpad {
                     off: false,
                     tap: true,
@@ -960,36 +973,41 @@ mod tests {
                         },
                     ),
                 },
-                mouse: Mouse {
-                    off: false,
-                    natural_scroll: true,
-                    accel_speed: FloatOrInt(
-                        0.4,
-                    ),
-                    accel_profile: Some(
-                        Flat,
-                    ),
-                    scroll_method: Some(
-                        NoScroll,
-                    ),
-                    scroll_button: Some(
-                        273,
-                    ),
-                    scroll_button_lock: false,
-                    left_handed: false,
-                    middle_emulation: true,
-                    scroll_factor: Some(
-                        ScrollFactor {
-                            base: Some(
-                                FloatOrInt(
-                                    0.2,
-                                ),
+                mice: Mice(
+                    [
+                        Mouse {
+                            name: None,
+                            off: false,
+                            natural_scroll: true,
+                            accel_speed: FloatOrInt(
+                                0.4,
                             ),
-                            horizontal: None,
-                            vertical: None,
+                            accel_profile: Some(
+                                Flat,
+                            ),
+                            scroll_method: Some(
+                                NoScroll,
+                            ),
+                            scroll_button: Some(
+                                273,
+                            ),
+                            scroll_button_lock: false,
+                            left_handed: false,
+                            middle_emulation: true,
+                            scroll_factor: Some(
+                                ScrollFactor {
+                                    base: Some(
+                                        FloatOrInt(
+                                            0.2,
+                                        ),
+                                    ),
+                                    horizontal: None,
+                                    vertical: None,
+                                },
+                            ),
                         },
-                    ),
-                },
+                    ],
+                ),
                 trackpoint: Trackpoint {
                     off: true,
                     natural_scroll: true,

--- a/src/dbus/freedesktop_a11y.rs
+++ b/src/dbus/freedesktop_a11y.rs
@@ -472,7 +472,7 @@ impl State {
         });
 
         let config = self.niri.config.borrow();
-        let repeat_delay = Duration::from_millis(u64::from(config.input.keyboard.repeat_delay));
+        let repeat_delay = Duration::from_millis(u64::from(config.input.keyboards.repeat_delay()));
         let released = state == KeyState::Released;
 
         let Some(monitor) = &self.niri.a11y_keyboard_monitor else {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -413,6 +413,9 @@ impl State {
         #[cfg(not(feature = "dbus"))]
         let _ = consumed_by_a11y;
 
+        // Check if we need to switch XKB configuration for a different keyboard device.
+        self.maybe_switch_keyboard_xkb::<I>(&event);
+
         let Some(Some(bind)) = self.niri.seat.get_keyboard().unwrap().input(
             self,
             event.key_code(),
@@ -566,16 +569,16 @@ impl State {
         }
 
         let config = self.niri.config.borrow();
-        let config = &config.input.keyboard;
+        let keyboards = &config.input.keyboards;
 
-        let repeat_rate = config.repeat_rate;
+        let repeat_rate = keyboards.repeat_rate();
         if repeat_rate == 0 {
             return;
         }
         let repeat_duration = Duration::from_secs_f64(1. / f64::from(repeat_rate));
 
         let repeat_timer =
-            Timer::from_duration(Duration::from_millis(u64::from(config.repeat_delay)));
+            Timer::from_duration(Duration::from_millis(u64::from(keyboards.repeat_delay())));
 
         let token = self
             .niri
@@ -609,6 +612,67 @@ impl State {
 
         self.niri.pointer_visibility = PointerVisibility::Hidden;
         self.niri.queue_redraw_all();
+    }
+
+    /// Switches XKB configuration when a different keyboard device is used.
+    ///
+    /// This allows per-device keyboard layouts - for example, you can have one keyboard
+    /// with "us" layout and another with "us,ru" layout. The active XKB configuration
+    /// will switch automatically based on which keyboard you're typing on.
+    fn maybe_switch_keyboard_xkb<I: InputBackend>(&mut self, event: &I::KeyboardKeyEvent) {
+        let device = event.device();
+        let device_name = device.name().to_string();
+
+        // Check if this is a different keyboard than the last one
+        if self.niri.last_keyboard_device.as_ref() == Some(&device_name) {
+            return;
+        }
+
+        // Look up the keyboard configuration for this device
+        let xkb = {
+            let config = self.niri.config.borrow();
+            let keyboard_config = config.input.keyboards.find(Some(&device_name));
+
+            // Get the XKB config for this device (may be device-specific or default)
+            keyboard_config.xkb.clone().or_else(|| {
+                // If this device has no specific config, use the default
+                let default_config = config.input.keyboards.find(None);
+                default_config.xkb.clone()
+            })
+        }; // config borrow is dropped here
+
+        // Only switch if there's an XKB config to apply
+        if let Some(xkb) = xkb {
+            let xkb_config = xkb.to_xkb_config();
+
+            // Preserve the num lock state when switching keyboards
+            let keyboard = self.niri.seat.get_keyboard().unwrap();
+            let num_lock = keyboard.modifier_state().num_lock;
+
+            // Try to set the new XKB config
+            if let Err(err) = keyboard.set_xkb_config(self, xkb_config) {
+                warn!(
+                    "error switching xkb config for device '{}': {err:?}",
+                    device_name
+                );
+                return;
+            }
+
+            // Restore num lock to its previous value
+            let mut mods_state = keyboard.modifier_state();
+            if mods_state.num_lock != num_lock {
+                mods_state.num_lock = num_lock;
+                keyboard.set_modifier_state(mods_state);
+            }
+
+            debug!("switched XKB config for keyboard device: {}", device_name);
+
+            // Notify IPC clients about the layout change
+            self.ipc_keyboard_layouts_changed();
+        }
+
+        // Update the last keyboard device
+        self.niri.last_keyboard_device = Some(device_name);
     }
 
     pub fn handle_bind(&mut self, bind: Bind) {
@@ -3388,7 +3452,7 @@ impl State {
         let device_scroll_factor = {
             let config = self.niri.config.borrow();
             match source {
-                AxisSource::Wheel => config.input.mouse.scroll_factor,
+                AxisSource::Wheel => config.input.mice.find(None).scroll_factor,
                 AxisSource::Finger => config.input.touchpad.scroll_factor,
                 _ => None,
             }
@@ -4703,7 +4767,7 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
         && !is_trackball
         && !is_trackpoint;
     if is_mouse {
-        let c = &config.mouse;
+        let c = config.mice.find(Some(device.name()));
         let _ = device.config_send_events_set_mode(if c.off {
             input::SendEventsMode::DISABLED
         } else {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -266,6 +266,8 @@ pub struct Niri {
     pub devices: HashSet<input::Device>,
     pub tablets: HashMap<input::Device, TabletData>,
     pub touch: HashSet<input::Device>,
+    /// Tracks the last keyboard device that sent an event, for per-device XKB switching.
+    pub last_keyboard_device: Option<String>,
 
     // Smithay state.
     pub compositor_state: CompositorState,
@@ -1303,7 +1305,7 @@ impl State {
                 }
             }
 
-            if self.niri.config.borrow().input.keyboard.track_layout == TrackLayout::Window {
+            if self.niri.config.borrow().input.keyboards.track_layout() == TrackLayout::Window {
                 let current_layout = keyboard.with_xkb_state(self, |context| {
                     let xkb = context.xkb().lock().unwrap();
                     xkb.active_layout()
@@ -1363,7 +1365,7 @@ impl State {
     }
 
     fn load_xkb_file(&mut self) {
-        let xkb_file = self.niri.config.borrow().input.keyboard.xkb.file.clone();
+        let xkb_file = self.niri.config.borrow().input.keyboards.xkb().file.clone();
         if let Some(xkb_file) = xkb_file {
             if let Err(err) = self.set_xkb_file(xkb_file) {
                 warn!("error loading xkb_file: {err:?}");
@@ -1455,23 +1457,30 @@ impl State {
         }
 
         // We need &mut self to reload the xkb config, so just store it here.
-        if config.input.keyboard.xkb != old_config.input.keyboard.xkb {
-            reload_xkb = Some(config.input.keyboard.xkb.clone());
+        if config.input.keyboards.xkb() != old_config.input.keyboards.xkb() {
+            reload_xkb = Some(config.input.keyboards.xkb());
+        }
+
+        // Reset the last keyboard device if keyboard configs changed, so the next keystroke
+        // will trigger a re-application of the XKB configuration.
+        if config.input.keyboards != old_config.input.keyboards {
+            self.niri.last_keyboard_device = None;
         }
 
         // Reload the repeat info.
-        if config.input.keyboard.repeat_rate != old_config.input.keyboard.repeat_rate
-            || config.input.keyboard.repeat_delay != old_config.input.keyboard.repeat_delay
+        if config.input.keyboards.repeat_rate() != old_config.input.keyboards.repeat_rate()
+            || config.input.keyboards.repeat_delay() != old_config.input.keyboards.repeat_delay()
         {
             let keyboard = self.niri.seat.get_keyboard().unwrap();
             keyboard.change_repeat_info(
-                config.input.keyboard.repeat_rate.into(),
-                config.input.keyboard.repeat_delay.into(),
+                config.input.keyboards.repeat_rate().into(),
+                config.input.keyboards.repeat_delay().into(),
             );
         }
 
         if config.input.touchpad != old_config.input.touchpad
-            || config.input.mouse != old_config.input.mouse
+            || config.input.keyboards != old_config.input.keyboards
+            || config.input.mice != old_config.input.mice
             || config.input.trackball != old_config.input.trackball
             || config.input.trackpoint != old_config.input.trackpoint
             || config.input.tablet != old_config.input.tablet
@@ -2409,7 +2418,7 @@ impl State {
 
         {
             let config = self.niri.config.borrow();
-            if config.input.keyboard.xkb != Xkb::default() {
+            if config.input.keyboards.xkb() != Xkb::default() {
                 trace!("ignoring locale1 xkb change because niri config has xkb settings");
                 return;
             }
@@ -2569,9 +2578,9 @@ impl Niri {
 
         let mut seat: Seat<State> = seat_state.new_wl_seat(&display_handle, backend.seat_name());
         let keyboard = match seat.add_keyboard(
-            config_.input.keyboard.xkb.to_xkb_config(),
-            config_.input.keyboard.repeat_delay.into(),
-            config_.input.keyboard.repeat_rate.into(),
+            config_.input.keyboards.xkb().to_xkb_config(),
+            config_.input.keyboards.repeat_delay().into(),
+            config_.input.keyboards.repeat_rate().into(),
         ) {
             Err(err) => {
                 if let smithay::input::keyboard::Error::BadKeymap = err {
@@ -2581,14 +2590,14 @@ impl Niri {
                 }
                 seat.add_keyboard(
                     Default::default(),
-                    config_.input.keyboard.repeat_delay.into(),
-                    config_.input.keyboard.repeat_rate.into(),
+                    config_.input.keyboards.repeat_delay().into(),
+                    config_.input.keyboards.repeat_rate().into(),
                 )
                 .unwrap()
             }
             Ok(keyboard) => keyboard,
         };
-        if config_.input.keyboard.numlock {
+        if config_.input.keyboards.numlock() {
             let mut modifier_state = keyboard.modifier_state();
             modifier_state.num_lock = true;
             keyboard.set_modifier_state(modifier_state);
@@ -2721,6 +2730,7 @@ impl Niri {
             devices: HashSet::new(),
             tablets: HashMap::new(),
             touch: HashSet::new(),
+            last_keyboard_device: None,
 
             compositor_state,
             xdg_shell_state,


### PR DESCRIPTION
This enables users to configure different layouts and settings for individual keyboards and mice by device name. For example, you can now have one keyboard with a US layout and another with US+RU layouts, with automatic XKB switching when typing on different devices.

Changes:
- Add per-device keyboard layout configuration support
- Add per-device mouse settings configuration
- Implement automatic XKB switching based on active keyboard device
- Refactor Keyboard and Mouse types to support multiple device configs
- Add Keyboards and Mice collection types with device name lookup
- Update documentation with per-device configuration examples
- Save numlock state per keyboard (this may look weird as the LED follow the global state but as soon as you type on a keyboard with numlock disabled the LED shuts off)

Device names are matched case-insensitively from libinput (use `sudo libinput list-devices` to find device names).

This addresses issue #371