### PR TITLE
[Switch presets] add (no-)wraparound & make cycle-back an OPTION

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -303,12 +303,12 @@ pub enum Action {
     #[knuffel(skip)]
     ResetWindowHeightById(u64),
     SwitchPresetColumnWidth(
-        #[knuffel(property(name = "forwards"))] bool,
-        #[knuffel(property(name = "wrap"))] bool,
+        #[knuffel(property(name = "forwards"), default = true)] bool,
+        #[knuffel(property(name = "wrap"), default = true)] bool,
     ),
     SwitchPresetWindowWidth(
-        #[knuffel(property(name = "forwards"))] bool,
-        #[knuffel(property(name = "wrap"))] bool,
+        #[knuffel(property(name = "forwards"), default = true)] bool,
+        #[knuffel(property(name = "wrap"), default = true)] bool,
     ),
     #[knuffel(skip)]
     SwitchPresetWindowWidthById {
@@ -317,8 +317,8 @@ pub enum Action {
         wrap: bool,
     },
     SwitchPresetWindowHeight(
-        #[knuffel(property(name = "forwards"))] bool,
-        #[knuffel(property(name = "wrap"))] bool,
+        #[knuffel(property(name = "forwards"), default = true)] bool,
+        #[knuffel(property(name = "wrap"), default = true)] bool,
     ),
     #[knuffel(skip)]
     SwitchPresetWindowHeightById {

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -302,27 +302,24 @@ pub enum Action {
     ResetWindowHeight,
     #[knuffel(skip)]
     ResetWindowHeightById(u64),
-    #[knuffel(skip)]
-    SwitchPresetColumnWidth {
-        forwards: bool,
-        wrap: bool,
-    },
-    #[knuffel(skip)]
-    SwitchPresetWindowWidth {
-        forwards: bool,
-        wrap: bool,
-    },
+    SwitchPresetColumnWidth(
+        #[knuffel(property(name = "forwards"))] bool,
+        #[knuffel(property(name = "wrap"))] bool,
+    ),
+    SwitchPresetWindowWidth(
+        #[knuffel(property(name = "forwards"))] bool,
+        #[knuffel(property(name = "wrap"))] bool,
+    ),
     #[knuffel(skip)]
     SwitchPresetWindowWidthById {
         id: u64,
         forwards: bool,
         wrap: bool,
     },
-    #[knuffel(skip)]
-    SwitchPresetWindowHeight {
-        forwards: bool,
-        wrap: bool,
-    },
+    SwitchPresetWindowHeight(
+        #[knuffel(property(name = "forwards"))] bool,
+        #[knuffel(property(name = "wrap"))] bool,
+    ),
     #[knuffel(skip)]
     SwitchPresetWindowHeightById {
         id: u64,
@@ -608,13 +605,13 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::ResetWindowHeight { id: None } => Self::ResetWindowHeight,
             niri_ipc::Action::ResetWindowHeight { id: Some(id) } => Self::ResetWindowHeightById(id),
             niri_ipc::Action::SwitchPresetColumnWidth { forwards, wrap } => {
-                Self::SwitchPresetColumnWidth { forwards, wrap }
+                Self::SwitchPresetColumnWidth(forwards, wrap)
             }
             niri_ipc::Action::SwitchPresetWindowWidth {
                 id: None,
                 forwards,
                 wrap,
-            } => Self::SwitchPresetWindowWidth { forwards, wrap },
+            } => Self::SwitchPresetWindowWidth(forwards, wrap),
             niri_ipc::Action::SwitchPresetWindowWidth {
                 id: Some(id),
                 forwards,
@@ -624,7 +621,7 @@ impl From<niri_ipc::Action> for Action {
                 id: None,
                 forwards,
                 wrap,
-            } => Self::SwitchPresetWindowHeight { forwards, wrap },
+            } => Self::SwitchPresetWindowHeight(forwards, wrap),
             niri_ipc::Action::SwitchPresetWindowHeight {
                 id: Some(id),
                 forwards,

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -302,20 +302,33 @@ pub enum Action {
     ResetWindowHeight,
     #[knuffel(skip)]
     ResetWindowHeightById(u64),
-    SwitchPresetColumnWidth,
-    SwitchPresetColumnWidthBack,
-    SwitchPresetWindowWidth,
-    SwitchPresetWindowWidthBack,
     #[knuffel(skip)]
-    SwitchPresetWindowWidthById(u64),
+    SwitchPresetColumnWidth {
+        forwards: bool,
+        wrap: bool,
+    },
     #[knuffel(skip)]
-    SwitchPresetWindowWidthBackById(u64),
-    SwitchPresetWindowHeight,
-    SwitchPresetWindowHeightBack,
+    SwitchPresetWindowWidth {
+        forwards: bool,
+        wrap: bool,
+    },
     #[knuffel(skip)]
-    SwitchPresetWindowHeightById(u64),
+    SwitchPresetWindowWidthById {
+        id: u64,
+        forwards: bool,
+        wrap: bool,
+    },
     #[knuffel(skip)]
-    SwitchPresetWindowHeightBackById(u64),
+    SwitchPresetWindowHeight {
+        forwards: bool,
+        wrap: bool,
+    },
+    #[knuffel(skip)]
+    SwitchPresetWindowHeightById {
+        id: u64,
+        forwards: bool,
+        wrap: bool,
+    },
     MaximizeColumn,
     MaximizeWindowToEdges,
     #[knuffel(skip)]
@@ -594,30 +607,29 @@ impl From<niri_ipc::Action> for Action {
             } => Self::SetWindowHeightById { id, change },
             niri_ipc::Action::ResetWindowHeight { id: None } => Self::ResetWindowHeight,
             niri_ipc::Action::ResetWindowHeight { id: Some(id) } => Self::ResetWindowHeightById(id),
-            niri_ipc::Action::SwitchPresetColumnWidth {} => Self::SwitchPresetColumnWidth,
-            niri_ipc::Action::SwitchPresetColumnWidthBack {} => Self::SwitchPresetColumnWidthBack,
-            niri_ipc::Action::SwitchPresetWindowWidth { id: None } => Self::SwitchPresetWindowWidth,
-            niri_ipc::Action::SwitchPresetWindowWidthBack { id: None } => {
-                Self::SwitchPresetWindowWidthBack
+            niri_ipc::Action::SwitchPresetColumnWidth { forwards, wrap } => {
+                Self::SwitchPresetColumnWidth { forwards, wrap }
             }
-            niri_ipc::Action::SwitchPresetWindowWidth { id: Some(id) } => {
-                Self::SwitchPresetWindowWidthById(id)
-            }
-            niri_ipc::Action::SwitchPresetWindowWidthBack { id: Some(id) } => {
-                Self::SwitchPresetWindowWidthBackById(id)
-            }
-            niri_ipc::Action::SwitchPresetWindowHeight { id: None } => {
-                Self::SwitchPresetWindowHeight
-            }
-            niri_ipc::Action::SwitchPresetWindowHeightBack { id: None } => {
-                Self::SwitchPresetWindowHeightBack
-            }
-            niri_ipc::Action::SwitchPresetWindowHeight { id: Some(id) } => {
-                Self::SwitchPresetWindowHeightById(id)
-            }
-            niri_ipc::Action::SwitchPresetWindowHeightBack { id: Some(id) } => {
-                Self::SwitchPresetWindowHeightBackById(id)
-            }
+            niri_ipc::Action::SwitchPresetWindowWidth {
+                id: None,
+                forwards,
+                wrap,
+            } => Self::SwitchPresetWindowWidth { forwards, wrap },
+            niri_ipc::Action::SwitchPresetWindowWidth {
+                id: Some(id),
+                forwards,
+                wrap,
+            } => Self::SwitchPresetWindowWidthById { id, forwards, wrap },
+            niri_ipc::Action::SwitchPresetWindowHeight {
+                id: None,
+                forwards,
+                wrap,
+            } => Self::SwitchPresetWindowHeight { forwards, wrap },
+            niri_ipc::Action::SwitchPresetWindowHeight {
+                id: Some(id),
+                forwards,
+                wrap,
+            } => Self::SwitchPresetWindowHeightById { id, forwards, wrap },
             niri_ipc::Action::MaximizeColumn {} => Self::MaximizeColumn,
             niri_ipc::Action::MaximizeWindowToEdges { id: None } => Self::MaximizeWindowToEdges,
             niri_ipc::Action::MaximizeWindowToEdges { id: Some(id) } => {

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -714,10 +714,10 @@ pub enum Action {
     /// Switch between preset column widths.
     SwitchPresetColumnWidth {
         /// If traversing should be in forwards direction
-        #[cfg_attr(feature = "clap", arg(short = 'f', long, action = clap::ArgAction::Set, default_value_t = true))]
+        #[cfg_attr(feature = "clap", arg(short, long, action = clap::ArgAction::Set, default_value_t = true))]
         forwards: bool,
         /// If traversing should wrap around
-        #[cfg_attr(feature = "clap", arg(short = 'w', long, action = clap::ArgAction::Set, default_value_t = true))]
+        #[cfg_attr(feature = "clap", arg(short, long, action = clap::ArgAction::Set, default_value_t = true))]
         wrap: bool,
     },
     /// Switch between preset window widths.
@@ -728,10 +728,10 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         id: Option<u64>,
         /// If traversing should be in forwards direction
-        #[cfg_attr(feature = "clap", arg(short = 'f', long, action = clap::ArgAction::Set, default_value_t = true))]
+        #[cfg_attr(feature = "clap", arg(short, long, action = clap::ArgAction::Set, default_value_t = true))]
         forwards: bool,
         /// If traversing should wrap around
-        #[cfg_attr(feature = "clap", arg(short = 'f', long, action = clap::ArgAction::Set, default_value_t = true))]
+        #[cfg_attr(feature = "clap", arg(short, long, action = clap::ArgAction::Set, default_value_t = true))]
         wrap: bool,
     },
     /// Switch between preset window heights.
@@ -742,10 +742,10 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         id: Option<u64>,
         /// If traversing should be in forwards direction
-        #[cfg_attr(feature = "clap", arg(short = 'f', long, action = clap::ArgAction::Set, default_value_t = true))]
+        #[cfg_attr(feature = "clap", arg(short, long, action = clap::ArgAction::Set, default_value_t = true))]
         forwards: bool,
         /// If traversing should wrap around
-        #[cfg_attr(feature = "clap", arg(short = 'f', long, action = clap::ArgAction::Set, default_value_t = true))]
+        #[cfg_attr(feature = "clap", arg(short, long, action = clap::ArgAction::Set, default_value_t = true))]
         wrap: bool,
     },
     /// Toggle the maximized state of the focused column.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -712,9 +712,14 @@ pub enum Action {
         id: Option<u64>,
     },
     /// Switch between preset column widths.
-    SwitchPresetColumnWidth {},
-    /// Switch between preset column widths backwards.
-    SwitchPresetColumnWidthBack {},
+    SwitchPresetColumnWidth {
+        /// If traversing should be in forwards direction
+        #[cfg_attr(feature = "clap", arg(short = 'f', long, action = clap::ArgAction::Set, default_value_t = true))]
+        forwards: bool,
+        /// If traversing should wrap around
+        #[cfg_attr(feature = "clap", arg(short = 'w', long, action = clap::ArgAction::Set, default_value_t = true))]
+        wrap: bool,
+    },
     /// Switch between preset window widths.
     SwitchPresetWindowWidth {
         /// Id of the window whose width to switch.
@@ -722,14 +727,12 @@ pub enum Action {
         /// If `None`, uses the focused window.
         #[cfg_attr(feature = "clap", arg(long))]
         id: Option<u64>,
-    },
-    /// Switch between preset window widths backwards.
-    SwitchPresetWindowWidthBack {
-        /// Id of the window whose width to switch.
-        ///
-        /// If `None`, uses the focused window.
-        #[cfg_attr(feature = "clap", arg(long))]
-        id: Option<u64>,
+        /// If traversing should be in forwards direction
+        #[cfg_attr(feature = "clap", arg(short = 'f', long, action = clap::ArgAction::Set, default_value_t = true))]
+        forwards: bool,
+        /// If traversing should wrap around
+        #[cfg_attr(feature = "clap", arg(short = 'f', long, action = clap::ArgAction::Set, default_value_t = true))]
+        wrap: bool,
     },
     /// Switch between preset window heights.
     SwitchPresetWindowHeight {
@@ -738,14 +741,12 @@ pub enum Action {
         /// If `None`, uses the focused window.
         #[cfg_attr(feature = "clap", arg(long))]
         id: Option<u64>,
-    },
-    /// Switch between preset window heights backwards.
-    SwitchPresetWindowHeightBack {
-        /// Id of the window whose height to switch.
-        ///
-        /// If `None`, uses the focused window.
-        #[cfg_attr(feature = "clap", arg(long))]
-        id: Option<u64>,
+        /// If traversing should be in forwards direction
+        #[cfg_attr(feature = "clap", arg(short = 'f', long, action = clap::ArgAction::Set, default_value_t = true))]
+        forwards: bool,
+        /// If traversing should wrap around
+        #[cfg_attr(feature = "clap", arg(short = 'f', long, action = clap::ArgAction::Set, default_value_t = true))]
+        wrap: bool,
     },
     /// Toggle the maximized state of the focused column.
     MaximizeColumn {},

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1570,50 +1570,31 @@ impl State {
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
-            Action::SwitchPresetColumnWidth => {
-                self.niri.layout.toggle_width(true);
+            Action::SwitchPresetColumnWidth { forwards, wrap } => {
+                self.niri.layout.toggle_width(forwards, wrap);
             }
-            Action::SwitchPresetColumnWidthBack => {
-                self.niri.layout.toggle_width(false);
+            Action::SwitchPresetWindowWidth { forwards, wrap } => {
+                self.niri.layout.toggle_window_width(None, forwards, wrap);
             }
-            Action::SwitchPresetWindowWidth => {
-                self.niri.layout.toggle_window_width(None, true);
-            }
-            Action::SwitchPresetWindowWidthBack => {
-                self.niri.layout.toggle_window_width(None, false);
-            }
-            Action::SwitchPresetWindowWidthById(id) => {
+            Action::SwitchPresetWindowWidthById { id, forwards, wrap } => {
                 let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
                 let window = window.map(|(_, m)| m.window.clone());
                 if let Some(window) = window {
-                    self.niri.layout.toggle_window_width(Some(&window), true);
+                    self.niri
+                        .layout
+                        .toggle_window_width(Some(&window), forwards, wrap);
                 }
             }
-            Action::SwitchPresetWindowWidthBackById(id) => {
+            Action::SwitchPresetWindowHeight { forwards, wrap } => {
+                self.niri.layout.toggle_window_height(None, forwards, wrap);
+            }
+            Action::SwitchPresetWindowHeightById { id, forwards, wrap } => {
                 let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
                 let window = window.map(|(_, m)| m.window.clone());
                 if let Some(window) = window {
-                    self.niri.layout.toggle_window_width(Some(&window), false);
-                }
-            }
-            Action::SwitchPresetWindowHeight => {
-                self.niri.layout.toggle_window_height(None, true);
-            }
-            Action::SwitchPresetWindowHeightBack => {
-                self.niri.layout.toggle_window_height(None, false);
-            }
-            Action::SwitchPresetWindowHeightById(id) => {
-                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
-                let window = window.map(|(_, m)| m.window.clone());
-                if let Some(window) = window {
-                    self.niri.layout.toggle_window_height(Some(&window), true);
-                }
-            }
-            Action::SwitchPresetWindowHeightBackById(id) => {
-                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
-                let window = window.map(|(_, m)| m.window.clone());
-                if let Some(window) = window {
-                    self.niri.layout.toggle_window_height(Some(&window), false);
+                    self.niri
+                        .layout
+                        .toggle_window_height(Some(&window), forwards, wrap);
                 }
             }
             Action::CenterColumn => {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1570,10 +1570,10 @@ impl State {
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
-            Action::SwitchPresetColumnWidth { forwards, wrap } => {
+            Action::SwitchPresetColumnWidth(forwards, wrap) => {
                 self.niri.layout.toggle_width(forwards, wrap);
             }
-            Action::SwitchPresetWindowWidth { forwards, wrap } => {
+            Action::SwitchPresetWindowWidth(forwards, wrap) => {
                 self.niri.layout.toggle_window_width(None, forwards, wrap);
             }
             Action::SwitchPresetWindowWidthById { id, forwards, wrap } => {
@@ -1585,7 +1585,7 @@ impl State {
                         .toggle_window_width(Some(&window), forwards, wrap);
                 }
             }
-            Action::SwitchPresetWindowHeight { forwards, wrap } => {
+            Action::SwitchPresetWindowHeight(forwards, wrap) => {
                 self.niri.layout.toggle_window_height(None, forwards, wrap);
             }
             Action::SwitchPresetWindowHeightById { id, forwards, wrap } => {

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -16,6 +16,7 @@ use super::{
     ConfigureIntent, InteractiveResizeData, LayoutElement, Options, RemovedTile, SizeFrac,
 };
 use crate::animation::{Animation, Clock};
+use crate::layout::next_preset_idx;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::RenderTarget;
@@ -625,7 +626,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
         }
     }
 
-    pub fn toggle_window_width(&mut self, id: Option<&W::Id>, forwards: bool) {
+    pub fn toggle_window_width(&mut self, id: Option<&W::Id>, forwards: bool, wrap: bool) {
         let Some(id) = id.or(self.active_window_id.as_ref()).cloned() else {
             return;
         };
@@ -636,7 +637,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
         let len = self.options.layout.preset_column_widths.len();
         let tile = &mut self.tiles[idx];
         let preset_idx = if let Some(idx) = tile.floating_preset_width_idx {
-            (idx + if forwards { 1 } else { len - 1 }) % len
+            next_preset_idx(idx, len, forwards, wrap)
         } else {
             let current_window = tile.window_expected_or_current_size().w;
             let current_tile = tile.tile_expected_or_current_size().w;
@@ -686,7 +687,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
         true
     }
 
-    pub fn toggle_window_height(&mut self, id: Option<&W::Id>, forwards: bool) {
+    pub fn toggle_window_height(&mut self, id: Option<&W::Id>, forwards: bool, wrap: bool) {
         let Some(id) = id.or(self.active_window_id.as_ref()).cloned() else {
             return;
         };
@@ -697,7 +698,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
         let len = self.options.layout.preset_window_heights.len();
         let tile = &mut self.tiles[idx];
         let preset_idx = if let Some(idx) = tile.floating_preset_height_idx {
-            (idx + if forwards { 1 } else { len - 1 }) % len
+            next_preset_idx(idx, len, forwards, wrap)
         } else {
             let current_window = tile.window_expected_or_current_size().h;
             let current_tile = tile.tile_expected_or_current_size().h;

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2932,14 +2932,14 @@ impl<W: LayoutElement> Layout<W> {
         self.options = options;
     }
 
-    pub fn toggle_width(&mut self, forwards: bool) {
+    pub fn toggle_width(&mut self, forwards: bool, wrap: bool) {
         let Some(workspace) = self.active_workspace_mut() else {
             return;
         };
-        workspace.toggle_width(forwards);
+        workspace.toggle_width(forwards, wrap);
     }
 
-    pub fn toggle_window_width(&mut self, window: Option<&W::Id>, forwards: bool) {
+    pub fn toggle_window_width(&mut self, window: Option<&W::Id>, forwards: bool, wrap: bool) {
         if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
             if window.is_none() || window == Some(move_.tile.window().id()) {
                 return;
@@ -2959,10 +2959,10 @@ impl<W: LayoutElement> Layout<W> {
         let Some(workspace) = workspace else {
             return;
         };
-        workspace.toggle_window_width(window, forwards);
+        workspace.toggle_window_width(window, forwards, wrap);
     }
 
-    pub fn toggle_window_height(&mut self, window: Option<&W::Id>, forwards: bool) {
+    pub fn toggle_window_height(&mut self, window: Option<&W::Id>, forwards: bool, wrap: bool) {
         if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
             if window.is_none() || window == Some(move_.tile.window().id()) {
                 return;
@@ -2982,7 +2982,7 @@ impl<W: LayoutElement> Layout<W> {
         let Some(workspace) = workspace else {
             return;
         };
-        workspace.toggle_window_height(window, forwards);
+        workspace.toggle_window_height(window, forwards, wrap);
     }
 
     pub fn toggle_full_width(&mut self) {
@@ -4931,5 +4931,14 @@ fn compute_overview_zoom(options: &Options, overview_progress: Option<f64>) -> f
         (1. - p * (1. - zoom)).max(0.0001)
     } else {
         1.
+    }
+}
+
+fn next_preset_idx(idx: usize, len: usize, forwards: bool, wrap: bool) -> usize {
+    match (forwards, wrap) {
+        (true, true) => (idx + 1) % len,
+        (false, true) => (idx + len - 1) % len,
+        (true, false) => usize::min(idx + 1, len - 1),
+        (false, false) => usize::max(1, idx) - 1,
     }
 }

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -18,7 +18,7 @@ use super::workspace::{InteractiveResize, ResolvedSize};
 use super::{ConfigureIntent, HitType, InteractiveResizeData, LayoutElement, Options, RemovedTile};
 use crate::animation::{Animation, Clock};
 use crate::input::swipe_tracker::SwipeTracker;
-use crate::layout::SizingMode;
+use crate::layout::{next_preset_idx, SizingMode};
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::RenderTarget;
@@ -2581,13 +2581,13 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         None
     }
 
-    pub fn toggle_width(&mut self, forwards: bool) {
+    pub fn toggle_width(&mut self, forwards: bool, wrap: bool) {
         if self.columns.is_empty() {
             return;
         }
 
         let col = &mut self.columns[self.active_column_idx];
-        col.toggle_width(None, forwards);
+        col.toggle_width(None, forwards, wrap);
 
         cancel_resize_for_column(&mut self.interactive_resize, col);
     }
@@ -2675,7 +2675,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         cancel_resize_for_column(&mut self.interactive_resize, col);
     }
 
-    pub fn toggle_window_width(&mut self, window: Option<&W::Id>, forwards: bool) {
+    pub fn toggle_window_width(&mut self, window: Option<&W::Id>, forwards: bool, wrap: bool) {
         if self.columns.is_empty() {
             return;
         }
@@ -2694,12 +2694,12 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             (&mut self.columns[self.active_column_idx], None)
         };
 
-        col.toggle_width(tile_idx, forwards);
+        col.toggle_width(tile_idx, forwards, wrap);
 
         cancel_resize_for_column(&mut self.interactive_resize, col);
     }
 
-    pub fn toggle_window_height(&mut self, window: Option<&W::Id>, forwards: bool) {
+    pub fn toggle_window_height(&mut self, window: Option<&W::Id>, forwards: bool, wrap: bool) {
         if self.columns.is_empty() {
             return;
         }
@@ -2718,7 +2718,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             (&mut self.columns[self.active_column_idx], None)
         };
 
-        col.toggle_window_height(tile_idx, forwards);
+        col.toggle_window_height(tile_idx, forwards, wrap);
 
         cancel_resize_for_column(&mut self.interactive_resize, col);
     }
@@ -4791,7 +4791,7 @@ impl<W: LayoutElement> Column<W> {
         true
     }
 
-    fn toggle_width(&mut self, tile_idx: Option<usize>, forwards: bool) {
+    fn toggle_width(&mut self, tile_idx: Option<usize>, forwards: bool, wrap: bool) {
         let tile_idx = tile_idx.unwrap_or(self.active_tile_idx);
 
         let preset_idx = if self.is_full_width || self.is_pending_maximized {
@@ -4802,7 +4802,7 @@ impl<W: LayoutElement> Column<W> {
 
         let len = self.options.layout.preset_column_widths.len();
         let preset_idx = if let Some(idx) = preset_idx {
-            (idx + if forwards { 1 } else { len - 1 }) % len
+            next_preset_idx(idx, len, forwards, wrap)
         } else {
             let tile = &self.tiles[tile_idx];
             let current_window = tile.window_expected_or_current_size().w;
@@ -5003,7 +5003,7 @@ impl<W: LayoutElement> Column<W> {
         self.update_tile_sizes(true);
     }
 
-    fn toggle_window_height(&mut self, tile_idx: Option<usize>, forwards: bool) {
+    fn toggle_window_height(&mut self, tile_idx: Option<usize>, forwards: bool, wrap: bool) {
         let tile_idx = tile_idx.unwrap_or(self.active_tile_idx);
 
         // Start by converting all heights to automatic, since only one window in the column can be
@@ -5018,7 +5018,7 @@ impl<W: LayoutElement> Column<W> {
         let len = self.options.layout.preset_window_heights.len();
         let preset_idx = match self.data[tile_idx].height {
             WindowHeight::Preset(idx) if !self.is_pending_maximized => {
-                (idx + if forwards { 1 } else { len - 1 }) % len
+                next_preset_idx(idx, len, forwards, wrap)
             }
             _ => {
                 let current = self.data[tile_idx].size.h;

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -566,23 +566,21 @@ enum Op {
         target_ws_idx: Option<usize>,
         activate: bool,
     },
-    SwitchPresetColumnWidth,
-    SwitchPresetColumnWidthBack,
+    SwitchPresetColumnWidth {
+        forwards: bool,
+        wrap: bool,
+    },
     SwitchPresetWindowWidth {
         #[proptest(strategy = "proptest::option::of(1..=5usize)")]
         id: Option<usize>,
-    },
-    SwitchPresetWindowWidthBack {
-        #[proptest(strategy = "proptest::option::of(1..=5usize)")]
-        id: Option<usize>,
+        forwards: bool,
+        wrap: bool,
     },
     SwitchPresetWindowHeight {
         #[proptest(strategy = "proptest::option::of(1..=5usize)")]
         id: Option<usize>,
-    },
-    SwitchPresetWindowHeightBack {
-        #[proptest(strategy = "proptest::option::of(1..=5usize)")]
-        id: Option<usize>,
+        forwards: bool,
+        wrap: bool,
     },
     MaximizeColumn,
     MaximizeWindowToEdges {
@@ -1298,23 +1296,14 @@ impl Op {
 
                 layout.move_workspace_to_output_by_id(old_idx, Some(old_output), &output);
             }
-            Op::SwitchPresetColumnWidth => layout.toggle_width(true),
-            Op::SwitchPresetColumnWidthBack => layout.toggle_width(false),
-            Op::SwitchPresetWindowWidth { id } => {
+            Op::SwitchPresetColumnWidth { forwards, wrap } => layout.toggle_width(forwards, wrap),
+            Op::SwitchPresetWindowWidth { id, forwards, wrap } => {
                 let id = id.filter(|id| layout.has_window(id));
-                layout.toggle_window_width(id.as_ref(), true);
+                layout.toggle_window_width(id.as_ref(), forwards, wrap);
             }
-            Op::SwitchPresetWindowWidthBack { id } => {
+            Op::SwitchPresetWindowHeight { id, forwards, wrap } => {
                 let id = id.filter(|id| layout.has_window(id));
-                layout.toggle_window_width(id.as_ref(), false);
-            }
-            Op::SwitchPresetWindowHeight { id } => {
-                let id = id.filter(|id| layout.has_window(id));
-                layout.toggle_window_height(id.as_ref(), true);
-            }
-            Op::SwitchPresetWindowHeightBack { id } => {
-                let id = id.filter(|id| layout.has_window(id));
-                layout.toggle_window_height(id.as_ref(), false);
+                layout.toggle_window_height(id.as_ref(), forwards, wrap);
             }
             Op::MaximizeColumn => layout.toggle_full_width(),
             Op::MaximizeWindowToEdges { id } => {
@@ -2416,8 +2405,11 @@ fn preset_height_change_removes_preset() {
             params: TestWindowParams::new(2),
         },
         Op::ConsumeOrExpelWindowLeft { id: None },
-        Op::SwitchPresetWindowHeight { id: None },
-        Op::SwitchPresetWindowHeight { id: None },
+        Op::SwitchPresetWindowHeight {
+            id: None,
+            forwards: true,
+            wrap: true,
+        },
     ];
     for op in ops {
         op.apply(&mut layout);
@@ -3339,7 +3331,10 @@ fn preset_column_width_fixed_correct_with_border() {
         Op::AddWindow {
             params: TestWindowParams::new(0),
         },
-        Op::SwitchPresetColumnWidth,
+        Op::SwitchPresetColumnWidth {
+            forwards: true,
+            wrap: true,
+        },
     ];
 
     let options = Options {
@@ -3374,7 +3369,7 @@ fn preset_column_width_fixed_correct_with_border() {
     assert_eq!(win.requested_size().unwrap().w, 490);
 
     // However, preset fixed width will still work correctly.
-    layout.toggle_width(true);
+    layout.toggle_width(true, true);
     let win = layout.windows().next().unwrap().1;
     assert_eq!(win.requested_size().unwrap().w, 500);
 }
@@ -3386,12 +3381,18 @@ fn preset_column_width_reset_after_set_width() {
         Op::AddWindow {
             params: TestWindowParams::new(0),
         },
-        Op::SwitchPresetColumnWidth,
+        Op::SwitchPresetColumnWidth {
+            forwards: true,
+            wrap: true,
+        },
         Op::SetWindowWidth {
             id: None,
             change: SizeChange::AdjustFixed(-10),
         },
-        Op::SwitchPresetColumnWidth,
+        Op::SwitchPresetColumnWidth {
+            forwards: true,
+            wrap: true,
+        },
     ];
 
     let options = Options {
@@ -3640,7 +3641,11 @@ fn tabs_with_different_border() {
                 ..TestWindowParams::new(2)
             },
         },
-        Op::SwitchPresetWindowHeight { id: None },
+        Op::SwitchPresetWindowHeight {
+            id: None,
+            forwards: true,
+            wrap: true,
+        },
         Op::ToggleColumnTabbedDisplay,
         Op::AddWindow {
             params: TestWindowParams::new(3),

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1173,11 +1173,11 @@ impl<W: LayoutElement> Workspace<W> {
         self.scrolling.center_visible_columns();
     }
 
-    pub fn toggle_width(&mut self, forwards: bool) {
+    pub fn toggle_width(&mut self, forwards: bool, wrap: bool) {
         if self.floating_is_active.get() {
-            self.floating.toggle_window_width(None, forwards);
+            self.floating.toggle_window_width(None, forwards, wrap);
         } else {
-            self.scrolling.toggle_width(forwards);
+            self.scrolling.toggle_width(forwards, wrap);
         }
     }
 
@@ -1227,23 +1227,23 @@ impl<W: LayoutElement> Workspace<W> {
         self.scrolling.reset_window_height(window);
     }
 
-    pub fn toggle_window_width(&mut self, window: Option<&W::Id>, forwards: bool) {
+    pub fn toggle_window_width(&mut self, window: Option<&W::Id>, forwards: bool, wrap: bool) {
         if window.map_or(self.floating_is_active.get(), |id| {
             self.floating.has_window(id)
         }) {
-            self.floating.toggle_window_width(window, forwards);
+            self.floating.toggle_window_width(window, forwards, wrap);
         } else {
-            self.scrolling.toggle_window_width(window, forwards);
+            self.scrolling.toggle_window_width(window, forwards, wrap);
         }
     }
 
-    pub fn toggle_window_height(&mut self, window: Option<&W::Id>, forwards: bool) {
+    pub fn toggle_window_height(&mut self, window: Option<&W::Id>, forwards: bool, wrap: bool) {
         if window.map_or(self.floating_is_active.get(), |id| {
             self.floating.has_window(id)
         }) {
-            self.floating.toggle_window_height(window, forwards);
+            self.floating.toggle_window_height(window, forwards, wrap);
         } else {
-            self.scrolling.toggle_window_height(window, forwards);
+            self.scrolling.toggle_window_height(window, forwards, wrap);
         }
     }
 

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -251,7 +251,10 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
     }
 
     actions.extend(&[
-        &Action::SwitchPresetColumnWidth,
+        &Action::SwitchPresetColumnWidth {
+            forwards: true,
+            wrap: true,
+        },
         &Action::MaximizeColumn,
         &Action::ConsumeOrExpelWindowLeft,
         &Action::ConsumeOrExpelWindowRight,
@@ -470,7 +473,10 @@ fn action_name(action: &Action) -> String {
         Action::MoveColumnToWorkspaceUp(_) => String::from("Move Column to Workspace Up"),
         Action::MoveWindowToWorkspaceDown(_) => String::from("Move Window to Workspace Down"),
         Action::MoveWindowToWorkspaceUp(_) => String::from("Move Window to Workspace Up"),
-        Action::SwitchPresetColumnWidth => String::from("Switch Preset Column Widths"),
+        Action::SwitchPresetColumnWidth {
+            forwards: true,
+            wrap: true,
+        } => String::from("Switch Preset Column Widths"),
         Action::MaximizeColumn => String::from("Maximize Column"),
         Action::ConsumeOrExpelWindowLeft => String::from("Consume or Expel Window Left"),
         Action::ConsumeOrExpelWindowRight => String::from("Consume or Expel Window Right"),

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -251,10 +251,7 @@ fn collect_actions(config: &Config) -> Vec<&Action> {
     }
 
     actions.extend(&[
-        &Action::SwitchPresetColumnWidth {
-            forwards: true,
-            wrap: true,
-        },
+        &Action::SwitchPresetColumnWidth(true, true),
         &Action::MaximizeColumn,
         &Action::ConsumeOrExpelWindowLeft,
         &Action::ConsumeOrExpelWindowRight,
@@ -473,10 +470,7 @@ fn action_name(action: &Action) -> String {
         Action::MoveColumnToWorkspaceUp(_) => String::from("Move Column to Workspace Up"),
         Action::MoveWindowToWorkspaceDown(_) => String::from("Move Window to Workspace Down"),
         Action::MoveWindowToWorkspaceUp(_) => String::from("Move Window to Workspace Up"),
-        Action::SwitchPresetColumnWidth {
-            forwards: true,
-            wrap: true,
-        } => String::from("Switch Preset Column Widths"),
+        Action::SwitchPresetColumnWidth(true, true) => String::from("Switch Preset Column Widths"),
         Action::MaximizeColumn => String::from("Maximize Column"),
         Action::ConsumeOrExpelWindowLeft => String::from("Consume or Expel Window Left"),
         Action::ConsumeOrExpelWindowRight => String::from("Consume or Expel Window Right"),


### PR DESCRIPTION
Improves #1670 and adds a no-wraparound option which desire was mentioned at couple of places,
like in #1000 and #1367.

I didn't see the need to add tests, so if someone wants to contribute in that regard, please do so.