### PR TITLE
Add spawn-sh support to switch-events

### DIFF
--- a/docs/wiki/Configuration:-Switch-Events.md
+++ b/docs/wiki/Configuration:-Switch-Events.md
@@ -10,13 +10,13 @@ Here are all the events that you can bind at a glance:
 switch-events {
     lid-close { spawn "notify-send" "The laptop lid is closed!"; }
     lid-open { spawn "notify-send" "The laptop lid is open!"; }
-    tablet-mode-on { spawn "bash" "-c" "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true"; }
-    tablet-mode-off { spawn "bash" "-c" "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false"; }
+    tablet-mode-on { spawn-sh "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true"; }
+    tablet-mode-off { spawn-sh "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false"; }
 }
 ```
 
 The syntax is similar to key bindings.
-Currently, only the [`spawn` action](./Configuration:-Key-Bindings.md#spawn) are supported.
+The [`spawn`](./Configuration:-Key-Bindings.md#spawn) and [`spawn-sh`](./Configuration:-Key-Bindings.md#spawn-sh) actions are supported.
 
 > [!NOTE]
 > In contrast to key bindings, switch event bindings are *always* executed, even when the session is locked.
@@ -44,7 +44,7 @@ In tablet mode, the keyboard and mouse are usually inaccessible, so you can use 
 
 ```kdl
 switch-events {
-    tablet-mode-on { spawn "bash" "-c" "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true"; }
-    tablet-mode-off { spawn "bash" "-c" "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false"; }
+    tablet-mode-on { spawn-sh "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true"; }
+    tablet-mode-off { spawn-sh "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false"; }
 }
 ```

--- a/docs/wiki/Configuration:-Switch-Events.md
+++ b/docs/wiki/Configuration:-Switch-Events.md
@@ -16,7 +16,7 @@ switch-events {
 ```
 
 The syntax is similar to key bindings.
-The [`spawn`](./Configuration:-Key-Bindings.md#spawn) and [`spawn-sh`](./Configuration:-Key-Bindings.md#spawn-sh) actions are supported.
+The [`spawn`](./Configuration:-Key-Bindings.md#spawn) and [`spawn-sh`](./Configuration:-Key-Bindings.md#spawn-sh) <sup>Since: next release</sup> actions are supported.
 
 > [!NOTE]
 > In contrast to key bindings, switch event bindings are *always* executed, even when the session is locked.

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -13,7 +13,7 @@ use smithay::input::keyboard::xkb::{keysym_from_name, KEYSYM_CASE_INSENSITIVE, K
 use smithay::input::keyboard::Keysym;
 
 use crate::recent_windows::{MruDirection, MruFilter, MruScope};
-use crate::utils::{expect_only_children, MergeWith};
+use crate::utils::{expect_only_children, parse_arg_node, MergeWith};
 
 #[derive(Debug, Default, PartialEq)]
 pub struct Binds(pub Vec<Bind>);
@@ -90,10 +90,72 @@ impl MergeWith<SwitchBinds> for SwitchBinds {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SwitchAction {
-    #[knuffel(child, unwrap(arguments))]
-    pub spawn: Vec<String>,
+    pub spawn: Option<Vec<String>>,
+    pub spawn_sh: Option<String>,
+}
+
+impl<S: knuffel::traits::ErrorSpan> knuffel::Decode<S> for SwitchAction {
+    fn decode_node(
+        node: &knuffel::ast::SpannedNode<S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        expect_only_children(node, ctx);
+
+        let mut spawn: Option<Vec<String>> = None;
+        let mut spawn_sh: Option<String> = None;
+
+        for child in node.children() {
+            match &**child.node_name {
+                "spawn" => {
+                    if spawn.is_some() || spawn_sh.is_some() {
+                        ctx.emit_error(DecodeError::unexpected(
+                            child,
+                            "node",
+                            "only one of `spawn` or `spawn-sh` is allowed",
+                        ));
+                        continue;
+                    }
+                    let mut args: Vec<String> = Vec::new();
+                    for arg in child.arguments.iter() {
+                        match knuffel::traits::DecodeScalar::decode(arg, ctx) {
+                            Ok(v) => args.push(v),
+                            Err(e) => ctx.emit_error(e),
+                        }
+                    }
+                    spawn = Some(args);
+                }
+                "spawn-sh" => {
+                    if spawn_sh.is_some() || spawn.is_some() {
+                        ctx.emit_error(DecodeError::unexpected(
+                            child,
+                            "node",
+                            "only one of `spawn` or `spawn-sh` is allowed",
+                        ));
+                        continue;
+                    }
+                    match parse_arg_node("command", child, ctx) {
+                        Ok(cmd) => spawn_sh = Some(cmd),
+                        Err(e) => ctx.emit_error(e),
+                    }
+                }
+                name => {
+                    ctx.emit_error(DecodeError::unexpected(
+                        child,
+                        "node",
+                        format!("unexpected node `{}`", name.escape_default()),
+                    ));
+                }
+            }
+        }
+
+        if spawn.is_none() && spawn_sh.is_none() {
+            ctx.emit_error(DecodeError::missing(node, "expected `spawn` or `spawn-sh`"));
+        }
+
+        Ok(SwitchAction { spawn, spawn_sh })
+    }
 }
 
 // Remember to add new actions to the CLI enum too.

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -13,7 +13,7 @@ use smithay::input::keyboard::xkb::{keysym_from_name, KEYSYM_CASE_INSENSITIVE, K
 use smithay::input::keyboard::Keysym;
 
 use crate::recent_windows::{MruDirection, MruFilter, MruScope};
-use crate::utils::{expect_only_children, parse_arg_node, MergeWith};
+use crate::utils::{expect_only_children, MergeWith};
 
 #[derive(Debug, Default, PartialEq)]
 pub struct Binds(pub Vec<Bind>);
@@ -92,8 +92,7 @@ impl MergeWith<SwitchBinds> for SwitchBinds {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SwitchAction {
-    pub spawn: Option<Vec<String>>,
-    pub spawn_sh: Option<String>,
+    pub action: Action,
 }
 
 impl<S: knuffel::traits::ErrorSpan> knuffel::Decode<S> for SwitchAction {
@@ -103,58 +102,40 @@ impl<S: knuffel::traits::ErrorSpan> knuffel::Decode<S> for SwitchAction {
     ) -> Result<Self, DecodeError<S>> {
         expect_only_children(node, ctx);
 
-        let mut spawn: Option<Vec<String>> = None;
-        let mut spawn_sh: Option<String> = None;
+        let mut action: Option<Action> = None;
 
         for child in node.children() {
-            match &**child.node_name {
-                "spawn" => {
-                    if spawn.is_some() || spawn_sh.is_some() {
+            if action.is_some() {
+                ctx.emit_error(DecodeError::unexpected(
+                    child,
+                    "node",
+                    "only one action is allowed per switch event",
+                ));
+                continue;
+            }
+            match Action::decode_node(child, ctx) {
+                Ok(a) => {
+                    if matches!(a, Action::Spawn(_) | Action::SpawnSh(_)) {
+                        action = Some(a);
+                    } else {
                         ctx.emit_error(DecodeError::unexpected(
                             child,
                             "node",
-                            "only one of `spawn` or `spawn-sh` is allowed",
+                            "only `spawn` or `spawn-sh` are supported for switch events",
                         ));
-                        continue;
-                    }
-                    let mut args: Vec<String> = Vec::new();
-                    for arg in child.arguments.iter() {
-                        match knuffel::traits::DecodeScalar::decode(arg, ctx) {
-                            Ok(v) => args.push(v),
-                            Err(e) => ctx.emit_error(e),
-                        }
-                    }
-                    spawn = Some(args);
-                }
-                "spawn-sh" => {
-                    if spawn_sh.is_some() || spawn.is_some() {
-                        ctx.emit_error(DecodeError::unexpected(
-                            child,
-                            "node",
-                            "only one of `spawn` or `spawn-sh` is allowed",
-                        ));
-                        continue;
-                    }
-                    match parse_arg_node("command", child, ctx) {
-                        Ok(cmd) => spawn_sh = Some(cmd),
-                        Err(e) => ctx.emit_error(e),
                     }
                 }
-                name => {
-                    ctx.emit_error(DecodeError::unexpected(
-                        child,
-                        "node",
-                        format!("unexpected node `{}`", name.escape_default()),
-                    ));
-                }
+                Err(e) => ctx.emit_error(e),
             }
         }
 
-        if spawn.is_none() && spawn_sh.is_none() {
+        if action.is_none() {
             ctx.emit_error(DecodeError::missing(node, "expected `spawn` or `spawn-sh`"));
         }
 
-        Ok(SwitchAction { spawn, spawn_sh })
+        Ok(SwitchAction {
+            action: action.unwrap_or(Action::Spawn(vec![])),
+        })
     }
 }
 

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -129,13 +129,10 @@ impl<S: knuffel::traits::ErrorSpan> knuffel::Decode<S> for SwitchAction {
             }
         }
 
-        if action.is_none() {
-            ctx.emit_error(DecodeError::missing(node, "expected `spawn` or `spawn-sh`"));
+        match action {
+            Some(action) => Ok(SwitchAction { action }),
+            None => Err(DecodeError::missing(node, "expected `spawn` or `spawn-sh`")),
         }
-
-        Ok(SwitchAction {
-            action: action.unwrap_or(Action::Spawn(vec![])),
-        })
     }
 }
 

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -947,14 +947,7 @@ where
         };
 
         if let Some(child) = children.next() {
-            for unwanted_child in children {
-                ctx.emit_error(DecodeError::unexpected(
-                    unwanted_child,
-                    "node",
-                    "only one action is allowed per keybind",
-                ));
-            }
-            match Action::decode_node(child, ctx) {
+            let action = match Action::decode_node(child, ctx) {
                 Ok(action) => {
                     if !matches!(action, Action::Spawn(_) | Action::SpawnSh(_)) {
                         if let Some(node) = allow_when_locked_node {
@@ -986,7 +979,15 @@ where
                     ctx.emit_error(e);
                     Ok(dummy)
                 }
+            };
+            for unwanted_child in children {
+                ctx.emit_error(DecodeError::unexpected(
+                    unwanted_child,
+                    "node",
+                    "only one action is allowed per keybind",
+                ));
             }
+            action
         } else {
             ctx.emit_error(DecodeError::missing(
                 node,

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -102,36 +102,41 @@ impl<S: knuffel::traits::ErrorSpan> knuffel::Decode<S> for SwitchAction {
     ) -> Result<Self, DecodeError<S>> {
         expect_only_children(node, ctx);
 
-        let mut action: Option<Action> = None;
+        let dummy = SwitchAction {
+            action: Action::Spawn(vec![]),
+        };
 
-        for child in node.children() {
-            if action.is_some() {
+        let mut children = node.children();
+
+        if let Some(child) = children.next() {
+            let action = match &**child.node_name {
+                "spawn" | "spawn-sh" => match Action::decode_node(child, ctx) {
+                    Ok(a) => Ok(SwitchAction { action: a }),
+                    Err(e) => {
+                        ctx.emit_error(e);
+                        Ok(dummy)
+                    }
+                },
+                _ => {
+                    ctx.emit_error(DecodeError::unexpected(
+                        child,
+                        "node",
+                        "expected `spawn` or `spawn-sh`",
+                    ));
+                    Ok(dummy)
+                }
+            };
+            for unwanted_child in children {
                 ctx.emit_error(DecodeError::unexpected(
-                    child,
+                    unwanted_child,
                     "node",
                     "only one action is allowed per switch event",
                 ));
-                continue;
             }
-            match Action::decode_node(child, ctx) {
-                Ok(a) => {
-                    if matches!(a, Action::Spawn(_) | Action::SpawnSh(_)) {
-                        action = Some(a);
-                    } else {
-                        ctx.emit_error(DecodeError::unexpected(
-                            child,
-                            "node",
-                            "only `spawn` or `spawn-sh` are supported for switch events",
-                        ));
-                    }
-                }
-                Err(e) => ctx.emit_error(e),
-            }
-        }
-
-        match action {
-            Some(action) => Ok(SwitchAction { action }),
-            None => Err(DecodeError::missing(node, "expected `spawn` or `spawn-sh`")),
+            action
+        } else {
+            ctx.emit_error(DecodeError::missing(node, "expected `spawn` or `spawn-sh`"));
+            Ok(dummy)
         }
     }
 }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2158,20 +2158,26 @@ mod tests {
                 lid_close: None,
                 tablet_mode_on: Some(
                     SwitchAction {
-                        spawn: [
-                            "bash",
-                            "-c",
-                            "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true",
-                        ],
+                        spawn: Some(
+                            [
+                                "bash",
+                                "-c",
+                                "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true",
+                            ],
+                        ),
+                        spawn_sh: None,
                     },
                 ),
                 tablet_mode_off: Some(
                     SwitchAction {
-                        spawn: [
-                            "bash",
-                            "-c",
-                            "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false",
-                        ],
+                        spawn: Some(
+                            [
+                                "bash",
+                                "-c",
+                                "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false",
+                            ],
+                        ),
+                        spawn_sh: None,
                     },
                 ),
             },
@@ -2404,5 +2410,102 @@ mod tests {
         +                0.66667,
         "#,
         );
+    }
+
+    #[test]
+    fn switch_events_spawn() {
+        let config = do_parse(
+            r#"
+            switch-events {
+                lid-open { spawn "notify-send" "lid open"; }
+                lid-close { spawn "notify-send" "lid close"; }
+                tablet-mode-on { spawn "notify-send" "tablet on"; }
+                tablet-mode-off { spawn "notify-send" "tablet off"; }
+            }
+            "#,
+        );
+        assert_eq!(
+            config.switch_events,
+            SwitchBinds {
+                lid_open: Some(SwitchAction {
+                    spawn: Some(vec!["notify-send".to_owned(), "lid open".to_owned()]),
+                    spawn_sh: None,
+                }),
+                lid_close: Some(SwitchAction {
+                    spawn: Some(vec!["notify-send".to_owned(), "lid close".to_owned()]),
+                    spawn_sh: None,
+                }),
+                tablet_mode_on: Some(SwitchAction {
+                    spawn: Some(vec!["notify-send".to_owned(), "tablet on".to_owned()]),
+                    spawn_sh: None,
+                }),
+                tablet_mode_off: Some(SwitchAction {
+                    spawn: Some(vec!["notify-send".to_owned(), "tablet off".to_owned()]),
+                    spawn_sh: None,
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn switch_events_spawn_sh() {
+        let config = do_parse(
+            r#"
+            switch-events {
+                lid-open { spawn-sh "echo open"; }
+                lid-close { spawn-sh "echo close"; }
+                tablet-mode-on { spawn-sh "echo tablet on"; }
+                tablet-mode-off { spawn-sh "echo tablet off"; }
+            }
+            "#,
+        );
+        assert_eq!(
+            config.switch_events,
+            SwitchBinds {
+                lid_open: Some(SwitchAction {
+                    spawn: None,
+                    spawn_sh: Some("echo open".to_owned()),
+                }),
+                lid_close: Some(SwitchAction {
+                    spawn: None,
+                    spawn_sh: Some("echo close".to_owned()),
+                }),
+                tablet_mode_on: Some(SwitchAction {
+                    spawn: None,
+                    spawn_sh: Some("echo tablet on".to_owned()),
+                }),
+                tablet_mode_off: Some(SwitchAction {
+                    spawn: None,
+                    spawn_sh: Some("echo tablet off".to_owned()),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn switch_events_empty_block_is_error() {
+        assert!(Config::parse_mem(
+            r#"
+            switch-events {
+                lid-close { }
+            }
+            "#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn switch_events_both_spawn_and_spawn_sh_is_error() {
+        assert!(Config::parse_mem(
+            r#"
+            switch-events {
+                lid-close {
+                    spawn "foo"
+                    spawn-sh "bar"
+                }
+            }
+            "#,
+        )
+        .is_err());
     }
 }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2158,26 +2158,24 @@ mod tests {
                 lid_close: None,
                 tablet_mode_on: Some(
                     SwitchAction {
-                        spawn: Some(
+                        action: Spawn(
                             [
                                 "bash",
                                 "-c",
                                 "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true",
                             ],
                         ),
-                        spawn_sh: None,
                     },
                 ),
                 tablet_mode_off: Some(
                     SwitchAction {
-                        spawn: Some(
+                        action: Spawn(
                             [
                                 "bash",
                                 "-c",
                                 "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled false",
                             ],
                         ),
-                        spawn_sh: None,
                     },
                 ),
             },
@@ -2428,20 +2426,16 @@ mod tests {
             config.switch_events,
             SwitchBinds {
                 lid_open: Some(SwitchAction {
-                    spawn: Some(vec!["notify-send".to_owned(), "lid open".to_owned()]),
-                    spawn_sh: None,
+                    action: Action::Spawn(vec!["notify-send".to_owned(), "lid open".to_owned()]),
                 }),
                 lid_close: Some(SwitchAction {
-                    spawn: Some(vec!["notify-send".to_owned(), "lid close".to_owned()]),
-                    spawn_sh: None,
+                    action: Action::Spawn(vec!["notify-send".to_owned(), "lid close".to_owned()]),
                 }),
                 tablet_mode_on: Some(SwitchAction {
-                    spawn: Some(vec!["notify-send".to_owned(), "tablet on".to_owned()]),
-                    spawn_sh: None,
+                    action: Action::Spawn(vec!["notify-send".to_owned(), "tablet on".to_owned()]),
                 }),
                 tablet_mode_off: Some(SwitchAction {
-                    spawn: Some(vec!["notify-send".to_owned(), "tablet off".to_owned()]),
-                    spawn_sh: None,
+                    action: Action::Spawn(vec!["notify-send".to_owned(), "tablet off".to_owned()]),
                 }),
             }
         );
@@ -2463,20 +2457,16 @@ mod tests {
             config.switch_events,
             SwitchBinds {
                 lid_open: Some(SwitchAction {
-                    spawn: None,
-                    spawn_sh: Some("echo open".to_owned()),
+                    action: Action::SpawnSh("echo open".to_owned()),
                 }),
                 lid_close: Some(SwitchAction {
-                    spawn: None,
-                    spawn_sh: Some("echo close".to_owned()),
+                    action: Action::SpawnSh("echo close".to_owned()),
                 }),
                 tablet_mode_on: Some(SwitchAction {
-                    spawn: None,
-                    spawn_sh: Some("echo tablet on".to_owned()),
+                    action: Action::SpawnSh("echo tablet on".to_owned()),
                 }),
                 tablet_mode_off: Some(SwitchAction {
-                    spawn: None,
-                    spawn_sh: Some("echo tablet off".to_owned()),
+                    action: Action::SpawnSh("echo tablet off".to_owned()),
                 }),
             }
         );

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2498,4 +2498,60 @@ mod tests {
         )
         .is_err());
     }
+
+    #[test]
+    fn switch_events_spawn_sh_no_args_is_error() {
+        assert!(Config::parse_mem(
+            r#"
+            switch-events {
+                lid-close {
+                    spawn-sh
+                }
+            }
+            "#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn switch_events_spawn_sh_multiple_args_is_error() {
+        assert!(Config::parse_mem(
+            r#"
+            switch-events {
+                lid-close {
+                    spawn-sh "foo" "bar"
+                }
+            }
+            "#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn switch_events_unknown_action_is_error() {
+        assert!(Config::parse_mem(
+            r#"
+            switch-events {
+                lid-close {
+                    spawn-shh "notify-send 'Lid closed'"
+                }
+            }
+            "#,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn switch_events_disallowed_action_is_error() {
+        assert!(Config::parse_mem(
+            r#"
+            switch-events {
+                lid-close {
+                    close-window
+                }
+            }
+            "#,
+        )
+        .is_err());
+    }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4478,15 +4478,7 @@ fn find_configured_switch_action(
         (Switch::TabletMode, SwitchState::On) => &bindings.tablet_mode_on,
         _ => unreachable!(),
     };
-    switch_action.as_ref().map(|switch_action| {
-        if let Some(command) = &switch_action.spawn_sh {
-            Action::SpawnSh(command.clone())
-        } else if let Some(args) = &switch_action.spawn {
-            Action::Spawn(args.clone())
-        } else {
-            unreachable!("SwitchAction must have spawn or spawn-sh set")
-        }
-    })
+    switch_action.as_ref().map(|sa| sa.action.clone())
 }
 
 fn modifiers_from_state(mods: ModifiersState) -> Modifiers {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4478,9 +4478,15 @@ fn find_configured_switch_action(
         (Switch::TabletMode, SwitchState::On) => &bindings.tablet_mode_on,
         _ => unreachable!(),
     };
-    switch_action
-        .as_ref()
-        .map(|switch_action| Action::Spawn(switch_action.spawn.clone()))
+    switch_action.as_ref().map(|switch_action| {
+        if let Some(command) = &switch_action.spawn_sh {
+            Action::SpawnSh(command.clone())
+        } else if let Some(args) = &switch_action.spawn {
+            Action::Spawn(args.clone())
+        } else {
+            unreachable!("SwitchAction must have spawn or spawn-sh set")
+        }
+    })
 }
 
 fn modifiers_from_state(mods: ModifiersState) -> Modifiers {


### PR DESCRIPTION
Inspired by https://github.com/niri-wm/niri/issues/3605

Adds `spawn-sh` as an alternative to `spawn` in `switch-events` blocks. Exactly one of the two must be specified - empty blocks and using both together are parse errors.

I’m not very familiar with Rust, but I tried my best to follow the existing code style. Happy to make changes if anything looks off.