### PR TITLE
feat: add flip option for tab-indicator

### DIFF
--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -458,6 +458,7 @@ impl MergeWith<WorkspaceShadowPart> for WorkspaceShadow {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TabIndicator {
     pub off: bool,
+    pub flip: bool,
     pub hide_when_single_tab: bool,
     pub place_within_column: bool,
     pub gap: f64,
@@ -494,6 +495,7 @@ impl Default for TabIndicator {
             active_gradient: None,
             inactive_gradient: None,
             urgent_gradient: None,
+            flip: false,
         }
     }
 }
@@ -504,6 +506,8 @@ impl MergeWith<TabIndicatorPart> for TabIndicator {
         if part.on {
             self.off = false;
         }
+
+        self.flip ^= part.flip;
 
         merge!(
             (self, part),
@@ -532,6 +536,8 @@ pub struct TabIndicatorPart {
     pub off: bool,
     #[knuffel(child)]
     pub on: bool,
+    #[knuffel(child)]
+    pub flip: bool,
     #[knuffel(child)]
     pub hide_when_single_tab: Option<Flag>,
     #[knuffel(child)]

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -479,6 +479,7 @@ impl Default for TabIndicator {
     fn default() -> Self {
         Self {
             off: false,
+            flip: false,
             hide_when_single_tab: false,
             place_within_column: false,
             gap: 5.,
@@ -495,7 +496,6 @@ impl Default for TabIndicator {
             active_gradient: None,
             inactive_gradient: None,
             urgent_gradient: None,
-            flip: false,
         }
     }
 }

--- a/src/layout/tab_indicator.rs
+++ b/src/layout/tab_indicator.rs
@@ -113,7 +113,14 @@ impl TabIndicator {
 
         let flip = self.config.flip;
         let offset = round((side - length) / 2.);
-        let mut shader_loc = Point::from((-gap - width, if flip { side - offset } else { offset }));
+        let mut shader_loc = Point::from((
+            -gap - width,
+            if flip {
+                side - offset - px_per_tab
+            } else {
+                offset
+            },
+        ));
         match position {
             TabIndicatorPosition::Left => (),
             TabIndicatorPosition::Right => shader_loc.x = area.size.w + gap,
@@ -124,17 +131,6 @@ impl TabIndicator {
             }
         }
         shader_loc += area.loc;
-
-        if flip {
-            match position {
-                TabIndicatorPosition::Left | TabIndicatorPosition::Right => {
-                    shader_loc.y -= px_per_tab
-                }
-                TabIndicatorPosition::Top | TabIndicatorPosition::Bottom => {
-                    shader_loc.x -= px_per_tab
-                }
-            }
-        }
 
         (0..count).map(move |_| {
             let mut px_per_tab = px_per_tab;

--- a/src/layout/tab_indicator.rs
+++ b/src/layout/tab_indicator.rs
@@ -111,7 +111,9 @@ impl TabIndicator {
         let floored_length = count as f64 * (px_per_tab + gaps_between) - gaps_between;
         let mut ones_left = ((length - floored_length) / pixel).round() as usize;
 
-        let mut shader_loc = Point::from((-gap - width, round((side - length) / 2.)));
+        let flip = self.config.flip;
+        let offset = round((side - length) / 2.);
+        let mut shader_loc = Point::from((-gap - width, if flip { side - offset } else { offset }));
         match position {
             TabIndicatorPosition::Left => (),
             TabIndicatorPosition::Right => shader_loc.x = area.size.w + gap,
@@ -123,6 +125,17 @@ impl TabIndicator {
         }
         shader_loc += area.loc;
 
+        if flip {
+            match position {
+                TabIndicatorPosition::Left | TabIndicatorPosition::Right => {
+                    shader_loc.y -= px_per_tab
+                }
+                TabIndicatorPosition::Top | TabIndicatorPosition::Bottom => {
+                    shader_loc.x -= px_per_tab
+                }
+            }
+        }
+
         (0..count).map(move |_| {
             let mut px_per_tab = px_per_tab;
             if ones_left > 0 {
@@ -132,13 +145,15 @@ impl TabIndicator {
 
             let loc = shader_loc;
 
+            let delta = if flip {
+                -(px_per_tab + gaps_between)
+            } else {
+                px_per_tab + gaps_between
+            };
+
             match position {
-                TabIndicatorPosition::Left | TabIndicatorPosition::Right => {
-                    shader_loc.y += px_per_tab + gaps_between
-                }
-                TabIndicatorPosition::Top | TabIndicatorPosition::Bottom => {
-                    shader_loc.x += px_per_tab + gaps_between
-                }
+                TabIndicatorPosition::Left | TabIndicatorPosition::Right => shader_loc.y += delta,
+                TabIndicatorPosition::Top | TabIndicatorPosition::Bottom => shader_loc.x += delta,
             }
 
             let size = match position {


### PR DESCRIPTION
Add support to flip the display of the tab indicator.
One can now add the following to config:
```
tab-indicator {
    flip // <--
    position "bottom"
}
```
Now `Mod+J` can be used to move to the window on the left instead of right.

