### PR TITLE
add on-output window rule match property

### DIFF
--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -37,6 +37,7 @@ window-rule {
     match is-window-cast-target=true
     match is-urgent=true
     match at-startup=true
+    match on-output="HDMI-A-1"
 
     // Properties that apply once upon window opening.
     default-column-width { proportion 0.75; }
@@ -314,6 +315,45 @@ This is useful for properties like `open-on-output` which you may want to apply 
 // Open windows on the HDMI-A-1 monitor at niri startup, but not afterwards.
 window-rule {
     match at-startup=true
+    open-on-output "HDMI-A-1"
+}
+```
+
+#### `on-output`
+
+<sup>Since: next</sup>
+
+Matches windows based on the output (monitor) they will open on or are currently on.
+
+The value is a string that matches by connector name (e.g. `"DP-1"`, `"HDMI-A-1"`) or by make/model/serial (e.g. `"Goldstar LG ULTRAWIDE 123456789"`), same as in `output` configuration blocks.
+
+For example, you can open Firefox maximized on a laptop display but at 50% width on an external monitor.
+
+```kdl
+// On a large monitor, open Firefox at 50% width.
+window-rule {
+    match app-id="firefox" on-output="HDMI-A-1"
+    default-column-width { proportion 0.5; }
+}
+
+// On a laptop display, open Firefox maximized.
+window-rule {
+    match app-id="firefox"
+    exclude on-output="HDMI-A-1"
+    open-maximized true
+}
+```
+
+> [!NOTE]
+> When a window first opens, `on-output` matches against the output where the window *will* open (determined by `open-on-output`, parent window, or the focused monitor).
+> Properties like `open-on-output` and `open-on-workspace` are evaluated *before* `on-output` matching, so they are not affected by `on-output`.
+
+> [!NOTE]
+> Using `open-on-output` or `open-on-workspace` in a rule with an `on-output` matcher is not allowed, since it would create a circular dependency.
+
+```kdl,must-fail
+window-rule {
+    match on-output="DP-1"
     open-on-output "HDMI-A-1"
 }
 ```

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -94,6 +94,8 @@ pub struct Match {
     pub is_urgent: Option<bool>,
     #[knuffel(property)]
     pub at_startup: Option<bool>,
+    #[knuffel(property)]
+    pub on_output: Option<String>,
 }
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -1039,6 +1039,7 @@ impl State {
             &config.window_rules,
             WindowRef::Unmapped(unmapped),
             self.niri.is_at_startup,
+            None,
         );
 
         let Unmapped { window, state, .. } = unmapped;
@@ -1375,6 +1376,7 @@ impl State {
                 window_rules,
                 WindowRef::Unmapped(unmapped),
                 self.niri.is_at_startup,
+                None,
             );
             if let InitialConfigureState::Configured { rules, .. } = &mut unmapped.state {
                 *rules = new_rules;
@@ -1384,7 +1386,7 @@ impl State {
             .layout
             .find_window_and_output_mut(toplevel.wl_surface())
         {
-            if mapped.recompute_window_rules(window_rules, self.niri.is_at_startup) {
+            if mapped.recompute_window_rules(window_rules, self.niri.is_at_startup, None) {
                 drop(config);
                 let output = output.cloned();
                 let window = mapped.window.clone();

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 
 use calloop::Interest;
-use niri_config::PresetSize;
+use niri_config::{OutputName, PresetSize};
 use smithay::desktop::{
     find_popup_root_surface, get_popup_toplevel_coords, layer_map_for_output, utils, LayerSurface,
     PopupKeyboardGrab, PopupKind, PopupManager, PopupPointerGrab, PopupUngrabStrategy, Window,
@@ -1029,39 +1029,50 @@ impl State {
     pub fn send_initial_configure(&mut self, toplevel: &ToplevelSurface) {
         let _span = tracy_client::span!("State::send_initial_configure");
 
-        let Some(unmapped) = self.niri.unmapped_windows.get_mut(toplevel.wl_surface()) else {
-            error!("window must be present in unmapped_windows in send_initial_configure()");
-            return;
-        };
-
         let config = self.niri.config.borrow();
-        let rules = ResolvedWindowRules::compute(
-            &config.window_rules,
-            WindowRef::Unmapped(unmapped),
-            self.niri.is_at_startup,
-            None,
-        );
 
-        let Unmapped { window, state, .. } = unmapped;
+        // Compute rules without output context first, to get open-on-output /
+        // open-on-workspace redirects.
+        let (preliminary_rules, wants_fullscreen, wants_maximized) = {
+            let Some(unmapped) = self.niri.unmapped_windows.get_mut(toplevel.wl_surface()) else {
+                error!("window must be present in unmapped_windows in send_initial_configure()");
+                return;
+            };
 
-        let InitialConfigureState::NotConfigured {
-            wants_fullscreen,
-            wants_maximized,
-        } = state
-        else {
-            error!("window must not be already configured in send_initial_configure()");
-            return;
+            let preliminary_rules = ResolvedWindowRules::compute(
+                &config.window_rules,
+                WindowRef::Unmapped(unmapped),
+                self.niri.is_at_startup,
+                None,
+            );
+
+            let Unmapped { state, .. } = unmapped;
+
+            let InitialConfigureState::NotConfigured {
+                wants_fullscreen,
+                wants_maximized,
+            } = state
+            else {
+                error!("window must not be already configured in send_initial_configure()");
+                return;
+            };
+
+            (
+                preliminary_rules,
+                wants_fullscreen.clone(),
+                *wants_maximized,
+            )
         };
 
         // Pick the target monitor. First, check if we had a workspace set in the window rules.
-        let mon = rules
+        let mon = preliminary_rules
             .open_on_workspace
             .as_deref()
             .and_then(|name| self.niri.layout.monitor_for_workspace(name));
 
         // If not, check if we had an output set in the window rules.
         let mon = mon.or_else(|| {
-            rules
+            preliminary_rules
                 .open_on_output
                 .as_deref()
                 .and_then(|name| {
@@ -1107,6 +1118,24 @@ impl State {
             .map(|(mon, _)| mon.output().clone());
         let mon = mon.map(|(mon, _)| mon);
 
+        // Recompute rules with the target output for on-output matching.
+        let output_name = mon
+            .map(|m| m.output())
+            .and_then(|o| o.user_data().get::<OutputName>().cloned());
+
+        let unmapped = self
+            .niri
+            .unmapped_windows
+            .get_mut(toplevel.wl_surface())
+            .unwrap();
+        let rules = ResolvedWindowRules::compute(
+            &config.window_rules,
+            WindowRef::Unmapped(unmapped),
+            self.niri.is_at_startup,
+            output_name.as_ref(),
+        );
+        let Unmapped { window, state, .. } = unmapped;
+
         let mut width = None;
         let mut floating_width = None;
         let mut height = None;
@@ -1127,7 +1156,7 @@ impl State {
         let mut is_pending_maximized = false;
         if let Some(ws) = ws {
             // Set a fullscreen and maximized state based on window request and window rule.
-            is_pending_maximized = (*wants_maximized && rules.open_maximized_to_edges.is_none())
+            is_pending_maximized = (wants_maximized && rules.open_maximized_to_edges.is_none())
                 || rules.open_maximized_to_edges == Some(true);
 
             if (wants_fullscreen.is_some() && rules.open_fullscreen.is_none())
@@ -1372,11 +1401,17 @@ impl State {
         let window_rules = &config.window_rules;
 
         if let Some(unmapped) = self.niri.unmapped_windows.get_mut(toplevel.wl_surface()) {
+            let output_name = match &unmapped.state {
+                InitialConfigureState::Configured { output, .. } => output
+                    .as_ref()
+                    .and_then(|o| o.user_data().get::<OutputName>().cloned()),
+                _ => None,
+            };
             let new_rules = ResolvedWindowRules::compute(
                 window_rules,
                 WindowRef::Unmapped(unmapped),
                 self.niri.is_at_startup,
-                None,
+                output_name.as_ref(),
             );
             if let InitialConfigureState::Configured { rules, .. } = &mut unmapped.state {
                 *rules = new_rules;
@@ -1386,7 +1421,14 @@ impl State {
             .layout
             .find_window_and_output_mut(toplevel.wl_surface())
         {
-            if mapped.recompute_window_rules(window_rules, self.niri.is_at_startup, None) {
+            let output_name = output
+                .as_ref()
+                .and_then(|o| o.user_data().get::<OutputName>().cloned());
+            if mapped.recompute_window_rules(
+                window_rules,
+                self.niri.is_at_startup,
+                output_name.as_ref(),
+            ) {
                 drop(config);
                 let output = output.cloned();
                 let window = mapped.window.clone();

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -3940,7 +3940,7 @@ impl Niri {
         let mut windows = vec![];
         let mut outputs = HashSet::new();
         self.layout.with_windows_mut(|mapped, output| {
-            if mapped.recompute_window_rules_if_needed(window_rules, self.is_at_startup) {
+            if mapped.recompute_window_rules_if_needed(window_rules, self.is_at_startup, None) {
                 windows.push(mapped.window.clone());
 
                 if let Some(output) = output {
@@ -5957,6 +5957,7 @@ impl Niri {
                     window_rules,
                     WindowRef::Unmapped(unmapped),
                     self.is_at_startup,
+                    None,
                 );
                 if let InitialConfigureState::Configured { rules, .. } = &mut unmapped.state {
                     *rules = new_rules;
@@ -5965,7 +5966,7 @@ impl Niri {
 
             let mut windows = vec![];
             self.layout.with_windows_mut(|mapped, _| {
-                if mapped.recompute_window_rules(window_rules, self.is_at_startup) {
+                if mapped.recompute_window_rules(window_rules, self.is_at_startup, None) {
                     windows.push(mapped.window.clone());
                 }
             });

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -3940,7 +3940,12 @@ impl Niri {
         let mut windows = vec![];
         let mut outputs = HashSet::new();
         self.layout.with_windows_mut(|mapped, output| {
-            if mapped.recompute_window_rules_if_needed(window_rules, self.is_at_startup, None) {
+            let output_name = output.and_then(|o| o.user_data().get::<OutputName>().cloned());
+            if mapped.recompute_window_rules_if_needed(
+                window_rules,
+                self.is_at_startup,
+                output_name.as_ref(),
+            ) {
                 windows.push(mapped.window.clone());
 
                 if let Some(output) = output {
@@ -5953,11 +5958,17 @@ impl Niri {
             let window_rules = &self.config.borrow().window_rules;
 
             for unmapped in self.unmapped_windows.values_mut() {
+                let output_name = match &unmapped.state {
+                    InitialConfigureState::Configured { output, .. } => output
+                        .as_ref()
+                        .and_then(|o| o.user_data().get::<OutputName>().cloned()),
+                    _ => None,
+                };
                 let new_rules = ResolvedWindowRules::compute(
                     window_rules,
                     WindowRef::Unmapped(unmapped),
                     self.is_at_startup,
-                    None,
+                    output_name.as_ref(),
                 );
                 if let InitialConfigureState::Configured { rules, .. } = &mut unmapped.state {
                     *rules = new_rules;
@@ -5965,8 +5976,13 @@ impl Niri {
             }
 
             let mut windows = vec![];
-            self.layout.with_windows_mut(|mapped, _| {
-                if mapped.recompute_window_rules(window_rules, self.is_at_startup, None) {
+            self.layout.with_windows_mut(|mapped, output| {
+                let output_name = output.and_then(|o| o.user_data().get::<OutputName>().cloned());
+                if mapped.recompute_window_rules(
+                    window_rules,
+                    self.is_at_startup,
+                    output_name.as_ref(),
+                ) {
                     windows.push(mapped.window.clone());
                 }
             });

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, Ref, RefCell};
 use std::time::Duration;
 
-use niri_config::{Color, CornerRadius, GradientInterpolation, WindowRule};
+use niri_config::{Color, CornerRadius, GradientInterpolation, OutputName, WindowRule};
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::Kind;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -298,10 +298,16 @@ impl Mapped {
     }
 
     /// Recomputes the resolved window rules and returns whether they changed.
-    pub fn recompute_window_rules(&mut self, rules: &[WindowRule], is_at_startup: bool) -> bool {
+    pub fn recompute_window_rules(
+        &mut self,
+        rules: &[WindowRule],
+        is_at_startup: bool,
+        output: Option<&OutputName>,
+    ) -> bool {
         self.need_to_recompute_rules = false;
 
-        let new_rules = ResolvedWindowRules::compute(rules, WindowRef::Mapped(self), is_at_startup);
+        let new_rules =
+            ResolvedWindowRules::compute(rules, WindowRef::Mapped(self), is_at_startup, output);
         if new_rules == self.rules {
             return false;
         }
@@ -320,12 +326,13 @@ impl Mapped {
         &mut self,
         rules: &[WindowRule],
         is_at_startup: bool,
+        output: Option<&OutputName>,
     ) -> bool {
         if !self.need_to_recompute_rules {
             return false;
         }
 
-        self.recompute_window_rules(rules, is_at_startup)
+        self.recompute_window_rules(rules, is_at_startup, output)
     }
 
     pub fn set_needs_configure(&mut self) {


### PR DESCRIPTION
Closes #2600

This adds an on-output match property to window rules, so you can apply different rules to windows depending on which monitor they're on. It matches by connector name, like "DP-1", or make/model/serial, same style as output config blocks.

## Motivation

I use a Framework 13 laptop with a 32" external monitor and want different window sizing per display.

A specific example:
- I want to open a Firefox window at 1/3 width on the big 32" monitor, but maximized on other screens.
- I want messaging clients (discord, signal, etc) to open at 1/2 width on the 32" monitor, but maximized on other screens.

Per-output layout blocks get you part of the way there but they apply to all windows on that output, not specific ones.

Here's a snippet of what my `config.kdl` looks like now with these things applied:
```kdl
// Firefox: 1/3 width on the MSI 32"
window-rule {
    match app-id="firefox" on-output="Microstep MSI MAG321CQR KA3H071804955"
    default-column-width { proportion 0.33333; }
}

// Firefox: open maximized on all other displays
window-rule {
    match app-id="firefox"
    exclude on-output="Microstep MSI MAG321CQR KA3H071804955"
    open-maximized true
}

// Messaging clients: 1/2 width on the MSI 32"
window-rule {
    match app-id=r#"^vesktop$"# on-output="Microstep MSI MAG321CQR KA3H071804955"
    match app-id=r#"^Element"# on-output="Microstep MSI MAG321CQR KA3H071804955"
    match app-id=r#"^signal$"# on-output="Microstep MSI MAG321CQR KA3H071804955"
    default-column-width { proportion 0.5; }
}

// Messaging clients: open maximized on all other displays
window-rule {
    match app-id=r#"^vesktop$"#
    match app-id=r#"^Element"#
    match app-id=r#"^signal$"#
    exclude on-output="Microstep MSI MAG321CQR KA3H071804955"
    open-maximized true
}

```

## Notes

### Circular dependency guard
Like discussed in #2600, on-output and open-on-output in the same rule would create a circular dependency so we'd need to know the target output to evaluate the rule, but the rule changes the target output. So this is handled with:

- A config-level validation that rejects any window rule combining on-output matchers with open-on-output or open-on-workspace
- A two-pass evaluation at window open time. The first pass resolves open-on-output/open-on-workspace redirects without output context, second pass re-evaluates with the resolved target output for on-output matching

I think this implementation is sensible, I would appreciate any feedback / help with this here!

## Changes
- niri-config: add on_output field to Match, reject open-on-output/open-on-workspace in rules with on-output
- src/window: thread Option<&OutputName> through ResolvedWindowRules::compute and window_matches
- src/handlers/xdg_shell.rs: two-pass rule evaluation in send_initial_configure, preliminary pass for output/workspace redirects, then full pass with resolved output
- src/niri.rs: pass output context when recomputing rules for mapped/unmapped windows
- Wiki: document on-output with examples and must-fail block for the circular case
