### PR TITLE
fix: prioritize activation region hits over CSD overflow in scrolling hit testing

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -594,6 +594,17 @@ impl HitType {
             .map(|hit| (tile.window(), hit.offset_win_pos(tile_pos)))
     }
 
+    /// Like `hit_tile()`, but clipped to the tile's activation region.
+    pub fn hit_tile_within_activation_region<W: LayoutElement>(
+        tile: &Tile<W>,
+        tile_pos: Point<f64, Logical>,
+        point: Point<f64, Logical>,
+    ) -> Option<(&W, Self)> {
+        let pos_within_tile = point - tile_pos;
+        tile.hit_within_activation_region(pos_within_tile)
+            .map(|hit| (tile.window(), hit.offset_win_pos(tile_pos)))
+    }
+
     pub fn to_activate(self) -> Self {
         match self {
             HitType::Input { .. } => HitType::Activate {

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -867,6 +867,27 @@ impl<W: LayoutElement> Tile<W> {
         activation_region.contains(point)
     }
 
+    /// Like `hit()`, but only returns a result if the point is within the tile's activation
+    /// region (i.e. within tile bounds). This prevents CSD input regions (shadows, resize handles)
+    /// from claiming hits outside the tile.
+    pub fn hit_within_activation_region(&self, point: Point<f64, Logical>) -> Option<HitType> {
+        let offset = self.bob_offset();
+        let point = point - offset;
+
+        if self.is_in_activation_region(point) {
+            if self.is_in_input_region(point) {
+                let win_pos = self.buf_loc() + offset;
+                Some(HitType::Input { win_pos })
+            } else {
+                Some(HitType::Activate {
+                    is_tab_indicator: false,
+                })
+            }
+        } else {
+            None
+        }
+    }
+
     pub fn hit(&self, point: Point<f64, Logical>) -> Option<HitType> {
         let offset = self.bob_offset();
         let point = point - offset;

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1768,7 +1768,7 @@ impl<W: LayoutElement> Workspace<W> {
 
                 let pos_within_tile = pos - tile_pos;
 
-                if tile.hit(pos_within_tile).is_some() {
+                if tile.hit_within_activation_region(pos_within_tile).is_some() {
                     let size = tile.tile_size().to_f64();
 
                     let mut edges = ResizeEdge::empty();


### PR DESCRIPTION
## what this fixes

focus-follows-mouse edge panning doesn't work reliably with CSD windows. with struts enabled and two 0.5-proportion columns side by side, moving the mouse to the screen edge should focus the adjacent peeking column - but CSD windows like firefox and alacritty block it most of the time, while SSD windows work fine.

## root cause

CSD windows have buffers and input regions that extend beyond their `geometry()` bounds (shadows, resize handles etc). in `ScrollingSpace::window_under()`, tiles are checked in render order and the first tile whose `hit()` returns `Some` wins. since `hit()` checks `is_in_input_region()` first - which delegates to the wayland client's input region without clipping to tile bounds - the CSD shadow bleeds into the strut zone, the active column steals the hit, focus-follows-mouse sees the same window already focused, and nothing happens.

SSD windows don't have this issue because their `geometry().loc` is `(0,0)` and their buffer doesn't extend beyond the geometry.

worth noting that `clip-to-geometry` only affects rendering, not input - so it can't help here either.

## the fix

instead of unconditionally clipping all pointer input to the activation region (which would break legitimate CSD surfaces extending beyond tile bounds, like GTK 3 subsurface popups or non-grabbing popups), this uses a two-pass approach in `ScrollingSpace::window_under()`:

1. **first pass** - only accept hits within the tile's activation region (tile bounds). this means the peeking column wins over the active column's CSD shadow in strut zones.
2. **second pass** - fall back to the full `hit()` including CSD overflow regions. this preserves normal pointer input on legitimate surfaces extending beyond tile bounds.

the first pass almost always matches (pointer is within some tile's bounds), so the second pass only runs when the pointer is in a CSD overflow zone outside all tile bounds - negligible performance impact.

adds `Tile::hit_within_activation_region()` which checks activation region first, then input region within it. the original `Tile::hit()` is unchanged.

also updated `resize_edges_under()` in `workspace.rs` to use `hit_within_activation_region()` for consistency - it had a comment explicitly noting it should match `window_under()` behavior, and resize edge calculations are relative to tile geometry so CSD overflow hits would produce meaningless edges anyway.

## what about other hit testing paths

- **floating windows** - use single-pass `hit_tile()`. CSD overlap between floating windows is a z-order concern, not a strut/peeking issue. left as-is.
- **interactive move** - uses single-pass `hit_tile()` on the single dragged tile. no overlap with itself, no change needed.
- **overview mode** - converts all hits to `Activate` and disables resize. unaffected.
- **tab indicators** - checked before tiles in the first pass so they win correctly. not rechecked in the second pass, but tab indicators don't extend into other columns' CSD zones in practice.

## tested with

same tight layout - 4px gaps, 2px struts, 2px focus ring border, `clip-to-geometry true`, `prefer-no-csd` on:

```kdl
layout {
    gaps 4
    struts {
        left 2
        right 2
    }
    default-column-width { proportion 0.5; }
    border {
        width 2
    }
}
```

- edge panning via focus-follows-mouse works consistently on CSD windows (firefox, alacritty, chromium, discord, spotify)
- normal pointer input on CSD regions extending beyond tile bounds (shadows, resize handles) still works
- mod+right-click resize behaves correctly at tile edges
- SSD windows unaffected (hit() and hit_within_activation_region() are equivalent for them)
- also tested with different gap/strut/border geometries - all working

tried to test for regressions with the second pass (GTK 3 subsurface popups, non-grabbing popups) but couldn't find a good client that reliably produces CSD surfaces extending beyond tile bounds in a way that would exercise the fallback path. if anyone has a test case for that I'm happy to verify.

would definitely benefit from further testing, but since this enables a purely mouse-driven horizontal scrolling use-case that was broken before, I think it's worth checking out.