### PR TITLE
feat: keycode resolution, keycode triggers

### DIFF
--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -81,6 +81,34 @@ binds {
 
 This is mostly useful for the scroll bindings.
 
+### Non-Qwerty Layout
+Any non-Qwerty layout should work as-is and work out of the box (the default xkb layout is used for resolution of bind symbols).
+
+> [!TIP]
+> Make sure your default xkb layout is Qwerty, as this will ensure correct behavior of bindings in many applications.
+> Using a non-Qwerty layout by default regularly leads to applications behaving undesirably, so be mindful of this fact.
+
+If you want to use symbolic values for keybind resolution with your non-Qwerty layout, then you should set the following in your config:
+```kdl
+input {
+    bind-to-keysyms true
+}
+```
+
+### Physical Key Mapping
+You can bind to physical keycodes in niri. To find the keycode, you can use programs like wev.
+
+For example, binding to Mod+T in Qwerty will look like this:
+
+```kdl
+binds {
+    Mod+keycode:28 { spawn "alacritty"; }
+}
+```
+Note that this ultimately allows for the possibility of multiple bindings to one key, and this is intended behavior.
+Multiple layouts can have different mappings to symbols. However, it's still illegal to bind multiple times to one keycode.
+In case of collision, the keycode bind takes precedence over a keysym bind regardless of config order.
+
 ### Scroll Bindings
 
 You can bind mouse wheel scroll ticks using the following syntax.

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -9,6 +9,7 @@ use miette::miette;
 use niri_ipc::{
     ColumnDisplay, LayoutSwitchTarget, PositionChange, SizeChange, WorkspaceReferenceArg,
 };
+use smithay::backend::input::Keycode;
 use smithay::input::keyboard::keysyms::KEY_NoSymbol;
 use smithay::input::keyboard::xkb::{keysym_from_name, KEYSYM_CASE_INSENSITIVE, KEYSYM_NO_FLAGS};
 use smithay::input::keyboard::Keysym;
@@ -39,6 +40,7 @@ pub struct Key {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum Trigger {
     Keysym(Keysym),
+    Keycode(Keycode),
     MouseLeft,
     MouseRight,
     MouseMiddle,
@@ -1000,6 +1002,11 @@ impl FromStr for Key {
             Trigger::TouchpadScrollLeft
         } else if key.eq_ignore_ascii_case("TouchpadScrollRight") {
             Trigger::TouchpadScrollRight
+        } else if let Some(num) = key.strip_prefix("keycode:") {
+            let Ok(keycode) = num.parse::<u32>() else {
+                return Err(miette!("invalid keycode: {key}"));
+            };
+            Trigger::Keycode(keycode.into())
         } else {
             let mut keysym = keysym_from_name(key, KEYSYM_CASE_INSENSITIVE);
             // The keyboard event handling code can receive either

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -9,6 +9,7 @@ use miette::miette;
 use niri_ipc::{
     ColumnDisplay, LayoutSwitchTarget, PositionChange, SizeChange, WorkspaceReferenceArg,
 };
+use smithay::backend::input::Keycode;
 use smithay::input::keyboard::keysyms::KEY_NoSymbol;
 use smithay::input::keyboard::xkb::{keysym_from_name, KEYSYM_CASE_INSENSITIVE, KEYSYM_NO_FLAGS};
 use smithay::input::keyboard::Keysym;
@@ -39,6 +40,7 @@ pub struct Key {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum Trigger {
     Keysym(Keysym),
+    Keycode(Keycode),
     MouseLeft,
     MouseRight,
     MouseMiddle,
@@ -1009,6 +1011,11 @@ impl FromStr for Key {
             Trigger::TabletStylusButton2
         } else if key.eq_ignore_ascii_case("TabletStylusButton3") {
             Trigger::TabletStylusButton3
+        } else if let Some(num) = key.strip_prefix("keycode:") {
+            let Ok(keycode) = num.parse::<u32>() else {
+                return Err(miette!("invalid keycode: {key}"));
+            };
+            Trigger::Keycode(keycode.into())
         } else {
             let mut keysym = keysym_from_name(key, KEYSYM_CASE_INSENSITIVE);
             // The keyboard event handling code can receive either

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -18,6 +18,7 @@ pub struct Input {
     pub tablet: Tablet,
     pub touch: Touch,
     pub disable_power_key_handling: bool,
+    pub bind_to_keysyms: bool,
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
     pub workspace_auto_back_and_forth: bool,
@@ -44,6 +45,8 @@ pub struct InputPart {
     #[knuffel(child)]
     pub disable_power_key_handling: Option<Flag>,
     #[knuffel(child)]
+    pub bind_to_keysyms: Option<Flag>,
+    #[knuffel(child)]
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     #[knuffel(child)]
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
@@ -61,6 +64,7 @@ impl MergeWith<InputPart> for Input {
             (self, part),
             keyboard,
             disable_power_key_handling,
+            bind_to_keysyms,
             workspace_auto_back_and_forth,
         );
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1123,6 +1123,7 @@ mod tests {
                     ),
                 },
                 disable_power_key_handling: true,
+                bind_to_keysyms: false,
                 warp_mouse_to_focus: Some(
                     WarpMouseToFocus {
                         mode: None,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1126,6 +1126,7 @@ mod tests {
                     ),
                 },
                 disable_power_key_handling: true,
+                bind_to_keysyms: false,
                 warp_mouse_to_focus: Some(
                     WarpMouseToFocus {
                         mode: None,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -67,6 +67,12 @@ input {
     // Focus windows and outputs automatically when moving the mouse into them.
     // Setting max-scroll-amount="0%" makes it work only on windows already fully on screen.
     // focus-follows-mouse max-scroll-amount="0%"
+
+    // Resolve keybinds by keysym (Percieved text value) instead of a physical key code
+    // Note: it uses default xkb layout for resolution to physical keys, changing the default layout will
+    // adjust your keybinds with it.
+    // This logic applies to other windows that follow this path.
+    // bind-to-keysyms false
 }
 
 // You can configure outputs by their name, which you can find

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4322,7 +4322,7 @@ impl State {
 #[allow(clippy::too_many_arguments)]
 fn should_intercept_key<'a>(
     suppressed_keys: &mut HashSet<Keycode>,
-    bindings: impl IntoIterator<Item = &'a Bind>,
+    bindings: impl IntoIterator<Item = &'a Bind> + Clone,
     mod_key: ModKey,
     key_code: Keycode,
     modified: Keysym,
@@ -4343,6 +4343,7 @@ fn should_intercept_key<'a>(
     let mut final_bind = find_bind(
         bindings,
         mod_key,
+        key_code,
         modified,
         raw,
         mods,
@@ -4405,8 +4406,9 @@ fn should_intercept_key<'a>(
 }
 
 fn find_bind<'a>(
-    bindings: impl IntoIterator<Item = &'a Bind>,
+    bindings: impl IntoIterator<Item = &'a Bind> + Clone,
     mod_key: ModKey,
+    key_code: Keycode,
     modified: Keysym,
     raw: Option<Keysym>,
     mods: ModifiersState,
@@ -4444,6 +4446,15 @@ fn find_bind<'a>(
             allow_inhibiting: false,
             hotkey_overlay_title: None,
         });
+    }
+
+    if let Some(bind) = find_configured_bind(
+        bindings.clone(),
+        mod_key,
+        Trigger::Keycode(key_code),
+        mods,
+    ) {
+        return Some(bind);
     }
 
     let trigger = Trigger::Keysym(raw?);
@@ -5453,6 +5464,103 @@ mod tests {
                 },
             ),
             None,
+        );
+    }
+
+    #[test]
+    fn keycode_handling() {
+        let bindings = Binds(vec![
+            Bind {
+                key: Key {
+                    trigger: Trigger::Keysym(Keysym::q),
+                    modifiers: Modifiers::SUPER,
+                },
+                action: Action::CloseWindow,
+                repeat: false,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: false,
+                hotkey_overlay_title: None,
+            },
+            Bind {
+                key: Key {
+                    trigger: Trigger::Keycode(Keycode::new(32)),
+                    modifiers: Modifiers::SUPER,
+                },
+                action: Action::FocusColumnLeft,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+            },
+        ]);
+
+        assert_eq!(
+            find_bind(
+                &bindings.0,
+                ModKey::Super,
+                Keycode::new(32),
+                Keysym::h,
+                Some(Keysym::h),
+                ModifiersState {
+                    logo: true,
+                    ..Default::default()
+                },
+                false,
+            )
+            .as_ref(),
+            Some(&bindings.0[1])
+        );
+
+        assert_eq!(
+            find_bind(
+                &bindings.0,
+                ModKey::Super,
+                Keycode::new(31),
+                Keysym::h,
+                Some(Keysym::h),
+                ModifiersState {
+                    logo: true,
+                    ..Default::default()
+                },
+                false,
+            ),
+            None,
+        );
+
+        assert_eq!(
+            find_bind(
+                &bindings.0,
+                ModKey::Super,
+                Keycode::new(31),
+                Keysym::q,
+                Some(Keysym::q),
+                ModifiersState {
+                    logo: true,
+                    ..Default::default()
+                },
+                false,
+            )
+            .as_ref(),
+            Some(&bindings.0[0]),
+        );
+
+        assert_eq!(
+            find_bind(
+                &bindings.0,
+                ModKey::Super,
+                Keycode::new(32),
+                Keysym::q,
+                Some(Keysym::q),
+                ModifiersState {
+                    logo: true,
+                    ..Default::default()
+                },
+                false,
+            )
+            .as_ref(),
+            Some(&bindings.0[1]),
         );
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -426,9 +426,19 @@ impl State {
             time,
             |this, mods, keysym| {
                 let key_code = event.key_code();
-                let modified = keysym.modified_sym();
-                let raw = keysym.raw_latin_sym_or_raw_current_sym();
+                let keysym_binded = this.niri.config.borrow().input.bind_to_keysyms;
+
                 let modifiers = modifiers_from_state(*mods);
+                let modified = keysym.modified_sym();
+
+                let raw = if keysym_binded {
+                    keysym.raw_latin_sym_or_raw_current_sym()
+                } else {
+                    let xkb = keysym.xkb().lock().unwrap();
+                    xkb.raw_syms_for_key_in_layout(key_code, Layout(0))
+                        .first()
+                        .cloned()
+                };
 
                 // After updating XKB state from accessibility-grabbed keys, return right away and
                 // don't handle them.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -472,9 +472,19 @@ impl State {
             time,
             |this, mods, keysym| {
                 let key_code = event.key_code();
-                let modified = keysym.modified_sym();
-                let raw = keysym.raw_latin_sym_or_raw_current_sym();
+                let keysym_binded = this.niri.config.borrow().input.bind_to_keysyms;
+
                 let modifiers = modifiers_from_state(*mods);
+                let modified = keysym.modified_sym();
+
+                let raw = if keysym_binded {
+                    keysym.raw_latin_sym_or_raw_current_sym()
+                } else {
+                    let xkb = keysym.xkb().lock().unwrap();
+                    xkb.raw_syms_for_key_in_layout(key_code, Layout(0))
+                        .first()
+                        .cloned()
+                };
 
                 // After updating XKB state from accessibility-grabbed keys, return right away and
                 // don't handle them.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4508,7 +4508,7 @@ impl State {
 #[allow(clippy::too_many_arguments)]
 fn should_intercept_key<'a>(
     suppressed_keys: &mut HashSet<Keycode>,
-    bindings: impl IntoIterator<Item = &'a Bind>,
+    bindings: impl IntoIterator<Item = &'a Bind> + Clone,
     mod_key: ModKey,
     key_code: Keycode,
     modified: Keysym,
@@ -4529,6 +4529,7 @@ fn should_intercept_key<'a>(
     let mut final_bind = find_bind(
         bindings,
         mod_key,
+        key_code,
         modified,
         raw,
         mods,
@@ -4591,8 +4592,9 @@ fn should_intercept_key<'a>(
 }
 
 fn find_bind<'a>(
-    bindings: impl IntoIterator<Item = &'a Bind>,
+    bindings: impl IntoIterator<Item = &'a Bind> + Clone,
     mod_key: ModKey,
+    key_code: Keycode,
     modified: Keysym,
     raw: Option<Keysym>,
     mods: ModifiersState,
@@ -4630,6 +4632,15 @@ fn find_bind<'a>(
             allow_inhibiting: false,
             hotkey_overlay_title: None,
         });
+    }
+
+    if let Some(bind) = find_configured_bind(
+        bindings.clone(),
+        mod_key,
+        Trigger::Keycode(key_code),
+        mods,
+    ) {
+        return Some(bind);
     }
 
     let trigger = Trigger::Keysym(raw?);
@@ -5654,6 +5665,103 @@ mod tests {
                 },
             ),
             None,
+        );
+    }
+
+    #[test]
+    fn keycode_handling() {
+        let bindings = Binds(vec![
+            Bind {
+                key: Key {
+                    trigger: Trigger::Keysym(Keysym::q),
+                    modifiers: Modifiers::SUPER,
+                },
+                action: Action::CloseWindow,
+                repeat: false,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: false,
+                hotkey_overlay_title: None,
+            },
+            Bind {
+                key: Key {
+                    trigger: Trigger::Keycode(Keycode::new(32)),
+                    modifiers: Modifiers::SUPER,
+                },
+                action: Action::FocusColumnLeft,
+                repeat: true,
+                cooldown: None,
+                allow_when_locked: false,
+                allow_inhibiting: true,
+                hotkey_overlay_title: None,
+            },
+        ]);
+
+        assert_eq!(
+            find_bind(
+                &bindings.0,
+                ModKey::Super,
+                Keycode::new(32),
+                Keysym::h,
+                Some(Keysym::h),
+                ModifiersState {
+                    logo: true,
+                    ..Default::default()
+                },
+                false,
+            )
+            .as_ref(),
+            Some(&bindings.0[1])
+        );
+
+        assert_eq!(
+            find_bind(
+                &bindings.0,
+                ModKey::Super,
+                Keycode::new(31),
+                Keysym::h,
+                Some(Keysym::h),
+                ModifiersState {
+                    logo: true,
+                    ..Default::default()
+                },
+                false,
+            ),
+            None,
+        );
+
+        assert_eq!(
+            find_bind(
+                &bindings.0,
+                ModKey::Super,
+                Keycode::new(31),
+                Keysym::q,
+                Some(Keysym::q),
+                ModifiersState {
+                    logo: true,
+                    ..Default::default()
+                },
+                false,
+            )
+            .as_ref(),
+            Some(&bindings.0[0]),
+        );
+
+        assert_eq!(
+            find_bind(
+                &bindings.0,
+                ModKey::Super,
+                Keycode::new(32),
+                Keysym::q,
+                Some(Keysym::q),
+                ModifiersState {
+                    logo: true,
+                    ..Default::default()
+                },
+                false,
+            )
+            .as_ref(),
+            Some(&bindings.0[1]),
         );
     }
 }

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -547,6 +547,7 @@ fn key_name(screen_reader: bool, mod_key: ModKey, key: &Key) -> String {
 
     let pretty = match key.trigger {
         Trigger::Keysym(keysym) => prettify_keysym_name(screen_reader, &keysym_get_name(keysym)),
+        Trigger::Keycode(keycode) => format!("keycode:{}", keycode.raw()).to_owned(),
         Trigger::MouseLeft => String::from("Mouse Left"),
         Trigger::MouseRight => String::from("Mouse Right"),
         Trigger::MouseMiddle => String::from("Mouse Middle"),


### PR DESCRIPTION
Solves the issues with multiple layouts and exotic xkb keymaps behaving undesirably. By allowing for binds to physical keys and/or resolving all keybinds against default xkb layout. This allows niri to match behavior of majority of applications in regards with keysym resolution and mapping.

**Related discussions:** https://github.com/YaLTeR/niri/discussions/3255 (solves), https://github.com/YaLTeR/niri/discussions/2134 (useful proposal, but stale), https://github.com/YaLTeR/niri/discussions/1919 (solves), 
**Related issues**: https://github.com/YaLTeR/niri/issues/283 (solves)
**Similar PR:** https://github.com/YaLTeR/niri/pull/1920 (draft)

**Note on variants:** Pull request contains two variants for the same functionality provided in two commits. Cleaner (var2) and "Safer" (var1). Var1 is not much safer because avoiding xkb mutex lock and unwrap doesn't yeild any significant performance, nor will it remove other unwraps used by the libraries handling xkb connection. 