### PR TITLE
Feat/transition anim

### DIFF
--- a/docs/wiki/Configuration:-Animations.md
+++ b/docs/wiki/Configuration:-Animations.md
@@ -441,6 +441,7 @@ animations {
 ```
 
 #### `screen-transition`
+
 <sup>Since: next release</sup>
 
 The cross-fade animation of the `do-screen-transition` action.
@@ -448,7 +449,7 @@ The cross-fade animation of the `do-screen-transition` action.
 ```kdl
 animations {
     screen-transition {
-        curve "ease-out-quad"
+        curve "ease-out-expo"
     }
 }
 ```
@@ -469,16 +470,16 @@ When running niri as a systemd service, you can see the warnings in the journal:
 > Custom shaders do not have a backwards compatibility guarantee.
 > I may need to change their interface as I'm developing new features.
 
-<!-- Example: resize will show the next (after resize) window texture right away, stretched to the current geometry. -->
+<!-- Example: screen transition will show the previous screen texture and gradually fade in the next screen texture on top of it. -->
 
 ```kdl
 animations {
     screen-transition {
         custom-shader r"
             vec4 screen_transition_color(vec3 coords_curr_geo, vec3 size_curr_geo) {
-                vec3 coords_tex_next = niri_geo_to_tex_next * coords_curr_geo;
-                vec4 color = texture2D(niri_tex_next, coords_tex_next.st);
-                return color * niri_clamped_progress;
+                vec3 coords_tex = niri_geo_to_tex * coords_curr_geo;
+                vec4 color = texture2D(niri_tex_from, coords_tex.st);
+                return color * (1.0 - niri_clamped_progress);
             }
         "
     }

--- a/docs/wiki/Configuration:-Animations.md
+++ b/docs/wiki/Configuration:-Animations.md
@@ -440,6 +440,51 @@ animations {
 }
 ```
 
+#### `screen-transition`
+<sup>Since: next release</sup>
+
+The cross-fade animation of the `do-screen-transition` action.
+
+```kdl
+animations {
+    screen-transition {
+        curve "ease-out-quad"
+    }
+}
+```
+
+##### `custom-shader`
+
+<sup>Since: next release</sup>
+
+You can write a custom shader for drawing the screen during a screen transition animation.
+
+See [this example shader](./examples/screen_transition_custom_shader.frag) for a full documentation with several animations to experiment with.
+
+If a custom shader fails to compile, niri will print a warning and fall back to the default, or previous successfully compiled shader.
+When running niri as a systemd service, you can see the warnings in the journal: `journalctl -ef /usr/bin/niri`
+
+> [!WARNING]
+>
+> Custom shaders do not have a backwards compatibility guarantee.
+> I may need to change their interface as I'm developing new features.
+
+<!-- Example: resize will show the next (after resize) window texture right away, stretched to the current geometry. -->
+
+```kdl
+animations {
+    screen-transition {
+        custom-shader r"
+            vec4 screen_transition_color(vec3 coords_curr_geo, vec3 size_curr_geo) {
+                vec3 coords_tex_next = niri_geo_to_tex_next * coords_curr_geo;
+                vec4 color = texture2D(niri_tex_next, coords_tex_next.st);
+                return color * niri_clamped_progress;
+            }
+        "
+    }
+}
+```
+
 ### Synchronized Animations
 
 <sup>Since: 0.1.5</sup>

--- a/docs/wiki/examples/screen_transition_custom_shader.frag
+++ b/docs/wiki/examples/screen_transition_custom_shader.frag
@@ -1,0 +1,170 @@
+// Your shader must contain one function (see the bottom of this file).
+//
+// It should not contain any uniform definitions or anything else, as niri
+// provides them for you.
+//
+// All symbols defined by niri will have a niri_ prefix, so don't use it for
+// your own variables and functions.
+
+// The function that you must define looks like this:
+vec4 screen_transition_color(vec3 coords_geo, vec3 size_geo) {
+    vec4 color = /* ...compute the color... */;
+    return color;
+}
+
+// It takes as input:
+//
+// * coords_geo: coordinates of the current pixel relative to the output.
+//
+// These are homogeneous (the Z component is equal to 1) and scaled in such a
+// way that the 0 to 1 coordinates cover the full output.
+//
+// * size_geo: size of the output in logical pixels.
+//
+// It is homogeneous (the Z component is equal to 1).
+//
+// The screen transition shader renders as an overlay above the live workspace.
+// Making pixels transparent (alpha = 0) will reveal the new workspace
+// underneath, while opaque pixels (alpha = 1) will show the captured old
+// workspace snapshot. As the transition progresses, you should generally make
+// more pixels transparent to reveal the new workspace.
+//
+// The function must return the color of the pixel (with premultiplied alpha).
+// The pixel color will be further processed by niri (e.g. to apply final
+// alpha).
+
+// Now let's go over the uniforms that niri defines.
+//
+// You should only rely on the uniforms documented here. Any other uniforms can
+// change or be removed without notice.
+
+// The captured texture of the old workspace (before the switch).
+uniform sampler2D niri_tex_from;
+
+// Matrix that converts geometry coordinates into the old workspace texture
+// coordinates.
+//
+// You must always use this matrix to sample the texture, like this:
+//   vec3 coords_tex = niri_geo_to_tex * coords_geo;
+//   vec4 color = texture2D(niri_tex_from, coords_tex.st);
+// This ensures correct sampling when the output has a transform (rotation).
+uniform mat3 niri_geo_to_tex;
+
+
+// Unclamped progress of the animation.
+//
+// Goes from 0 to 1 but may overshoot and oscillate.
+uniform float niri_progress;
+
+// Clamped progress of the animation.
+//
+// Goes from 0 to 1, but will stop at 1 as soon as it first reaches 1. Will not
+// overshoot or oscillate.
+uniform float niri_clamped_progress;
+
+// Random float in [0; 1), consistent for the duration of the animation.
+uniform float niri_random_seed;
+
+// Mouse position in logical output coordinates (0,0 at top-left).
+// Set to (-1, -1) if the cursor is not on this output.
+uniform vec2 niri_mouse_pos;
+
+// Now let's look at some examples. You can copy everything below this line
+// into your custom-shader to experiment.
+
+// Example: gradually fade out the old workspace, equivalent to the default
+// crossfade transition.
+vec4 default_crossfade(vec3 coords_geo, vec3 size_geo) {
+    vec3 coords_tex = niri_geo_to_tex * coords_geo;
+    vec4 color = texture2D(niri_tex_from, coords_tex.st);
+
+    // Fade out the old workspace to reveal the new one underneath.
+    color *= (1.0 - niri_clamped_progress);
+
+    return color;
+}
+
+// Example: horizontal wipe from left to right revealing the new workspace.
+vec4 horizontal_wipe(vec3 coords_geo, vec3 size_geo) {
+    vec3 coords_tex = niri_geo_to_tex * coords_geo;
+    vec4 color = texture2D(niri_tex_from, coords_tex.st);
+
+    // The wipe edge moves from left (x=0) to right (x=1) with progress.
+    // Pixels to the left of the edge become transparent, revealing the
+    // new workspace underneath.
+    float alpha = smoothstep(niri_clamped_progress - 0.05,
+                             niri_clamped_progress + 0.05,
+                             coords_geo.x);
+
+    return color * alpha;
+}
+
+// Example: the old workspace slides upward off the screen.
+vec4 slide_up(vec3 coords_geo, vec3 size_geo) {
+    // Shift the sampling position upward as the transition progresses.
+    vec3 shifted = vec3(coords_geo.x,
+                        coords_geo.y + niri_clamped_progress,
+                        1.0);
+
+    // Pixels that have shifted beyond the old workspace should be
+    // transparent, letting the new workspace show through.
+    if (shifted.y > 1.0)
+        return vec4(0.0);
+
+    vec3 coords_tex = niri_geo_to_tex * shifted;
+    vec4 color = texture2D(niri_tex_from, coords_tex.st);
+
+    return color;
+}
+
+// Example: pixels randomly dissolve to reveal the new workspace.
+vec4 pixel_dissolve(vec3 coords_geo, vec3 size_geo) {
+    vec3 coords_tex = niri_geo_to_tex * coords_geo;
+    vec4 color = texture2D(niri_tex_from, coords_tex.st);
+
+    // Generate a pseudo-random value per pixel, offset by the random seed
+    // so each transition looks different.
+    vec2 seed = coords_geo.xy + vec2(niri_random_seed);
+    float random = fract(sin(dot(seed, vec2(12.9898, 78.233))) * 43758.5453);
+
+    // As progress increases, more pixels cross the threshold and become
+    // transparent, revealing the new workspace.
+    float threshold = niri_clamped_progress * 1.2;
+    float alpha = step(threshold, random);
+
+    return color * alpha;
+}
+
+// Example: expanding circle from mouse position revealing the new workspace.
+// Recommended setting: duration-ms 300
+vec4 circle_reveal(vec3 coords_geo, vec3 size_geo) {
+    vec3 coords_tex = niri_geo_to_tex * coords_geo;
+    vec4 color = texture2D(niri_tex_from, coords_tex.st);
+
+    // Use the mouse position as the circle center, or the screen center
+    // if the cursor is off this output (sentinel value -1, -1).
+    vec2 center = (niri_mouse_pos.x < 0.0)
+        ? vec2(0.5)
+        : niri_mouse_pos / size_geo.xy;
+
+    // Correct for aspect ratio so the reveal is a circle, not an ellipse.
+    vec2 aspect = size_geo.xy / length(size_geo.xy);
+    vec2 delta = (coords_geo.xy - center) * aspect;
+    float dist = length(delta);
+
+    // The circle expands with progress. Scale by ~1.5 to ensure
+    // it covers the full screen even when starting from a corner.
+    float radius = niri_clamped_progress * 1.5;
+
+    // Pixels inside the expanding circle become transparent (new workspace),
+    // pixels outside stay opaque (old workspace).
+    float alpha = smoothstep(radius - 0.05, radius, dist);
+
+    return color * alpha;
+}
+
+// This is the function that you must define.
+vec4 screen_transition_color(vec3 coords_geo, vec3 size_geo) {
+    // You can pick one of the example functions or write your own.
+    return circle_reveal(coords_geo, size_geo);
+}

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1637,6 +1637,18 @@ mod tests {
                         ),
                     },
                 ),
+                screen_transition: ScreenTransitionAnim {
+                    anim: Animation {
+                        off: false,
+                        kind: Easing(
+                            EasingParams {
+                                duration_ms: 300,
+                                curve: EaseOutExpo,
+                            },
+                        ),
+                    },
+                    custom_shader: None,
+                },
             },
             blur: Blur {
                 off: false,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1635,6 +1635,18 @@ mod tests {
                         ),
                     },
                 ),
+                screen_transition: ScreenTransitionAnim {
+                    anim: Animation {
+                        off: false,
+                        kind: Easing(
+                            EasingParams {
+                                duration_ms: 300,
+                                curve: EaseOutExpo,
+                            },
+                        ),
+                    },
+                    custom_shader: None,
+                },
             },
             blur: Blur {
                 off: false,

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -238,6 +238,19 @@ impl Animation {
         self.clock.now() >= self.start_time + self.duration
     }
 
+    /// Returns whether the animation is done as seen from a custom time `at`.
+    ///
+    /// Useful for delayed animations that derive their effective clock time from an offset
+    /// (e.g. `clock.now().saturating_sub(delay)`). Handles `should_complete_instantly`
+    /// the same way as `is_done`.
+    pub fn is_done_at(&self, at: Duration) -> bool {
+        if self.clock.should_complete_instantly() {
+            return true;
+        }
+
+        at >= self.start_time + self.duration
+    }
+
     pub fn is_clamped_done(&self) -> bool {
         if self.clock.should_complete_instantly() {
             return true;

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -843,6 +843,9 @@ impl Tty {
             if let Some(src) = config.animations.window_open.custom_shader.as_deref() {
                 shaders::set_custom_open_program(gles_renderer, Some(src));
             }
+            if let Some(src) = config.animations.screen_transition.custom_shader.as_deref() {
+                shaders::set_custom_screen_transition_program(gles_renderer, Some(src));
+            }
             drop(config);
 
             niri.update_shaders();

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -168,6 +168,9 @@ impl Winit {
         if let Some(src) = config.animations.window_open.custom_shader.as_deref() {
             shaders::set_custom_open_program(renderer, Some(src));
         }
+        if let Some(src) = config.animations.screen_transition.custom_shader.as_deref() {
+            shaders::set_custom_screen_transition_program(renderer, Some(src));
+        }
         drop(config);
 
         niri.update_shaders();

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1575,6 +1575,16 @@ impl State {
             shaders_changed = true;
         }
 
+        if config.animations.screen_transition.custom_shader
+            != old_config.animations.screen_transition.custom_shader
+        {
+            let src = config.animations.screen_transition.custom_shader.as_deref();
+            self.backend.with_primary_renderer(|renderer| {
+                shaders::set_custom_screen_transition_program(renderer, src);
+            });
+            shaders_changed = true;
+        }
+
         if config.cursor.hide_after_inactive_ms != old_config.cursor.hide_after_inactive_ms {
             cursor_inactivity_timeout_changed = true;
         }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -4244,7 +4244,8 @@ impl Niri {
                     }
                 });
 
-                push(transition.render(ctx.renderer, ctx.target, mouse_pos).into());
+                let transition_elem = transition.render(ctx.renderer, ctx.target, mouse_pos);
+                push(transition_elem.into());
             }
         }
 
@@ -6299,13 +6300,21 @@ impl Niri {
                     );
 
                     if let Err(err) = &res {
-                        warn!("error rendering output {}: {err:?}", output.name());
+                        warn!(
+                            "error rendering {:?} for output {}: {err:?}",
+                            target,
+                            output.name()
+                        );
                     }
 
                     res
                 });
 
                 if textures.iter().any(|res| res.is_err()) {
+                    warn!(
+                        "skipping screen transition for output {} due to render errors",
+                        output.name()
+                    );
                     return None;
                 }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -169,7 +169,7 @@ use crate::ui::config_error_notification::ConfigErrorNotification;
 use crate::ui::exit_confirm_dialog::{ExitConfirmDialog, ExitConfirmDialogRenderElement};
 use crate::ui::hotkey_overlay::HotkeyOverlay;
 use crate::ui::mru::{MruCloseRequest, WindowMruUi, WindowMruUiRenderElement};
-use crate::ui::screen_transition::{self, ScreenTransition};
+use crate::ui::screen_transition::{self, ScreenTransition, ScreenTransitionRenderElement};
 use crate::ui::screenshot_ui::{OutputScreenshot, ScreenshotUi, ScreenshotUiRenderElement};
 use crate::utils::scale::{closest_representable_scale, guess_monitor_scale};
 use crate::utils::spawning::{CHILD_DISPLAY, CHILD_ENV};
@@ -4226,7 +4226,25 @@ impl Niri {
         // Next, the screen transition texture.
         {
             if let Some(transition) = &state.screen_transition {
-                push(transition.render(ctx.target).into());
+                let mouse_pos = self.global_space.output_geometry(output).and_then(|geo| {
+                    let pos = self
+                        .tablet_cursor_location
+                        .unwrap_or_else(|| self.seat.get_pointer().unwrap().current_location());
+                    let local =
+                        Point::from((pos.x - f64::from(geo.loc.x), pos.y - f64::from(geo.loc.y)));
+
+                    if local.x < 0.
+                        || local.y < 0.
+                        || f64::from(geo.size.w) <= local.x
+                        || f64::from(geo.size.h) <= local.y
+                    {
+                        None
+                    } else {
+                        Some(local)
+                    }
+                });
+
+                push(transition.render(ctx.renderer, ctx.target, mouse_pos).into());
             }
         }
 
@@ -6244,6 +6262,8 @@ impl Niri {
     pub fn do_screen_transition(&mut self, renderer: &mut GlesRenderer, delay_ms: Option<u16>) {
         let _span = tracy_client::span!("Niri::do_screen_transition");
 
+        let anim_config = self.config.borrow().animations.screen_transition.anim;
+
         self.update_render_elements(None);
 
         let textures: Vec<_> = self
@@ -6313,6 +6333,7 @@ impl Niri {
             state.screen_transition = Some(ScreenTransition::new(
                 from_texture,
                 delay,
+                anim_config,
                 self.clock.clone(),
             ));
         }
@@ -6533,6 +6554,7 @@ niri_render_elements! {
         ScreenshotUi = ScreenshotUiRenderElement,
         WindowMruUi = WindowMruUiRenderElement<R>,
         ExitConfirmDialog = ExitConfirmDialogRenderElement,
+        ScreenTransition = ScreenTransitionRenderElement,
         Texture = PrimaryGpuTextureRenderElement,
         // Used for the CPU-rendered panels.
         RelocatedMemoryBuffer = RelocateRenderElement<MemoryRenderBufferRenderElement<R>>,

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -199,7 +199,7 @@ impl Shaders {
         self.custom_open.replace(program)
     }
 
-    pub fn replace_custom_transition_program(
+    pub fn replace_custom_screen_transition_program(
         &self,
         program: Option<ShaderProgram>,
     ) -> Option<ShaderProgram> {
@@ -368,20 +368,20 @@ fn compile_screen_transition_program(
     renderer: &mut GlesRenderer,
     src: &str,
 ) -> Result<ShaderProgram, GlesError> {
-    let mut program = include_str!("transition_prelude.frag").to_string();
+    let mut program = include_str!("screen_transition_prelude.frag").to_string();
     program.push_str(src);
-    program.push_str(include_str!("transition_epilogue.frag"));
+    program.push_str(include_str!("screen_transition_epilogue.frag"));
 
     ShaderProgram::compile(
         renderer,
         &program,
         &[
-            UniformName::new("niri_cursor_coords", UniformType::_2f),
             UniformName::new("niri_progress", UniformType::_1f),
             UniformName::new("niri_clamped_progress", UniformType::_1f),
+            UniformName::new("niri_mouse_pos", UniformType::_2f),
             UniformName::new("niri_random_seed", UniformType::_1f),
         ],
-        &["niri_tex_prev", "niri_tex_next"],
+        &["niri_tex_from"],
     )
 }
 
@@ -398,7 +398,7 @@ pub fn set_custom_screen_transition_program(renderer: &mut GlesRenderer, src: Op
         None
     };
 
-    if let Some(prev) = Shaders::get(renderer).replace_custom_transition_program(program) {
+    if let Some(prev) = Shaders::get(renderer).replace_custom_screen_transition_program(program) {
         if let Err(err) = prev.destroy(renderer) {
             warn!("error destroying previous custom transition shader: {err:?}");
         }

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -376,6 +376,8 @@ fn compile_screen_transition_program(
         renderer,
         &program,
         &[
+            UniformName::new("niri_input_to_geo", UniformType::Matrix3x3),
+            UniformName::new("niri_geo_size", UniformType::_2f),
             UniformName::new("niri_geo_to_tex", UniformType::Matrix3x3),
             UniformName::new("niri_progress", UniformType::_1f),
             UniformName::new("niri_clamped_progress", UniformType::_1f),

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -21,6 +21,7 @@ pub struct Shaders {
     pub custom_resize: RefCell<Option<ShaderProgram>>,
     pub custom_close: RefCell<Option<ShaderProgram>>,
     pub custom_open: RefCell<Option<ShaderProgram>>,
+    pub custom_screen_transition: RefCell<Option<ShaderProgram>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -30,6 +31,7 @@ pub enum ProgramType {
     Resize,
     Close,
     Open,
+    ScreenTransition,
 }
 
 impl Shaders {
@@ -159,6 +161,7 @@ impl Shaders {
             custom_resize: RefCell::new(None),
             custom_close: RefCell::new(None),
             custom_open: RefCell::new(None),
+            custom_screen_transition: RefCell::new(None),
         }
     }
 
@@ -196,6 +199,13 @@ impl Shaders {
         self.custom_open.replace(program)
     }
 
+    pub fn replace_custom_transition_program(
+        &self,
+        program: Option<ShaderProgram>,
+    ) -> Option<ShaderProgram> {
+        self.custom_screen_transition.replace(program)
+    }
+
     pub fn program(&self, program: ProgramType) -> Option<ShaderProgram> {
         match program {
             ProgramType::Border => self.border.clone(),
@@ -207,6 +217,7 @@ impl Shaders {
                 .or_else(|| self.resize.clone()),
             ProgramType::Close => self.custom_close.borrow().clone(),
             ProgramType::Open => self.custom_open.borrow().clone(),
+            ProgramType::ScreenTransition => self.custom_screen_transition.borrow().clone(),
         }
     }
 }
@@ -349,6 +360,47 @@ pub fn set_custom_open_program(renderer: &mut GlesRenderer, src: Option<&str>) {
     if let Some(prev) = Shaders::get(renderer).replace_custom_open_program(program) {
         if let Err(err) = prev.destroy(renderer) {
             warn!("error destroying previous custom open shader: {err:?}");
+        }
+    }
+}
+
+fn compile_screen_transition_program(
+    renderer: &mut GlesRenderer,
+    src: &str,
+) -> Result<ShaderProgram, GlesError> {
+    let mut program = include_str!("transition_prelude.frag").to_string();
+    program.push_str(src);
+    program.push_str(include_str!("transition_epilogue.frag"));
+
+    ShaderProgram::compile(
+        renderer,
+        &program,
+        &[
+            UniformName::new("niri_cursor_coords", UniformType::_2f),
+            UniformName::new("niri_progress", UniformType::_1f),
+            UniformName::new("niri_clamped_progress", UniformType::_1f),
+            UniformName::new("niri_random_seed", UniformType::_1f),
+        ],
+        &["niri_tex_prev", "niri_tex_next"],
+    )
+}
+
+pub fn set_custom_screen_transition_program(renderer: &mut GlesRenderer, src: Option<&str>) {
+    let program = if let Some(src) = src {
+        match compile_screen_transition_program(renderer, src) {
+            Ok(program) => Some(program),
+            Err(err) => {
+                warn!("error compiling custom transition shader: {err:?}");
+                return;
+            }
+        }
+    } else {
+        None
+    };
+
+    if let Some(prev) = Shaders::get(renderer).replace_custom_transition_program(program) {
+        if let Err(err) = prev.destroy(renderer) {
+            warn!("error destroying previous custom transition shader: {err:?}");
         }
     }
 }

--- a/src/render_helpers/shaders/mod.rs
+++ b/src/render_helpers/shaders/mod.rs
@@ -376,6 +376,7 @@ fn compile_screen_transition_program(
         renderer,
         &program,
         &[
+            UniformName::new("niri_geo_to_tex", UniformType::Matrix3x3),
             UniformName::new("niri_progress", UniformType::_1f),
             UniformName::new("niri_clamped_progress", UniformType::_1f),
             UniformName::new("niri_mouse_pos", UniformType::_2f),

--- a/src/render_helpers/shaders/screen_transition_epilogue.frag
+++ b/src/render_helpers/shaders/screen_transition_epilogue.frag
@@ -1,0 +1,15 @@
+void main() {
+    vec3 coords_input = vec3(niri_v_coords, 1.0);
+    vec3 size_input = vec3(niri_size, 1.0);
+
+    vec4 color = screen_transition_color(coords_input, size_input);
+
+    color = color * niri_alpha;
+
+#if defined(DEBUG_FLAGS)
+    if (niri_tint == 1.0)
+        color = vec4(0.0, 0.2, 0.0, 0.2) + color * 0.8;
+#endif
+
+    gl_FragColor = color;
+}

--- a/src/render_helpers/shaders/screen_transition_epilogue.frag
+++ b/src/render_helpers/shaders/screen_transition_epilogue.frag
@@ -1,8 +1,11 @@
+
 void main() {
     vec3 coords_input = vec3(niri_v_coords, 1.0);
     vec3 size_input = vec3(niri_size, 1.0);
 
-    vec4 color = screen_transition_color(coords_input, size_input);
+    vec3 coords_tex = niri_geo_to_tex * coords_input;
+
+    vec4 color = screen_transition_color(coords_tex, size_input);
 
     color = color * niri_alpha;
 

--- a/src/render_helpers/shaders/screen_transition_epilogue.frag
+++ b/src/render_helpers/shaders/screen_transition_epilogue.frag
@@ -1,11 +1,9 @@
 
 void main() {
-    vec3 coords_input = vec3(niri_v_coords, 1.0);
-    vec3 size_input = vec3(niri_size, 1.0);
+    vec3 coords_geo = niri_input_to_geo * vec3(niri_v_coords, 1.0);
+    vec3 size_geo = vec3(niri_geo_size, 1.0);
 
-    vec3 coords_tex = niri_geo_to_tex * coords_input;
-
-    vec4 color = screen_transition_color(coords_tex, size_input);
+    vec4 color = screen_transition_color(coords_geo, size_geo);
 
     color = color * niri_alpha;
 

--- a/src/render_helpers/shaders/screen_transition_prelude.frag
+++ b/src/render_helpers/shaders/screen_transition_prelude.frag
@@ -8,6 +8,7 @@ varying vec2 niri_v_coords;
 uniform vec2 niri_size;
 
 uniform sampler2D niri_tex_from;
+uniform mat3 niri_geo_to_tex;
 
 uniform float niri_progress;
 uniform float niri_clamped_progress;

--- a/src/render_helpers/shaders/screen_transition_prelude.frag
+++ b/src/render_helpers/shaders/screen_transition_prelude.frag
@@ -1,0 +1,21 @@
+precision highp float;
+
+#if defined(DEBUG_FLAGS)
+uniform float niri_tint;
+#endif
+
+varying vec2 niri_v_coords;
+uniform vec2 niri_size;
+
+uniform sampler2D niri_tex_from;
+
+uniform float niri_progress;
+uniform float niri_clamped_progress;
+uniform float niri_alpha;
+uniform float niri_scale;
+
+// Mouse position in logical output coordinates (0,0 at top-left).
+uniform vec2 niri_mouse_pos;
+
+// Random seed generated once per transition.
+uniform float niri_random_seed;

--- a/src/render_helpers/shaders/screen_transition_prelude.frag
+++ b/src/render_helpers/shaders/screen_transition_prelude.frag
@@ -7,6 +7,9 @@ uniform float niri_tint;
 varying vec2 niri_v_coords;
 uniform vec2 niri_size;
 
+uniform mat3 niri_input_to_geo;
+uniform vec2 niri_geo_size;
+
 uniform sampler2D niri_tex_from;
 uniform mat3 niri_geo_to_tex;
 

--- a/src/ui/screen_transition.rs
+++ b/src/ui/screen_transition.rs
@@ -1,17 +1,19 @@
+use std::collections::HashMap;
+use std::rc::Rc;
 use std::time::Duration;
 
 use smithay::backend::renderer::element::Kind;
-use smithay::backend::renderer::gles::GlesTexture;
-use smithay::utils::{Scale, Transform};
+use smithay::backend::renderer::gles::{GlesTexture, Uniform};
+use smithay::utils::{Logical, Point, Scale, Transform};
 
 use crate::animation::{Animation, Clock};
 use crate::niri_render_elements;
 use crate::render_helpers::primary_gpu_texture::PrimaryGpuTextureRenderElement;
+use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shader_element::ShaderRenderElement;
-use crate::render_helpers::shaders::{mat3_uniform, ProgramType, Shaders};
-use crate::render_helpers::snapshot::RenderSnapshot;
+use crate::render_helpers::shaders::{ProgramType, Shaders};
 use crate::render_helpers::texture::{TextureBuffer, TextureRenderElement};
-use crate::render_helpers::{render_to_encompassing_texture, RenderTarget};
+use crate::render_helpers::RenderTarget;
 
 pub const DELAY: Duration = Duration::from_millis(250);
 pub const DURATION: Duration = Duration::from_millis(500);
@@ -20,9 +22,7 @@ pub const DURATION: Duration = Duration::from_millis(500);
 pub struct ScreenTransition {
     /// Texture to crossfade from for each render target.
     from_texture: [TextureBuffer<GlesTexture>; 3],
-    /// Monotonic time when to start the crossfade.
-    start_at: Duration,
-    /// The transition animation.
+    delay: Duration,
     anim: Animation,
     /// Random seed for the shader.
     random_seed: f32,
@@ -41,12 +41,13 @@ impl ScreenTransition {
     pub fn new(
         from_texture: [TextureBuffer<GlesTexture>; 3],
         delay: Duration,
-        anim: Animation,
+        config: niri_config::Animation,
         clock: Clock,
     ) -> Self {
+        let anim = Animation::new(clock.clone(), 1., 0., 0., config);
         Self {
             from_texture,
-            start_at: clock.now_unadjusted() + delay,
+            delay,
             anim,
             random_seed: fastrand::f32(),
             clock,
@@ -54,7 +55,7 @@ impl ScreenTransition {
     }
 
     pub fn is_done(&self) -> bool {
-        self.start_at + DURATION <= self.clock.now_unadjusted()
+        self.anim.end_time() <= self.clock.now().saturating_sub(self.delay)
     }
 
     pub fn update_render_elements(&mut self, scale: Scale<f64>, transform: Transform) {
@@ -65,17 +66,19 @@ impl ScreenTransition {
         }
     }
 
-    pub fn render(&self, target: RenderTarget) -> PrimaryGpuTextureRenderElement {
-        // Screen transition ignores animation slowdown.
-        let now = self.clock.now_unadjusted();
+    pub fn render(
+        &self,
+        renderer: &mut impl NiriRenderer,
+        target: RenderTarget,
+        mouse_pos: Option<Point<f64, Logical>>,
+    ) -> ScreenTransitionRenderElement {
+        let now = self.clock.now().saturating_sub(self.delay);
 
-        let alpha = if self.start_at + DURATION <= now {
-            0.
-        } else if self.start_at <= now {
-            1. - (now - self.start_at).as_secs_f32() / DURATION.as_secs_f32()
-        } else {
-            1.
-        };
+        let alpha = self.anim.value_at(now);
+        let clamped_alpha = alpha.clamp(0., 1.);
+
+        let progress = 1. - alpha;
+        let clamped_progress = progress.clamp(0., 1.);
 
         let idx = match target {
             RenderTarget::Output => 0,
@@ -83,13 +86,46 @@ impl ScreenTransition {
             RenderTarget::ScreenCapture => 2,
         };
 
+        let texture_scale = self.from_texture[idx].texture_scale();
+
+        if Shaders::get(renderer)
+            .program(ProgramType::ScreenTransition)
+            .is_some()
+        {
+            let mouse_pos = mouse_pos
+                .map(|pos| [pos.x as f32, pos.y as f32])
+                .unwrap_or([-1., -1.]);
+
+            return ShaderRenderElement::new(
+                ProgramType::ScreenTransition,
+                self.from_texture[idx].logical_size(),
+                None,
+                texture_scale.x as f32,
+                1.,
+                Rc::new([
+                    Uniform::new("niri_progress", progress as f32),
+                    Uniform::new("niri_clamped_progress", clamped_progress as f32),
+                    Uniform::new("niri_mouse_pos", mouse_pos),
+                    Uniform::new("niri_random_seed", self.random_seed),
+                ]),
+                HashMap::from([(
+                    String::from("niri_tex_from"),
+                    self.from_texture[idx].texture().clone(),
+                )]),
+                Kind::Unspecified,
+            )
+            .with_location(Point::from((0., 0.)))
+            .into();
+        }
+
         PrimaryGpuTextureRenderElement(TextureRenderElement::from_texture_buffer(
             self.from_texture[idx].clone(),
             (0., 0.),
-            alpha,
+            clamped_alpha as f32,
             None,
             None,
             Kind::Unspecified,
         ))
+        .into()
     }
 }

--- a/src/ui/screen_transition.rs
+++ b/src/ui/screen_transition.rs
@@ -17,7 +17,6 @@ use crate::render_helpers::texture::{TextureBuffer, TextureRenderElement};
 use crate::render_helpers::RenderTarget;
 
 pub const DELAY: Duration = Duration::from_millis(250);
-pub const DURATION: Duration = Duration::from_millis(500);
 
 #[derive(Debug)]
 pub struct ScreenTransition {
@@ -73,6 +72,9 @@ impl ScreenTransition {
         target: RenderTarget,
         mouse_pos: Option<Point<f64, Logical>>,
     ) -> ScreenTransitionRenderElement {
+        // Animation start_time is set from clock.now(), so we must use clock.now() here
+        // too (not now_unadjusted) to keep the time domain consistent. This means screen
+        // transitions now respect animation slowdown, unlike the original hardcoded crossfade.
         let now = self.clock.now().saturating_sub(self.delay);
 
         let alpha = self.anim.value_at(now);
@@ -97,8 +99,15 @@ impl ScreenTransition {
                 .map(|pos| [pos.x as f32, pos.y as f32])
                 .unwrap_or([-1., -1.]);
 
-            // We need to transform the geometry coordinates to texture coordinates in the shader,
-            // so we calculate a matrix for that here.
+            // For a full-screen transition the element IS the geometry, so input_to_geo
+            // is identity. Shader authors get coords in [0,1] matching the close/open
+            // convention, with geo_size providing the actual output dimensions.
+            let input_to_geo = Mat3::IDENTITY;
+            let logical_size = self.from_texture[idx].logical_size();
+            let geo_size = [logical_size.w as f32, logical_size.h as f32];
+
+            // We need to transform the geometry coordinates to texture coordinates in the
+            // shader, so we calculate a matrix for that here.
             let transform = self.from_texture[idx].texture_transform();
             let size: Size<f64, Logical> = Size::from((1., 1.));
 
@@ -123,6 +132,8 @@ impl ScreenTransition {
                 texture_scale.x as f32,
                 1.,
                 Rc::new([
+                    mat3_uniform("niri_input_to_geo", input_to_geo),
+                    Uniform::new("niri_geo_size", geo_size),
                     mat3_uniform("niri_geo_to_tex", geo_to_tex),
                     Uniform::new("niri_progress", progress as f32),
                     Uniform::new("niri_clamped_progress", clamped_progress as f32),

--- a/src/ui/screen_transition.rs
+++ b/src/ui/screen_transition.rs
@@ -55,7 +55,8 @@ impl ScreenTransition {
     }
 
     pub fn is_done(&self) -> bool {
-        self.anim.end_time() <= self.clock.now().saturating_sub(self.delay)
+        self.anim
+            .is_done_at(self.clock.now().saturating_sub(self.delay))
     }
 
     pub fn update_render_elements(&mut self, scale: Scale<f64>, transform: Transform) {


### PR DESCRIPTION
Intending to implement full animations for the `do-screen-transition` action with custom-shader support.
Relevant discussion: #1620

Also, passes in the cursor position as uniform to the shader unlike the window-open/close/resize shaders.

The use-case is that I wanted more effects for workspace switch while overview is not enabled.

Extending the existing switch animation does not make sense design-wise and this action existed so this felt like a pretty natural workaround.


https://github.com/user-attachments/assets/56020aaf-f52c-41b9-b141-becc02482e0b

