### PR TITLE
Add per output max-bpc config and ipc action

### DIFF
--- a/docs/wiki/Configuration:-Outputs.md
+++ b/docs/wiki/Configuration:-Outputs.md
@@ -15,6 +15,7 @@ output "eDP-1" {
     variable-refresh-rate // on-demand=true
     focus-at-startup
     backdrop-color "#001100"
+    bpc 10
 
     hot-corners {
         // off
@@ -276,6 +277,21 @@ The alpha channel for this color will be ignored.
 ```kdl
 output "HDMI-A-1" {
     backdrop-color "#001100"
+}
+```
+
+### `bpc`
+
+<sup>Since: next release</sup>
+
+Set the maximum bits per channel (BPC) for this output.
+This is not needed for most outputs unless encountering bandwidth or lower-than-expected colour depth issues.
+
+Valid values are `8`, `10`.
+
+```kdl
+output "HDMI-A-1" {
+    bpc 10
 }
 ```
 

--- a/docs/wiki/Configuration:-Outputs.md
+++ b/docs/wiki/Configuration:-Outputs.md
@@ -15,6 +15,7 @@ output "eDP-1" {
     variable-refresh-rate // on-demand=true
     focus-at-startup
     backdrop-color "#001100"
+    max-bpc 8
 
     hot-corners {
         // off
@@ -276,6 +277,23 @@ The alpha channel for this color will be ignored.
 ```kdl
 output "HDMI-A-1" {
     backdrop-color "#001100"
+}
+```
+
+### `max-bpc`
+
+<sup>Since: next release</sup>
+
+Set the maximum bits per channel (BPC) for this output.
+You *do not* need to set this option unless you hit bandwidth issues (can't set a monitor configuration that works on other compositor) or lower-than-expected color depth.
+Particularly, 10-bit color output may work even if max-bpc is 8.
+
+Valid values are `6`, `8`, `10`, `12`, `14`, `16`.
+
+```kdl
+// Set 8 max-bpc on HDMI-A-1 to lower the bandwidth.
+output "HDMI-A-1" {
+    max-bpc 8
 }
 ```
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1139,7 +1139,9 @@ mod tests {
                                 y: 20,
                             },
                         ),
-                        bpc: _10,
+                        bpc: Some(
+                            _10,
+                        ),
                         mode: Some(
                             Mode {
                                 custom: false,
@@ -1185,7 +1187,7 @@ mod tests {
                         scale: None,
                         transform: Normal,
                         position: None,
-                        bpc: _8,
+                        bpc: None,
                         mode: Some(
                             Mode {
                                 custom: true,
@@ -1212,7 +1214,7 @@ mod tests {
                         scale: None,
                         transform: Normal,
                         position: None,
-                        bpc: _8,
+                        bpc: None,
                         mode: None,
                         modeline: Some(
                             Modeline {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -725,6 +725,7 @@ mod tests {
                 transform "flipped-90"
                 position x=10 y=20
                 mode "1920x1080@144"
+                bpc 10
                 variable-refresh-rate on-demand=true
                 background-color "rgba(25, 25, 102, 1.0)"
                 hot-corners {
@@ -837,7 +838,7 @@ mod tests {
                 window-open { off; }
 
                 window-close {
-                    curve "cubic-bezier" 0.05 0.7 0.1 1  
+                    curve "cubic-bezier" 0.05 0.7 0.1 1
                 }
 
                 recent-windows-close {
@@ -1138,6 +1139,7 @@ mod tests {
                                 y: 20,
                             },
                         ),
+                        bpc: _10,
                         mode: Some(
                             Mode {
                                 custom: false,
@@ -1183,6 +1185,7 @@ mod tests {
                         scale: None,
                         transform: Normal,
                         position: None,
+                        bpc: _8,
                         mode: Some(
                             Mode {
                                 custom: true,
@@ -1209,6 +1212,7 @@ mod tests {
                         scale: None,
                         transform: Normal,
                         position: None,
+                        bpc: _8,
                         mode: None,
                         modeline: Some(
                             Modeline {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -745,6 +745,7 @@ mod tests {
                 transform "flipped-90"
                 position x=10 y=20
                 mode "1920x1080@144"
+                max-bpc 10
                 variable-refresh-rate on-demand=true
                 background-color "rgba(25, 25, 102, 1.0)"
                 hot-corners {
@@ -857,7 +858,7 @@ mod tests {
                 window-open { off; }
 
                 window-close {
-                    curve "cubic-bezier" 0.05 0.7 0.1 1  
+                    curve "cubic-bezier" 0.05 0.7 0.1 1
                 }
 
                 recent-windows-close {
@@ -1160,6 +1161,11 @@ mod tests {
                                 y: 20,
                             },
                         ),
+                        max_bpc: Some(
+                            MaxBpc(
+                                _10,
+                            ),
+                        ),
                         mode: Some(
                             Mode {
                                 custom: false,
@@ -1205,6 +1211,7 @@ mod tests {
                         scale: None,
                         transform: Normal,
                         position: None,
+                        max_bpc: None,
                         mode: Some(
                             Mode {
                                 custom: true,
@@ -1231,6 +1238,7 @@ mod tests {
                         scale: None,
                         transform: Normal,
                         position: None,
+                        max_bpc: None,
                         mode: None,
                         modeline: Some(
                             Modeline {

--- a/niri-config/src/output.rs
+++ b/niri-config/src/output.rs
@@ -59,6 +59,8 @@ pub struct Output {
     pub transform: Transform,
     #[knuffel(child)]
     pub position: Option<Position>,
+    #[knuffel(child, unwrap(argument), default)]
+    pub bpc: Bpc,
     #[knuffel(child)]
     pub mode: Option<Mode>,
     #[knuffel(child)]
@@ -101,6 +103,7 @@ impl Default for Output {
             scale: None,
             transform: Transform::Normal,
             position: None,
+            bpc: Bpc::default(),
             mode: None,
             modeline: None,
             variable_refresh_rate: None,
@@ -126,6 +129,14 @@ pub struct Position {
     pub x: i32,
     #[knuffel(property)]
     pub y: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Bpc {
+    #[default]
+    _8,
+    _10,
+    _16,
 }
 
 #[derive(knuffel::Decode, Debug, Clone, PartialEq, Default)]
@@ -253,6 +264,53 @@ impl OutputName {
                 .then_with(|| self.model.cmp(&other.model))
                 .then_with(|| self.serial.cmp(&other.serial))
                 .then_with(|| self.connector.cmp(&other.connector)),
+        }
+    }
+}
+
+impl TryFrom<u8> for Bpc {
+    type Error = &'static str;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            8 => Ok(Bpc::_8),
+            10 => Ok(Bpc::_10),
+            16 => Ok(Bpc::_16),
+            _ => Err(r#"invalid bpc, can be 8, 10, or 16"#),
+        }
+    }
+}
+
+impl<S: ErrorSpan> knuffel::DecodeScalar<S> for Bpc {
+    fn type_check(
+        type_name: &Option<knuffel::span::Spanned<knuffel::ast::TypeName, S>>,
+        ctx: &mut Context<S>,
+    ) {
+        if let Some(type_name) = &type_name {
+            ctx.emit_error(DecodeError::unexpected(
+                type_name,
+                "type name",
+                "no type name expected for this node",
+            ));
+        }
+    }
+
+    fn raw_decode(
+        value: &knuffel::span::Spanned<knuffel::ast::Literal, S>,
+        ctx: &mut Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        match &**value {
+            knuffel::ast::Literal::Int(ref val) => match u8::try_from(val) {
+                Ok(v) => Bpc::try_from(v).map_err(|e| DecodeError::conversion(value, e)),
+                Err(e) => {
+                    ctx.emit_error(DecodeError::conversion(value, e));
+                    Ok(Self::default())
+                }
+            },
+            _ => {
+                ctx.emit_error(DecodeError::scalar_kind(knuffel::decode::Kind::Int, value));
+                Ok(Self::default())
+            }
         }
     }
 }

--- a/niri-config/src/output.rs
+++ b/niri-config/src/output.rs
@@ -59,8 +59,8 @@ pub struct Output {
     pub transform: Transform,
     #[knuffel(child)]
     pub position: Option<Position>,
-    #[knuffel(child, unwrap(argument), default)]
-    pub bpc: Bpc,
+    #[knuffel(child, unwrap(argument))]
+    pub bpc: Option<Bpc>,
     #[knuffel(child)]
     pub mode: Option<Mode>,
     #[knuffel(child)]
@@ -103,7 +103,7 @@ impl Default for Output {
             scale: None,
             transform: Transform::Normal,
             position: None,
-            bpc: Bpc::default(),
+            bpc: None,
             mode: None,
             modeline: None,
             variable_refresh_rate: None,
@@ -133,10 +133,9 @@ pub struct Position {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Bpc {
+    _8 = 8,
     #[default]
-    _8,
-    _10,
-    _16,
+    _10 = 10,
 }
 
 #[derive(knuffel::Decode, Debug, Clone, PartialEq, Default)]
@@ -275,8 +274,7 @@ impl TryFrom<u8> for Bpc {
         match value {
             8 => Ok(Bpc::_8),
             10 => Ok(Bpc::_10),
-            16 => Ok(Bpc::_16),
-            _ => Err(r#"invalid bpc, can be 8, 10, or 16"#),
+            _ => Err(r#"invalid bpc, can be 8 or 10"#),
         }
     }
 }

--- a/niri-config/src/output.rs
+++ b/niri-config/src/output.rs
@@ -59,6 +59,8 @@ pub struct Output {
     pub transform: Transform,
     #[knuffel(child)]
     pub position: Option<Position>,
+    #[knuffel(child, unwrap(argument))]
+    pub max_bpc: Option<MaxBpc>,
     #[knuffel(child)]
     pub mode: Option<Mode>,
     #[knuffel(child)]
@@ -101,6 +103,7 @@ impl Default for Output {
             scale: None,
             transform: Transform::Normal,
             position: None,
+            max_bpc: None,
             mode: None,
             modeline: None,
             variable_refresh_rate: None,
@@ -127,6 +130,9 @@ pub struct Position {
     #[knuffel(property)]
     pub y: i32,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct MaxBpc(pub niri_ipc::MaxBpc);
 
 #[derive(knuffel::Decode, Debug, Clone, PartialEq, Default)]
 pub struct Vrr {
@@ -253,6 +259,42 @@ impl OutputName {
                 .then_with(|| self.model.cmp(&other.model))
                 .then_with(|| self.serial.cmp(&other.serial))
                 .then_with(|| self.connector.cmp(&other.connector)),
+        }
+    }
+}
+
+impl<S: ErrorSpan> knuffel::DecodeScalar<S> for MaxBpc {
+    fn type_check(
+        type_name: &Option<knuffel::span::Spanned<knuffel::ast::TypeName, S>>,
+        ctx: &mut Context<S>,
+    ) {
+        if let Some(type_name) = &type_name {
+            ctx.emit_error(DecodeError::unexpected(
+                type_name,
+                "type name",
+                "no type name expected for this node",
+            ));
+        }
+    }
+
+    fn raw_decode(
+        value: &knuffel::span::Spanned<knuffel::ast::Literal, S>,
+        ctx: &mut Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        match &**value {
+            knuffel::ast::Literal::Int(ref val) => match u8::try_from(val) {
+                Ok(v) => niri_ipc::MaxBpc::try_from(v)
+                    .map(MaxBpc)
+                    .map_err(|e| DecodeError::conversion(value, e)),
+                Err(e) => {
+                    ctx.emit_error(DecodeError::conversion(value, e));
+                    Ok(Self::default())
+                }
+            },
+            _ => {
+                ctx.emit_error(DecodeError::scalar_kind(knuffel::decode::Kind::Int, value));
+                Ok(Self::default())
+            }
         }
     }
 }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1228,6 +1228,10 @@ pub struct Output {
     ///
     /// `None` if the output is not mapped to any logical output (for example, if it is disabled).
     pub logical: Option<LogicalOutput>,
+    /// Maximum bit per color  (bit depth), if known.
+    pub max_bpc: Option<u8>,
+    /// Pixel format for framebuffers, if known.
+    pub format: Option<String>,
 }
 
 /// Output mode.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1097,6 +1097,12 @@ pub enum OutputAction {
         #[cfg_attr(feature = "clap", command(flatten))]
         vrr: VrrToSet,
     },
+    /// Set the maximum bits per channel (bit depth).
+    MaxBpc {
+        /// Maximum bits per channel to set.
+        #[cfg_attr(feature = "clap", arg())]
+        max_bpc: MaxBpc,
+    },
 }
 
 /// Output mode to set.
@@ -1228,6 +1234,8 @@ pub struct Output {
     ///
     /// `None` if the output is not mapped to any logical output (for example, if it is disabled).
     pub logical: Option<LogicalOutput>,
+    /// Maximum bits per channel (bit depth), if known.
+    pub max_bpc: Option<u8>,
 }
 
 /// Output mode.
@@ -1289,6 +1297,32 @@ pub enum Transform {
     /// Rotated by 270° and flipped horizontally.
     #[cfg_attr(feature = "clap", value(name("flipped-270")))]
     Flipped270,
+}
+
+/// Output maximum bits per channel.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub enum MaxBpc {
+    /// 6-bit.
+    #[serde(rename = "6")]
+    _6 = 6,
+    /// 8-bit.
+    #[default]
+    #[serde(rename = "8")]
+    _8 = 8,
+    /// 10-bit.
+    #[serde(rename = "10")]
+    _10 = 10,
+    /// 12-bit.
+    #[serde(rename = "12")]
+    _12 = 12,
+    /// 14-bit.
+    #[serde(rename = "14")]
+    _14 = 14,
+    /// 16-bit.
+    #[serde(rename = "16")]
+    _16 = 16,
 }
 
 /// Toplevel window.
@@ -1865,6 +1899,30 @@ impl FromStr for Transform {
                 r#""flipped", "flipped-90", "flipped-180" or "flipped-270""#
             )),
         }
+    }
+}
+
+impl TryFrom<u8> for MaxBpc {
+    type Error = &'static str;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            6 => Ok(MaxBpc::_6),
+            8 => Ok(MaxBpc::_8),
+            10 => Ok(MaxBpc::_10),
+            12 => Ok(MaxBpc::_12),
+            14 => Ok(MaxBpc::_14),
+            16 => Ok(MaxBpc::_16),
+            _ => Err("invalid max-bpc, can be 6, 8, 10, 12, 14, 16"),
+        }
+    }
+}
+
+impl FromStr for MaxBpc {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s.parse::<u8>().unwrap_or_default())
     }
 }
 

--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -109,6 +109,8 @@ impl Headless {
                 vrr_supported: false,
                 vrr_enabled: false,
                 logical: Some(logical_output(&output)),
+                max_bpc: None,
+                format: None,
             },
         );
 

--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -109,6 +109,7 @@ impl Headless {
                 vrr_supported: false,
                 vrr_enabled: false,
                 logical: Some(logical_output(&output)),
+                max_bpc: None,
             },
         );
 

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -14,7 +14,7 @@ use anyhow::{anyhow, bail, ensure, Context};
 use bytemuck::cast_slice_mut;
 use drm_ffi::drm_mode_modeinfo;
 use libc::dev_t;
-use niri_config::output::Modeline;
+use niri_config::output::{Bpc, Modeline};
 use niri_config::{Config, OutputName};
 use niri_ipc::{HSyncPolarity, VSyncPolarity};
 use smithay::backend::allocator::dmabuf::Dmabuf;
@@ -70,7 +70,34 @@ use crate::render_helpers::renderer::AsGlesRenderer;
 use crate::render_helpers::{resources, shaders, RenderTarget};
 use crate::utils::{get_monotonic_time, is_laptop_panel, logical_output, PanelOrientation};
 
-const SUPPORTED_COLOR_FORMATS: [Fourcc; 4] = [
+const COLOR_FORMATS_8: [Fourcc; 4] = [
+    Fourcc::Xrgb8888,
+    Fourcc::Xbgr8888,
+    Fourcc::Argb8888,
+    Fourcc::Abgr8888,
+];
+
+const COLOR_FORMATS_10: [Fourcc; 8] = [
+    Fourcc::Xrgb2101010,
+    Fourcc::Xbgr2101010,
+    Fourcc::Argb2101010,
+    Fourcc::Abgr2101010,
+    Fourcc::Xrgb8888,
+    Fourcc::Xbgr8888,
+    Fourcc::Argb8888,
+    Fourcc::Abgr8888,
+];
+
+// Requires drm-fourcc update in smithay for non-floating formats
+const COLOR_FORMATS_16: [Fourcc; 12] = [
+    Fourcc::Xrgb16161616f,
+    Fourcc::Xbgr16161616f,
+    Fourcc::Argb16161616f,
+    Fourcc::Abgr16161616f,
+    Fourcc::Xrgb2101010,
+    Fourcc::Xbgr2101010,
+    Fourcc::Argb2101010,
+    Fourcc::Abgr2101010,
     Fourcc::Xrgb8888,
     Fourcc::Xbgr8888,
     Fourcc::Argb8888,
@@ -1417,6 +1444,12 @@ impl Tty {
             })
             .collect::<FormatSet>();
 
+        let color_formats: &[Fourcc] = match config.bpc {
+            Bpc::_8 => &COLOR_FORMATS_8,
+            Bpc::_10 => &COLOR_FORMATS_10,
+            Bpc::_16 => &COLOR_FORMATS_16,
+        };
+
         // Create the compositor.
         let res = DrmCompositor::new(
             OutputModeSource::Auto(output.clone()),
@@ -1424,7 +1457,7 @@ impl Tty {
             None,
             device.allocator.clone(),
             GbmFramebufferExporter::new(device.gbm.clone(), device.render_node.into()),
-            SUPPORTED_COLOR_FORMATS,
+            color_formats.iter().copied(),
             // This is only used to pick a good internal format, so it can use the surface's render
             // formats, even though we only ever render on the primary GPU.
             render_formats.clone(),
@@ -1454,7 +1487,7 @@ impl Tty {
                     None,
                     device.allocator.clone(),
                     GbmFramebufferExporter::new(device.gbm.clone(), device.render_node.into()),
-                    SUPPORTED_COLOR_FORMATS,
+                    color_formats.iter().copied(),
                     render_formats,
                     device.drm.cursor_size(),
                     Some(device.gbm.clone()),

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -88,22 +88,6 @@ const COLOR_FORMATS_10: [Fourcc; 8] = [
     Fourcc::Abgr8888,
 ];
 
-// Requires drm-fourcc update in smithay for non-floating formats
-const COLOR_FORMATS_16: [Fourcc; 12] = [
-    Fourcc::Xrgb16161616f,
-    Fourcc::Xbgr16161616f,
-    Fourcc::Argb16161616f,
-    Fourcc::Abgr16161616f,
-    Fourcc::Xrgb2101010,
-    Fourcc::Xbgr2101010,
-    Fourcc::Argb2101010,
-    Fourcc::Abgr2101010,
-    Fourcc::Xrgb8888,
-    Fourcc::Xbgr8888,
-    Fourcc::Argb8888,
-    Fourcc::Abgr8888,
-];
-
 pub struct Tty {
     config: Rc<RefCell<Config>>,
     session: LibSeatSession,
@@ -699,6 +683,19 @@ impl Tty {
                         if let Ok(props) =
                             ConnectorProperties::try_new(&device.drm, surface.connector)
                         {
+                            if let Some(bpc) = self
+                                .config
+                                .borrow()
+                                .outputs
+                                .find(&surface.name)
+                                .and_then(|o| o.bpc)
+                            {
+                                match set_max_bpc(&props, bpc as u64) {
+                                    Ok(_) => (),
+                                    Err(err) => debug!("couldn't set max bpc: {err:?}"),
+                                }
+                            }
+
                             match reset_hdr(&props) {
                                 Ok(()) => (),
                                 Err(err) => debug!("couldn't reset HDR properties: {err:?}"),
@@ -1313,6 +1310,13 @@ impl Tty {
 
         let mut orientation = None;
         if let Ok(props) = ConnectorProperties::try_new(&device.drm, connector.handle()) {
+            if let Some(bpc) = config.bpc {
+                match set_max_bpc(&props, bpc as u64) {
+                    Ok(_) => (),
+                    Err(err) => debug!("couldn't set max bpc: {err:?}"),
+                }
+            }
+
             match reset_hdr(&props) {
                 Ok(()) => (),
                 Err(err) => debug!("couldn't reset HDR properties: {err:?}"),
@@ -1444,10 +1448,9 @@ impl Tty {
             })
             .collect::<FormatSet>();
 
-        let color_formats: &[Fourcc] = match config.bpc {
+        let color_formats: &[Fourcc] = match config.bpc.unwrap_or_default() {
             Bpc::_8 => &COLOR_FORMATS_8,
             Bpc::_10 => &COLOR_FORMATS_10,
-            Bpc::_16 => &COLOR_FORMATS_16,
         };
 
         // Create the compositor.
@@ -3300,6 +3303,33 @@ fn reset_hdr(props: &ConnectorProperties) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn set_max_bpc(props: &ConnectorProperties, bpc: u64) -> anyhow::Result<u64> {
+    let (info, value) = props.find(c"max bpc")?;
+
+    let property::ValueType::UnsignedRange(min, max) = info.value_type() else {
+        bail!("wrong property type")
+    };
+
+    let bpc = bpc.clamp(min, max);
+
+    let property::Value::UnsignedRange(value) = info.value_type().convert_value(*value) else {
+        bail!("wrong property type")
+    };
+
+    if value != bpc {
+        props
+            .device
+            .set_property(
+                props.connector,
+                info.handle(),
+                property::Value::UnsignedRange(bpc).into(),
+            )
+            .context("error setting property")?;
+    }
+
+    Ok(bpc)
 }
 
 fn is_vrr_capable(device: &DrmDevice, connector: connector::Handle) -> Option<bool> {

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -3337,7 +3337,7 @@ impl<'a> ConnectorProperties<'a> {
         };
 
         let bpc = bpc as u64;
-        let bpc = bpc.clamp(min, max);
+        let bpc = bpc.clamp(*min, *max);
 
         let property::Value::UnsignedRange(value) = info.value_type().convert_value(*value) else {
             bail!("wrong property type")

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -412,6 +412,8 @@ struct ConnectorProperties<'a> {
     device: &'a DrmDevice,
     connector: connector::Handle,
     properties: Vec<(property::Info, property::RawValue)>,
+    has_change: bool,
+    requests: AtomicModeReq,
 }
 
 impl Tty {
@@ -673,7 +675,7 @@ impl Tty {
                     // Apply pending gamma changes and restore our existing gamma.
                     let device = self.devices.get_mut(&node).unwrap();
                     for (crtc, surface) in device.surfaces.iter_mut() {
-                        if let Ok(props) =
+                        if let Ok(mut props) =
                             ConnectorProperties::try_new(&device.drm, surface.connector)
                         {
                             if let Some(bpc) = self
@@ -683,15 +685,17 @@ impl Tty {
                                 .find(&surface.name)
                                 .and_then(|o| o.bpc)
                             {
-                                match set_max_bpc(&props, bpc) {
-                                    Ok(_) => (),
-                                    Err(err) => debug!("couldn't set max bpc: {err:?}"),
-                                }
+                                if let Err(err) = props.set_max_bpc(bpc) {
+                                    warn!("failed to get `max bpc` property: {err}");
+                                };
                             }
 
-                            match reset_hdr(&props) {
-                                Ok(()) => (),
-                                Err(err) => debug!("couldn't reset HDR properties: {err:?}"),
+                            if let Err(err) = props.reset_hdr() {
+                                warn!("failed to get HDR properties: {err}");
+                            };
+
+                            if let Err(err) = props.commit() {
+                                warn!("failed to atomically commit properties: {err}");
                             }
                         } else {
                             warn!("failed to get connector properties");
@@ -1302,24 +1306,26 @@ impl Tty {
         debug!("picking mode: {mode:?}");
 
         let mut orientation = None;
-        if let Ok(props) = ConnectorProperties::try_new(&device.drm, connector.handle()) {
+        if let Ok(mut props) = ConnectorProperties::try_new(&device.drm, connector.handle()) {
             if let Some(bpc) = config.bpc {
-                match set_max_bpc(&props, bpc) {
-                    Ok(_) => (),
-                    Err(err) => debug!("couldn't set max bpc: {err:?}"),
-                }
+                if let Err(err) = props.set_max_bpc(bpc) {
+                    warn!("failed to get `max bpc` property: {err}");
+                };
             }
 
-            match reset_hdr(&props) {
-                Ok(()) => (),
-                Err(err) => debug!("couldn't reset HDR properties: {err:?}"),
-            }
+            if let Err(err) = props.reset_hdr() {
+                warn!("failed to get HDR properties: {err}");
+            };
 
             match get_panel_orientation(&props) {
                 Ok(x) => orientation = Some(x),
                 Err(err) => {
                     trace!("couldn't get panel orientation: {err:?}");
                 }
+            }
+
+            if let Err(err) = props.commit() {
+                warn!("failed to atomically commit properties: {err}");
             }
         } else {
             warn!("failed to get connector properties");
@@ -2436,11 +2442,14 @@ impl Tty {
                 };
 
                 if let Some(bpc) = config.bpc {
-                    if let Ok(props) = ConnectorProperties::try_new(&device.drm, surface.connector)
+                    if let Ok(mut props) =
+                        ConnectorProperties::try_new(&device.drm, surface.connector)
                     {
-                        match set_max_bpc(&props, bpc) {
-                            Ok(_) => (),
-                            Err(err) => debug!("couldn't set max bpc: {err:?}"),
+                        if let Err(err) = props.set_max_bpc(bpc) {
+                            warn!("failed to get `max bpc` property: {err}");
+                        };
+                        if let Err(err) = props.commit() {
+                            warn!("failed to atomically commit properties: {err}");
                         }
                     } else {
                         warn!("failed to get connector properties");
@@ -3275,6 +3284,8 @@ impl<'a> ConnectorProperties<'a> {
             device,
             connector,
             properties,
+            has_change: false,
+            requests: AtomicModeReq::new(),
         })
     }
 
@@ -3287,63 +3298,71 @@ impl<'a> ConnectorProperties<'a> {
 
         Err(anyhow!("couldn't find property: {name:?}"))
     }
-}
 
-const DRM_MODE_COLORIMETRY_DEFAULT: u64 = 0;
+    fn reset_hdr(&mut self) -> anyhow::Result<()> {
+        const DRM_MODE_COLORIMETRY_DEFAULT: u64 = 0;
 
-fn reset_hdr(props: &ConnectorProperties) -> anyhow::Result<()> {
-    let (info, value) = props.find(c"HDR_OUTPUT_METADATA")?;
-    let property::ValueType::Blob = info.value_type() else {
-        bail!("wrong property type")
-    };
+        let (info, value) = self.find(c"HDR_OUTPUT_METADATA")?;
 
-    if *value != 0 {
-        props
-            .device
-            .set_property(props.connector, info.handle(), 0)
-            .context("error setting property")?;
+        let property::ValueType::Blob = info.value_type() else {
+            bail!("wrong property type")
+        };
+        if *value != 0 {
+            self.requests
+                .add_raw_property(self.connector.into(), info.handle(), 0);
+            self.has_change = true;
+        }
+
+        let (info, value) = self.find(c"Colorspace")?;
+        let property::ValueType::Enum(_) = info.value_type() else {
+            bail!("wrong property type")
+        };
+        if *value != DRM_MODE_COLORIMETRY_DEFAULT {
+            self.requests.add_raw_property(
+                self.connector.into(),
+                info.handle(),
+                DRM_MODE_COLORIMETRY_DEFAULT,
+            );
+            self.has_change = true;
+        }
+
+        Ok(())
     }
 
-    let (info, value) = props.find(c"Colorspace")?;
-    let property::ValueType::Enum(_) = info.value_type() else {
-        bail!("wrong property type")
-    };
-    if *value != DRM_MODE_COLORIMETRY_DEFAULT {
-        props
-            .device
-            .set_property(props.connector, info.handle(), DRM_MODE_COLORIMETRY_DEFAULT)
-            .context("error setting property")?;
-    }
+    fn set_max_bpc(&mut self, bpc: Bpc) -> anyhow::Result<u64> {
+        let (info, value) = self.find(c"max bpc")?;
 
-    Ok(())
-}
+        let property::ValueType::UnsignedRange(min, max) = info.value_type() else {
+            bail!("wrong property type")
+        };
 
-fn set_max_bpc(props: &ConnectorProperties, bpc: Bpc) -> anyhow::Result<u64> {
-    let (info, value) = props.find(c"max bpc")?;
+        let bpc = bpc as u64;
+        let bpc = bpc.clamp(min, max);
 
-    let property::ValueType::UnsignedRange(min, max) = info.value_type() else {
-        bail!("wrong property type")
-    };
+        let property::Value::UnsignedRange(value) = info.value_type().convert_value(*value) else {
+            bail!("wrong property type")
+        };
 
-    let bpc = bpc as u64;
-    let bpc = bpc.clamp(min, max);
-
-    let property::Value::UnsignedRange(value) = info.value_type().convert_value(*value) else {
-        bail!("wrong property type")
-    };
-
-    if value != bpc {
-        props
-            .device
-            .set_property(
-                props.connector,
+        if value != bpc {
+            self.requests.add_raw_property(
+                self.connector.into(),
                 info.handle(),
                 property::Value::UnsignedRange(bpc).into(),
-            )
-            .context("error setting property")?;
+            );
+            self.has_change = true;
+        }
+
+        Ok(bpc)
     }
 
-    Ok(bpc)
+    fn commit(self) -> anyhow::Result<()> {
+        if self.has_change {
+            self.device
+                .atomic_commit(AtomicCommitFlags::ALLOW_MODESET, self.requests)?;
+        }
+
+        Ok(())
+    }
 }
 
 fn is_vrr_capable(device: &DrmDevice, connector: connector::Handle) -> Option<bool> {

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -70,14 +70,7 @@ use crate::render_helpers::renderer::AsGlesRenderer;
 use crate::render_helpers::{resources, shaders, RenderTarget};
 use crate::utils::{get_monotonic_time, is_laptop_panel, logical_output, PanelOrientation};
 
-const COLOR_FORMATS_8: [Fourcc; 4] = [
-    Fourcc::Xrgb8888,
-    Fourcc::Xbgr8888,
-    Fourcc::Argb8888,
-    Fourcc::Abgr8888,
-];
-
-const COLOR_FORMATS_10: [Fourcc; 8] = [
+const COLOR_FORMATS: [Fourcc; 8] = [
     Fourcc::Xrgb2101010,
     Fourcc::Xbgr2101010,
     Fourcc::Argb2101010,
@@ -690,7 +683,7 @@ impl Tty {
                                 .find(&surface.name)
                                 .and_then(|o| o.bpc)
                             {
-                                match set_max_bpc(&props, bpc as u64) {
+                                match set_max_bpc(&props, bpc) {
                                     Ok(_) => (),
                                     Err(err) => debug!("couldn't set max bpc: {err:?}"),
                                 }
@@ -1311,7 +1304,7 @@ impl Tty {
         let mut orientation = None;
         if let Ok(props) = ConnectorProperties::try_new(&device.drm, connector.handle()) {
             if let Some(bpc) = config.bpc {
-                match set_max_bpc(&props, bpc as u64) {
+                match set_max_bpc(&props, bpc) {
                     Ok(_) => (),
                     Err(err) => debug!("couldn't set max bpc: {err:?}"),
                 }
@@ -1448,11 +1441,6 @@ impl Tty {
             })
             .collect::<FormatSet>();
 
-        let color_formats: &[Fourcc] = match config.bpc.unwrap_or_default() {
-            Bpc::_8 => &COLOR_FORMATS_8,
-            Bpc::_10 => &COLOR_FORMATS_10,
-        };
-
         // Create the compositor.
         let res = DrmCompositor::new(
             OutputModeSource::Auto(output.clone()),
@@ -1460,7 +1448,7 @@ impl Tty {
             None,
             device.allocator.clone(),
             GbmFramebufferExporter::new(device.gbm.clone(), device.render_node.into()),
-            color_formats.iter().copied(),
+            COLOR_FORMATS,
             // This is only used to pick a good internal format, so it can use the surface's render
             // formats, even though we only ever render on the primary GPU.
             render_formats.clone(),
@@ -1490,7 +1478,7 @@ impl Tty {
                     None,
                     device.allocator.clone(),
                     GbmFramebufferExporter::new(device.gbm.clone(), device.render_node.into()),
-                    color_formats.iter().copied(),
+                    COLOR_FORMATS,
                     render_formats,
                     device.drm.cursor_size(),
                     Some(device.gbm.clone()),
@@ -2447,6 +2435,18 @@ impl Tty {
                     },
                 };
 
+                if let Some(bpc) = config.bpc {
+                    if let Ok(props) = ConnectorProperties::try_new(&device.drm, surface.connector)
+                    {
+                        match set_max_bpc(&props, bpc) {
+                            Ok(_) => (),
+                            Err(err) => debug!("couldn't set max bpc: {err:?}"),
+                        }
+                    } else {
+                        warn!("failed to get connector properties");
+                    }
+                }
+
                 let change_mode = surface.compositor.pending_mode() != mode;
 
                 let vrr_enabled = surface.compositor.vrr_enabled();
@@ -3318,13 +3318,14 @@ fn reset_hdr(props: &ConnectorProperties) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn set_max_bpc(props: &ConnectorProperties, bpc: u64) -> anyhow::Result<u64> {
+fn set_max_bpc(props: &ConnectorProperties, bpc: Bpc) -> anyhow::Result<u64> {
     let (info, value) = props.find(c"max bpc")?;
 
     let property::ValueType::UnsignedRange(min, max) = info.value_type() else {
         bail!("wrong property type")
     };
 
+    let bpc = bpc as u64;
     let bpc = bpc.clamp(min, max);
 
     let property::Value::UnsignedRange(value) = info.value_type().convert_value(*value) else {

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -2209,6 +2209,17 @@ impl Tty {
                     OutputId::next()
                 });
 
+                let props = ConnectorProperties::try_new(&device.drm, connector.handle()).ok();
+                let max_bpc = props.as_ref().and_then(|p| p.find(c"max bpc").ok());
+                let max_bpc = max_bpc.and_then(|(info, value)| {
+                    info.value_type()
+                        .convert_value(*value)
+                        .as_unsigned_range()
+                        .map(|v| v as u8)
+                });
+
+                let format = surface.map(|s| s.compositor.format().to_string());
+
                 let ipc_output = niri_ipc::Output {
                     name: connector_name,
                     make: output_name.make.unwrap_or_else(|| "Unknown".into()),
@@ -2221,6 +2232,8 @@ impl Tty {
                     vrr_supported,
                     vrr_enabled,
                     logical,
+                    max_bpc,
+                    format,
                 };
 
                 ipc_outputs.insert(id, ipc_output);

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -14,7 +14,7 @@ use anyhow::{anyhow, bail, ensure, Context};
 use bytemuck::cast_slice_mut;
 use drm_ffi::drm_mode_modeinfo;
 use libc::dev_t;
-use niri_config::output::Modeline;
+use niri_config::output::{MaxBpc, Modeline};
 use niri_config::{Config, OutputName};
 use niri_ipc::{HSyncPolarity, VSyncPolarity};
 use smithay::backend::allocator::dmabuf::Dmabuf;
@@ -405,6 +405,8 @@ struct ConnectorProperties<'a> {
     device: &'a DrmDevice,
     connector: connector::Handle,
     properties: Vec<(property::Info, property::RawValue)>,
+    has_change: bool,
+    requests: AtomicModeReq,
 }
 
 impl Tty {
@@ -676,16 +678,19 @@ impl Tty {
                     // Apply pending gamma changes and restore our existing gamma.
                     let device = self.devices.get_mut(&node).unwrap();
                     for (crtc, surface) in device.surfaces.iter_mut() {
-                        if let Ok(props) =
+                        if let Ok(mut props) =
                             ConnectorProperties::try_new(&device.drm, surface.connector)
                         {
-                            match reset_hdr(&props) {
-                                Ok(()) => (),
-                                Err(err) => debug!("couldn't reset HDR properties: {err:?}"),
-                            }
+                            let max_bpc = self
+                                .config
+                                .borrow()
+                                .outputs
+                                .find(&surface.name)
+                                .and_then(|o| o.max_bpc);
+                            set_connector_properties(&mut props, max_bpc, true);
                         } else {
                             warn!("failed to get connector properties");
-                        };
+                        }
 
                         if let Some(ramp) = surface.pending_gamma_change.take() {
                             let ramp = ramp.as_deref();
@@ -1302,13 +1307,10 @@ impl Tty {
         debug!("picking mode: {mode:?}");
 
         let mut orientation = None;
-        if let Ok(props) = ConnectorProperties::try_new(&device.drm, connector.handle()) {
-            match reset_hdr(&props) {
-                Ok(()) => (),
-                Err(err) => debug!("couldn't reset HDR properties: {err:?}"),
-            }
+        if let Ok(mut props) = ConnectorProperties::try_new(&device.drm, connector.handle()) {
+            set_connector_properties(&mut props, config.max_bpc, true);
 
-            match get_panel_orientation(&props) {
+            match props.get_panel_orientation() {
                 Ok(x) => orientation = Some(x),
                 Err(err) => {
                     trace!("couldn't get panel orientation: {err:?}");
@@ -1316,7 +1318,7 @@ impl Tty {
             }
         } else {
             warn!("failed to get connector properties");
-        };
+        }
 
         let mut gamma_props = GammaProps::new(&device.drm, crtc)
             .map_err(|err| debug!("couldn't get gamma properties: {err:?}"))
@@ -2194,6 +2196,15 @@ impl Tty {
                     OutputId::next()
                 });
 
+                let props = ConnectorProperties::try_new(&device.drm, connector.handle()).ok();
+                let max_bpc = props.as_ref().and_then(|p| p.find(c"max bpc").ok());
+                let max_bpc = max_bpc.and_then(|(info, value)| {
+                    info.value_type()
+                        .convert_value(*value)
+                        .as_unsigned_range()
+                        .map(|v| v as u8)
+                });
+
                 let ipc_output = niri_ipc::Output {
                     name: connector_name,
                     make: output_name.make.unwrap_or_else(|| "Unknown".into()),
@@ -2206,6 +2217,7 @@ impl Tty {
                     vrr_supported,
                     vrr_enabled,
                     logical,
+                    max_bpc,
                 };
 
                 ipc_outputs.insert(id, ipc_output);
@@ -2421,6 +2433,13 @@ impl Tty {
                         }
                     },
                 };
+
+                if let Ok(mut props) = ConnectorProperties::try_new(&device.drm, surface.connector)
+                {
+                    set_connector_properties(&mut props, config.max_bpc, false);
+                } else {
+                    warn!("failed to get connector properties");
+                }
 
                 let change_mode = surface.compositor.pending_mode() != mode;
 
@@ -3250,6 +3269,8 @@ impl<'a> ConnectorProperties<'a> {
             device,
             connector,
             properties,
+            has_change: false,
+            requests: AtomicModeReq::new(),
         })
     }
 
@@ -3262,58 +3283,120 @@ impl<'a> ConnectorProperties<'a> {
 
         Err(anyhow!("couldn't find property: {name:?}"))
     }
+
+    fn get_panel_orientation(&self) -> anyhow::Result<Transform> {
+        let (info, value) = self.find(c"panel orientation")?;
+        match info.value_type().convert_value(*value) {
+            property::Value::Enum(Some(val)) => match val.value() {
+                // "Normal"
+                0 => Ok(Transform::Normal),
+                // "Upside Down"
+                1 => Ok(Transform::_180),
+                // "Left Side Up"
+                2 => Ok(Transform::_90),
+                // "Right Side Up"
+                3 => Ok(Transform::_270),
+                _ => bail!("panel orientation has invalid value: {:?}", val),
+            },
+            _ => bail!("panel orientation has wrong value type"),
+        }
+    }
+
+    fn reset_hdr(&mut self) -> anyhow::Result<()> {
+        const DRM_MODE_COLORIMETRY_DEFAULT: u64 = 0;
+
+        let (info, value) = self.find(c"HDR_OUTPUT_METADATA")?;
+
+        let property::ValueType::Blob = info.value_type() else {
+            bail!("wrong property type")
+        };
+        if *value != 0 {
+            self.requests
+                .add_raw_property(self.connector.into(), info.handle(), 0);
+            self.has_change = true;
+        }
+
+        let (info, value) = self.find(c"Colorspace")?;
+        let property::ValueType::Enum(_) = info.value_type() else {
+            bail!("wrong property type")
+        };
+        if *value != DRM_MODE_COLORIMETRY_DEFAULT {
+            self.requests.add_raw_property(
+                self.connector.into(),
+                info.handle(),
+                DRM_MODE_COLORIMETRY_DEFAULT,
+            );
+            self.has_change = true;
+        }
+
+        Ok(())
+    }
+
+    fn set_max_bpc(&mut self, max_bpc: MaxBpc) -> anyhow::Result<u64> {
+        let (info, value) = self.find(c"max bpc")?;
+
+        let property::ValueType::UnsignedRange(min, max) = info.value_type() else {
+            bail!("wrong property type")
+        };
+
+        let max_bpc = max_bpc.0 as u64;
+        if !(min..=max).contains(&max_bpc) {
+            bail!("max-bpc {max_bpc} outside valid range of [{min}, {max}]");
+        }
+
+        let property::Value::UnsignedRange(value) = info.value_type().convert_value(*value) else {
+            bail!("wrong property type")
+        };
+
+        if value != max_bpc {
+            self.requests.add_raw_property(
+                self.connector.into(),
+                info.handle(),
+                property::Value::UnsignedRange(max_bpc).into(),
+            );
+            self.has_change = true;
+        }
+
+        Ok(max_bpc)
+    }
+
+    fn commit(&mut self) -> anyhow::Result<()> {
+        if self.has_change {
+            self.device.atomic_commit(
+                AtomicCommitFlags::ALLOW_MODESET,
+                std::mem::take(&mut self.requests),
+            )?;
+        }
+
+        Ok(())
+    }
 }
 
-const DRM_MODE_COLORIMETRY_DEFAULT: u64 = 0;
-
-fn reset_hdr(props: &ConnectorProperties) -> anyhow::Result<()> {
-    let (info, value) = props.find(c"HDR_OUTPUT_METADATA")?;
-    let property::ValueType::Blob = info.value_type() else {
-        bail!("wrong property type")
-    };
-
-    if *value != 0 {
-        props
-            .device
-            .set_property(props.connector, info.handle(), 0)
-            .context("error setting property")?;
+fn set_connector_properties(
+    props: &mut ConnectorProperties,
+    max_bpc: Option<MaxBpc>,
+    reset_hdr: bool,
+) {
+    if let Some(max_bpc) = max_bpc {
+        if let Err(err) = props.set_max_bpc(max_bpc) {
+            debug!("failed to set `max bpc` property: {err}");
+        }
     }
 
-    let (info, value) = props.find(c"Colorspace")?;
-    let property::ValueType::Enum(_) = info.value_type() else {
-        bail!("wrong property type")
-    };
-    if *value != DRM_MODE_COLORIMETRY_DEFAULT {
-        props
-            .device
-            .set_property(props.connector, info.handle(), DRM_MODE_COLORIMETRY_DEFAULT)
-            .context("error setting property")?;
+    if reset_hdr {
+        if let Err(err) = props.reset_hdr() {
+            debug!("failed to set HDR properties: {err}");
+        }
     }
 
-    Ok(())
+    if let Err(err) = props.commit() {
+        warn!("failed to atomically commit properties: {err}");
+    }
 }
 
 fn is_vrr_capable(device: &DrmDevice, connector: connector::Handle) -> Option<bool> {
     let (_, info, value) = find_drm_property(device, connector, "vrr_capable")?;
     info.value_type().convert_value(value).as_boolean()
-}
-
-fn get_panel_orientation(props: &ConnectorProperties) -> anyhow::Result<Transform> {
-    let (info, value) = props.find(c"panel orientation")?;
-    match info.value_type().convert_value(*value) {
-        property::Value::Enum(Some(val)) => match val.value() {
-            // "Normal"
-            0 => Ok(Transform::Normal),
-            // "Upside Down"
-            1 => Ok(Transform::_180),
-            // "Left Side Up"
-            2 => Ok(Transform::_90),
-            // "Right Side Up"
-            3 => Ok(Transform::_270),
-            _ => bail!("panel orientation has invalid value: {:?}", val),
-        },
-        _ => bail!("panel orientation has wrong value type"),
-    }
 }
 
 pub fn set_gamma_for_crtc(

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -70,7 +70,11 @@ use crate::render_helpers::renderer::AsGlesRenderer;
 use crate::render_helpers::{resources, shaders, RenderCtx, RenderTarget};
 use crate::utils::{get_monotonic_time, is_laptop_panel, logical_output, PanelOrientation};
 
-const SUPPORTED_COLOR_FORMATS: [Fourcc; 4] = [
+const SUPPORTED_COLOR_FORMATS: [Fourcc; 8] = [
+    Fourcc::Xrgb2101010,
+    Fourcc::Xbgr2101010,
+    Fourcc::Argb2101010,
+    Fourcc::Abgr2101010,
     Fourcc::Xrgb8888,
     Fourcc::Xbgr8888,
     Fourcc::Argb8888,

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -91,6 +91,8 @@ impl Winit {
                 vrr_supported: false,
                 vrr_enabled: false,
                 logical: Some(logical_output(&output)),
+                max_bpc: None,
+                format: None,
             },
         )])));
 

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -95,6 +95,7 @@ impl Winit {
                 vrr_supported: false,
                 vrr_enabled: false,
                 logical: Some(logical_output(&output)),
+                max_bpc: None,
             },
         )])));
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -568,6 +568,8 @@ fn print_output(output: Output) -> anyhow::Result<()> {
         vrr_supported,
         vrr_enabled,
         logical,
+        max_bpc,
+        format,
     } = output;
 
     let serial = serial.as_deref().unwrap_or("Unknown");
@@ -649,6 +651,14 @@ fn print_output(output: Output) -> anyhow::Result<()> {
             Transform::Flipped270 => "270° counter-clockwise, flipped horizontally",
         };
         println!("  Transform: {transform}");
+    }
+
+    if let Some(max_bpc) = max_bpc {
+        println!("  Max bits per channel: {max_bpc}");
+    }
+
+    if let Some(format) = format {
+        println!("  Pixel format: {format}");
     }
 
     println!("  Available modes:");

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -568,6 +568,7 @@ fn print_output(output: Output) -> anyhow::Result<()> {
         vrr_supported,
         vrr_enabled,
         logical,
+        max_bpc,
     } = output;
 
     let serial = serial.as_deref().unwrap_or("Unknown");
@@ -649,6 +650,10 @@ fn print_output(output: Output) -> anyhow::Result<()> {
             Transform::Flipped270 => "270° counter-clockwise, flipped horizontally",
         };
         println!("  Transform: {transform}");
+    }
+
+    if let Some(max_bpc) = max_bpc {
+        println!("  Max bits per channel: {max_bpc}");
     }
 
     println!("  Available modes:");

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -14,6 +14,7 @@ use _server_decoration::server::org_kde_kwin_server_decoration_manager::Mode as 
 use anyhow::{bail, ensure, Context};
 use calloop::futures::Scheduler;
 use niri_config::debug::PreviewRender;
+use niri_config::output::MaxBpc;
 use niri_config::{
     Config, FloatOrInt, Key, Modifiers, OutputName, TrackLayout, WarpMouseToFocusMode,
     WorkspaceReference, Xkb,
@@ -1925,6 +1926,7 @@ impl State {
                     None
                 }
             }
+            niri_ipc::OutputAction::MaxBpc { max_bpc } => config.max_bpc = Some(MaxBpc(max_bpc)),
         });
 
         self.reload_output_config();


### PR DESCRIPTION
This adds per output maximum bits per channel (max-bpc) config and ipc action as requested in #1533. 

```
output "DP-1" {
    ...
    max-bpc 10
}
```

Supported values are 6, 8, 10, 12, 14, 16. If not explicitly set, niri will not change the existing `max bpc` connector property.