### PR TITLE
feat: Add touch gesture support (mostly hardcoded)

### DIFF
--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -96,6 +96,7 @@ input {
     touch {
         // off
         map-to-output "eDP-1"
+        // natural-scroll
         // calibration-matrix 1.0 0.0 0.0 0.0 1.0 0.0
     }
 
@@ -262,6 +263,10 @@ Settings specific to `tablet` and `touch`:
 - `calibration-matrix`: set to six floating point numbers to change the calibration matrix. See the [`LIBINPUT_CALIBRATION_MATRIX` documentation](https://wayland.freedesktop.org/libinput/doc/latest/device-configuration-via-udev.html) for examples.
     - <sup>Since: 25.02</sup> for `tablet`
     - <sup>Since: 25.11</sup> for `touch`
+
+Settings specific to `touch`:
+
+- `natural-scroll`: <sup>Since: next</sup> if set, inverts the scrolling direction for touchscreen gestures (workspace switching and view scrolling).
 
 Tablets and touchscreens are absolute pointing devices that can be mapped to a specific output like so:
 

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -371,6 +371,8 @@ pub struct Tablet {
 pub struct Touch {
     #[knuffel(child)]
     pub off: bool,
+    #[knuffel(child)]
+    pub natural_scroll: bool,
     #[knuffel(child, unwrap(arguments))]
     pub calibration_matrix: Option<Vec<f32>>,
     #[knuffel(child, unwrap(argument))]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4076,7 +4076,7 @@ impl State {
 
         // Check if we're tracking a multi-finger gesture (2+ fingers).
         // If so, we should not forward events to clients.
-        let tracking_gesture = self.niri.touch_gesture_points.len() >= 2;
+        let tracking_gesture = self.niri.touch_gesture_points.len() > 2;
 
         let serial = SERIAL_COUNTER.next_serial();
 
@@ -4210,7 +4210,7 @@ impl State {
         let slot = evt.slot();
 
         // Check if we're tracking a multi-finger gesture before removing this touch point.
-        let tracking_gesture = self.niri.touch_gesture_points.len() >= 2;
+        let tracking_gesture = self.niri.touch_gesture_points.len() > 2;
 
         // Remove touch point from gesture tracking.
         self.niri.touch_gesture_points.remove(&Some(slot));

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4063,6 +4063,15 @@ impl State {
         };
         let slot = evt.slot();
 
+        // Track touch point for multi-finger gesture detection.
+        let was_single = self.niri.touch_gesture_points.len() == 1;
+        self.niri.touch_gesture_points.insert(Some(slot), pos);
+
+        // When second finger arrives, start gesture recognition.
+        if was_single && self.niri.touch_gesture_points.len() == 2 {
+            self.niri.touch_gesture_cumulative = Some((0., 0.));
+        }
+
         let serial = SERIAL_COUNTER.next_serial();
 
         let under = self.niri.contents_under(pos);
@@ -4191,6 +4200,23 @@ impl State {
         };
         let slot = evt.slot();
 
+        // Remove touch point from gesture tracking.
+        self.niri.touch_gesture_points.remove(&Some(slot));
+
+        // End gesture when fewer than 2 fingers remain.
+        if self.niri.touch_gesture_points.len() < 2 {
+            self.niri.touch_gesture_cumulative = None;
+
+            // End any ongoing gesture animations.
+            if let Some(output) = self.niri.layout.workspace_switch_gesture_end(Some(true)) {
+                self.niri.queue_redraw(&output);
+            }
+            if let Some(output) = self.niri.layout.view_offset_gesture_end(Some(true)) {
+                self.niri.queue_redraw(&output);
+            }
+            self.niri.layout.overview_gesture_end();
+        }
+
         if let Some(capture) = self.niri.screenshot_ui.pointer_up(Some(slot)) {
             if capture {
                 self.confirm_screenshot(true);
@@ -4217,6 +4243,112 @@ impl State {
             return;
         };
         let slot = evt.slot();
+
+        // Track touch gesture with 2+ fingers.
+        if let Some(old_pos) = self.niri.touch_gesture_points.get(&Some(slot)).copied() {
+            // Calculate delta from this finger's movement.
+            let delta_x = pos.x - old_pos.x;
+            let delta_y = pos.y - old_pos.y;
+
+            // Update stored position.
+            self.niri.touch_gesture_points.insert(Some(slot), pos);
+
+            // Process gesture if we're tracking (3+ fingers).
+            if self.niri.touch_gesture_points.len() >= 3 {
+                let timestamp = Duration::from_micros(evt.time());
+
+                // Check if we're still in recognition phase.
+                if let Some((cx, cy)) = &mut self.niri.touch_gesture_cumulative {
+                    *cx += delta_x;
+                    *cy += delta_y;
+
+                    // Check if gesture moved far enough to decide direction.
+                    // Threshold matches touchpad gestures (16px from GNOME Shell).
+                    let (cx, cy) = (*cx, *cy);
+                    if cx * cx + cy * cy >= 16. * 16. {
+                        self.niri.touch_gesture_cumulative = None;
+
+                        let finger_count = self.niri.touch_gesture_points.len();
+
+                        if finger_count >= 4 {
+                            // 4+ finger gesture: toggle overview.
+                            self.niri.layout.overview_gesture_begin();
+                        } else if let Some(output) = self.niri.output_under_cursor() {
+                            // 2-3 finger gesture: workspace switch or view offset.
+                            let is_overview_open = self.niri.layout.is_overview_open();
+
+                            if cx.abs() > cy.abs() {
+                                // Horizontal gesture: view offset (scroll within workspace).
+                                let output_ws = if is_overview_open {
+                                    self.niri.workspace_under_cursor(true)
+                                } else {
+                                    self.niri.output_under_cursor().and_then(|output| {
+                                        let mon = self.niri.layout.monitor_for_output(&output)?;
+                                        Some((output, mon.active_workspace_ref()))
+                                    })
+                                };
+
+                                if let Some((output, ws)) = output_ws {
+                                    let ws_idx =
+                                        self.niri.layout.find_workspace_by_id(ws.id()).unwrap().0;
+                                    self.niri.layout.view_offset_gesture_begin(
+                                        &output,
+                                        Some(ws_idx),
+                                        true,
+                                    );
+                                }
+                            } else {
+                                // Vertical gesture: workspace switch.
+                                self.niri
+                                    .layout
+                                    .workspace_switch_gesture_begin(&output, true);
+                            }
+                        }
+                    }
+                }
+
+                // Apply natural scroll if configured (invert deltas for natural feel).
+                let natural_scroll = self.niri.config.borrow().input.touch.natural_scroll;
+                let (gesture_delta_x, gesture_delta_y) = if natural_scroll {
+                    (-delta_x, -delta_y)
+                } else {
+                    (delta_x, delta_y)
+                };
+
+                // Continue ongoing gesture animations.
+                // Swipe down → previous workspace, swipe up → next workspace.
+                if self
+                    .niri
+                    .layout
+                    .workspace_switch_gesture_update(gesture_delta_y, timestamp, true)
+                    .is_some()
+                {
+                    self.niri.queue_redraw_all();
+                }
+
+                // Swipe right → scroll left (prev window), swipe left → scroll right (next window).
+                if self
+                    .niri
+                    .layout
+                    .view_offset_gesture_update(gesture_delta_x, timestamp, true)
+                    .is_some()
+                {
+                    self.niri.queue_redraw_all();
+                }
+
+                // Update overview gesture (uses vertical delta like touchpad).
+                // Overview always uses uninverted delta, matching touchpad behavior.
+                if let Some(redraw) = self
+                    .niri
+                    .layout
+                    .overview_gesture_update(-delta_y, timestamp)
+                {
+                    if redraw {
+                        self.niri.queue_redraw_all();
+                    }
+                }
+            }
+        }
 
         if let Some(output) = self.niri.screenshot_ui.selection_output().cloned() {
             let geom = self.niri.global_space.output_geometry(&output).unwrap();
@@ -4266,6 +4398,16 @@ impl State {
         let Some(handle) = self.niri.seat.get_touch() else {
             return;
         };
+
+        // Clear all touch gesture state.
+        self.niri.touch_gesture_points.clear();
+        self.niri.touch_gesture_cumulative = None;
+
+        // Cancel any ongoing gesture animations.
+        self.niri.layout.workspace_switch_gesture_end(Some(false));
+        self.niri.layout.view_offset_gesture_end(Some(false));
+        self.niri.layout.overview_gesture_end();
+
         handle.cancel(self);
     }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4290,19 +4290,22 @@ impl State {
                         if finger_count >= 4 {
                             // 4+ finger gesture: toggle overview.
                             self.niri.layout.overview_gesture_begin();
-                        } else if let Some(output) = self.niri.output_under_cursor() {
+                        } else if let Some((output, _pos_within_output)) =
+                            self.niri.output_under(pos)
+                        {
+                            let output = output.clone();
                             // 3 finger gesture: workspace switch or view offset.
                             let is_overview_open = self.niri.layout.is_overview_open();
 
                             if cx.abs() > cy.abs() {
                                 // Horizontal gesture: view offset (scroll within workspace).
                                 let output_ws = if is_overview_open {
-                                    self.niri.workspace_under_cursor(true)
+                                    self.niri.workspace_under(true, pos)
                                 } else {
-                                    self.niri.output_under_cursor().and_then(|output| {
-                                        let mon = self.niri.layout.monitor_for_output(&output)?;
-                                        Some((output, mon.active_workspace_ref()))
-                                    })
+                                    self.niri
+                                        .layout
+                                        .monitor_for_output(&output)
+                                        .map(|mon| (output.clone(), mon.active_workspace_ref()))
                                 };
 
                                 if let Some((output, ws)) = output_ws {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4067,10 +4067,16 @@ impl State {
         let was_single = self.niri.touch_gesture_points.len() == 1;
         self.niri.touch_gesture_points.insert(Some(slot), pos);
 
-        // When second finger arrives, start gesture recognition.
+        // When second finger arrives, start cumulative tracking for gesture recognition.
+        // Actual gestures (workspace/view/scroll) require 3+ fingers and are processed
+        // in on_touch_motion once the third finger arrives and moves.
         if was_single && self.niri.touch_gesture_points.len() == 2 {
             self.niri.touch_gesture_cumulative = Some((0., 0.));
         }
+
+        // Check if we're tracking a multi-finger gesture (2+ fingers).
+        // If so, we should not forward events to clients.
+        let tracking_gesture = self.niri.touch_gesture_points.len() >= 2;
 
         let serial = SERIAL_COUNTER.next_serial();
 
@@ -4180,16 +4186,19 @@ impl State {
             self.niri.focus_layer_surface_if_on_demand(under.layer);
         };
 
-        handle.down(
-            self,
-            under.surface,
-            &DownEvent {
-                slot,
-                location: pos,
-                serial,
-                time: evt.time_msec(),
-            },
-        );
+        // Only forward to client if not tracking a multi-finger gesture.
+        if !tracking_gesture {
+            handle.down(
+                self,
+                under.surface,
+                &DownEvent {
+                    slot,
+                    location: pos,
+                    serial,
+                    time: evt.time_msec(),
+                },
+            );
+        }
 
         // We're using touch, hide the pointer.
         self.niri.pointer_visibility = PointerVisibility::Disabled;
@@ -4199,6 +4208,9 @@ impl State {
             return;
         };
         let slot = evt.slot();
+
+        // Check if we're tracking a multi-finger gesture before removing this touch point.
+        let tracking_gesture = self.niri.touch_gesture_points.len() >= 2;
 
         // Remove touch point from gesture tracking.
         self.niri.touch_gesture_points.remove(&Some(slot));
@@ -4225,15 +4237,18 @@ impl State {
             }
         }
 
-        let serial = SERIAL_COUNTER.next_serial();
-        handle.up(
-            self,
-            &UpEvent {
-                slot,
-                serial,
-                time: evt.time_msec(),
-            },
-        )
+        // Only forward to client if not tracking a multi-finger gesture.
+        if !tracking_gesture {
+            let serial = SERIAL_COUNTER.next_serial();
+            handle.up(
+                self,
+                &UpEvent {
+                    slot,
+                    serial,
+                    time: evt.time_msec(),
+                },
+            )
+        }
     }
     fn on_touch_motion<I: InputBackend>(&mut self, evt: I::TouchMotionEvent) {
         let Some(handle) = self.niri.seat.get_touch() else {
@@ -4245,6 +4260,7 @@ impl State {
         let slot = evt.slot();
 
         // Track touch gesture with 2+ fingers.
+        let mut gesture_handled = false;
         if let Some(old_pos) = self.niri.touch_gesture_points.get(&Some(slot)).copied() {
             // Calculate delta from this finger's movement.
             let delta_x = pos.x - old_pos.x;
@@ -4256,6 +4272,7 @@ impl State {
             // Process gesture if we're tracking (3+ fingers).
             if self.niri.touch_gesture_points.len() >= 3 {
                 let timestamp = Duration::from_micros(evt.time());
+                gesture_handled = true;
 
                 // Check if we're still in recognition phase.
                 if let Some((cx, cy)) = &mut self.niri.touch_gesture_cumulative {
@@ -4274,7 +4291,7 @@ impl State {
                             // 4+ finger gesture: toggle overview.
                             self.niri.layout.overview_gesture_begin();
                         } else if let Some(output) = self.niri.output_under_cursor() {
-                            // 2-3 finger gesture: workspace switch or view offset.
+                            // 3 finger gesture: workspace switch or view offset.
                             let is_overview_open = self.niri.layout.is_overview_open();
 
                             if cx.abs() > cy.abs() {
@@ -4366,16 +4383,19 @@ impl State {
             self.niri.queue_redraw(&output);
         }
 
-        let under = self.niri.contents_under(pos);
-        handle.motion(
-            self,
-            under.surface,
-            &TouchMotionEvent {
-                slot,
-                location: pos,
-                time: evt.time_msec(),
-            },
-        );
+        // Only forward to client if not handling a multi-finger gesture.
+        if !gesture_handled {
+            let under = self.niri.contents_under(pos);
+            handle.motion(
+                self,
+                under.surface,
+                &TouchMotionEvent {
+                    slot,
+                    location: pos,
+                    time: evt.time_msec(),
+                },
+            );
+        }
 
         // Inform the layout of an ongoing DnD operation.
         let is_dnd_grab = handle

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -19,7 +19,7 @@ use niri_config::{
     WorkspaceReference, Xkb,
 };
 use smithay::backend::allocator::Fourcc;
-use smithay::backend::input::Keycode;
+use smithay::backend::input::{Keycode, TouchSlot};
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::element::memory::MemoryRenderBufferRenderElement;
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
@@ -364,6 +364,12 @@ pub struct Niri {
     pub pointer_inside_hot_corner: bool,
     pub tablet_cursor_location: Option<Point<f64, Logical>>,
     pub gesture_swipe_3f_cumulative: Option<(f64, f64)>,
+    /// Active touch points for multi-finger gesture detection.
+    pub touch_gesture_points: HashMap<Option<TouchSlot>, Point<f64, Logical>>,
+    /// Cumulative delta when tracking a 2+ finger touch gesture.
+    /// Set to Some((0, 0)) when gesture recognition starts (2nd finger down),
+    /// cleared when gesture completes or is cancelled.
+    pub touch_gesture_cumulative: Option<(f64, f64)>,
     pub overview_scroll_swipe_gesture: ScrollSwipeGesture,
     pub vertical_wheel_tracker: ScrollTracker,
     pub horizontal_wheel_tracker: ScrollTracker,
@@ -2517,6 +2523,8 @@ impl Niri {
             pointer_inside_hot_corner: false,
             tablet_cursor_location: None,
             gesture_swipe_3f_cumulative: None,
+            touch_gesture_points: HashMap::new(),
+            touch_gesture_cumulative: None,
             overview_scroll_swipe_gesture: ScrollSwipeGesture::new(),
             vertical_wheel_tracker: ScrollTracker::new(120),
             horizontal_wheel_tracker: ScrollTracker::new(120),


### PR DESCRIPTION
- Brings the touchscreen gestures to parity with touchpad/trackpad gestures, as best I can tell
- Matches behavior of touchpad gestures closely
- Updated docs with `Since` annotation
- Added natural-scroll config option for touchscreen gestures

**Testing**:
- 3-finger horizontal swipe correctly adjusts view offsets.
- 3-finger vertical swipe correctly switches workspaces
- 2-finger start into 3rd mid-gesture -> works
- During 3-finger gesture, when one finger is removed mid-gesture, the
  transition is held in place by the two fingers and finishes if a 2nd is
  removed and correctly snaps into place.
- Gestures during:
    - window animations -> works (tested with spawning windows with
      animations enabled)
    - window dragging -> works (though very slow when dragging windows in
