### PR TITLE
Add cgroup window rule matcher

### DIFF
--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -30,6 +30,7 @@ Here are all matchers and properties that a window rule could have:
 window-rule {
     match title="Firefox"
     match app-id="Alacritty"
+    match cgroup="browsing"
     match is-active=true
     match is-focused=false
     match is-active-in-column=true
@@ -183,6 +184,28 @@ You can find the title and the app ID of a window by running `niri msg pick-wind
 >     "tooltip-format": "{title} | {app_id}",
 > }
 > ```
+
+#### `cgroup`
+
+<sup>Since: TODO</sup>
+
+A regular expression that should match anywhere in the cgroup path of the process that created the window.
+
+> [!NOTE]
+> This matcher will apply only after the window is already open.
+> This means that you cannot use it to change the window opening properties like `default-window-height` or `open-on-workspace`.
+
+```kdl
+window-rule {
+    match cgroup="my-slice"
+}
+```
+
+You can find the cgroup of a window by reading `/proc/<pid>/cgroup`, where the PID can be fetched by first running `niri msg pick-window` and clicking on the window in question.
+
+> [!NOTE]
+> This matcher assumes cgroup v2 is in use.
+> For legacy systems with cgroup v1, matching is done for the first line only.
 
 #### `is-active`
 

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -30,6 +30,7 @@ Here are all matchers and properties that a window rule could have:
 window-rule {
     match title="Firefox"
     match app-id="Alacritty"
+    match cgroup="browsing"
     match is-active=true
     match is-focused=false
     match is-active-in-column=true
@@ -202,6 +203,28 @@ You can find the title and the app ID of a window by running `niri msg pick-wind
 >     "tooltip-format": "{title} | {app_id}",
 > }
 > ```
+
+#### `cgroup`
+
+<sup>Since: TODO</sup>
+
+A regular expression that should match anywhere in the cgroup path of the process that created the window.
+
+> [!NOTE]
+> This matcher will apply only after the window is already open.
+> This means that you cannot use it to change the window opening properties like `default-window-height` or `open-on-workspace`.
+
+```kdl
+window-rule {
+    match cgroup="my-slice"
+}
+```
+
+You can find the cgroup of a window by reading `/proc/<pid>/cgroup`, where the PID can be fetched by first running `niri msg pick-window` and clicking on the window in question.
+
+> [!NOTE]
+> This matcher assumes cgroup v2 is in use.
+> For legacy systems with cgroup v1, matching is done for the first line only.
 
 #### `is-active`
 

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -80,6 +80,8 @@ pub struct Match {
     pub app_id: Option<RegexEq>,
     #[knuffel(property, str)]
     pub title: Option<RegexEq>,
+    #[knuffel(property, str)]
+    pub cgroup: Option<RegexEq>,
     #[knuffel(property)]
     pub is_active: Option<bool>,
     #[knuffel(property)]

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -123,6 +123,8 @@ pub struct Match {
     pub app_id: Option<RegexEq>,
     #[knuffel(property, str)]
     pub title: Option<RegexEq>,
+    #[knuffel(property, str)]
+    pub cgroup: Option<RegexEq>,
     #[knuffel(property)]
     pub is_active: Option<bool>,
     #[knuffel(property)]

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1,4 +1,5 @@
 use std::cmp::{max, min};
+use std::fs;
 
 use niri_config::utils::MergeWith as _;
 use niri_config::window_rule::{Match, WindowRule};
@@ -13,6 +14,7 @@ use smithay::wayland::compositor::with_states;
 use smithay::wayland::shell::xdg::{
     SurfaceCachedState, ToplevelSurface, XdgToplevelSurfaceRoleAttributes,
 };
+use wayland_backend::server::Credentials;
 
 use crate::utils::with_toplevel_role;
 
@@ -169,6 +171,13 @@ impl<'a> WindowRef<'a> {
         match self {
             WindowRef::Unmapped(_) => false,
             WindowRef::Mapped(mapped) => mapped.is_window_cast_target(),
+        }
+    }
+
+    pub fn credentials(self) -> Option<&'a Credentials> {
+        match self {
+            WindowRef::Unmapped(_) => None,
+            WindowRef::Mapped(mapped) => mapped.credentials(),
         }
     }
 }
@@ -415,6 +424,18 @@ fn window_matches(window: WindowRef, role: &XdgToplevelSurfaceRoleAttributes, m:
         }
     }
 
+    if let Some(cgroup_re) = &m.cgroup {
+        let cgroup = window
+            .credentials()
+            .and_then(|creds| read_cgroup(creds.pid));
+        let Some(cgroup) = cgroup else {
+            return false;
+        };
+        if !cgroup_re.0.is_match(&cgroup) {
+            return false;
+        }
+    }
+
     if let Some(is_active_in_column) = m.is_active_in_column {
         if window.is_active_in_column() != is_active_in_column {
             return false;
@@ -434,4 +455,12 @@ fn window_matches(window: WindowRef, role: &XdgToplevelSurfaceRoleAttributes, m:
     }
 
     true
+}
+
+fn read_cgroup(pid: i32) -> Option<String> {
+    let path = format!("/proc/{pid}/cgroup");
+    let content = fs::read_to_string(path).ok()?;
+    let line = content.lines().next()?;
+    let cgroup_path = line.rsplit_once(':')?.1;
+    Some(cgroup_path.to_owned())
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1,4 +1,5 @@
 use std::cmp::{max, min};
+use std::fs;
 
 use niri_config::utils::MergeWith as _;
 use niri_config::window_rule::{Match, WindowRule};
@@ -13,6 +14,7 @@ use smithay::wayland::compositor::with_states;
 use smithay::wayland::shell::xdg::{
     SurfaceCachedState, ToplevelSurface, XdgToplevelSurfaceRoleAttributes,
 };
+use wayland_backend::server::Credentials;
 
 use crate::utils::with_toplevel_role;
 
@@ -175,6 +177,13 @@ impl<'a> WindowRef<'a> {
         match self {
             WindowRef::Unmapped(_) => false,
             WindowRef::Mapped(mapped) => mapped.is_window_cast_target(),
+        }
+    }
+
+    pub fn credentials(self) -> Option<&'a Credentials> {
+        match self {
+            WindowRef::Unmapped(_) => None,
+            WindowRef::Mapped(mapped) => mapped.credentials(),
         }
     }
 }
@@ -427,6 +436,18 @@ fn window_matches(window: WindowRef, role: &XdgToplevelSurfaceRoleAttributes, m:
         }
     }
 
+    if let Some(cgroup_re) = &m.cgroup {
+        let cgroup = window
+            .credentials()
+            .and_then(|creds| read_cgroup(creds.pid));
+        let Some(cgroup) = cgroup else {
+            return false;
+        };
+        if !cgroup_re.0.is_match(&cgroup) {
+            return false;
+        }
+    }
+
     if let Some(is_active_in_column) = m.is_active_in_column {
         if window.is_active_in_column() != is_active_in_column {
             return false;
@@ -446,4 +467,12 @@ fn window_matches(window: WindowRef, role: &XdgToplevelSurfaceRoleAttributes, m:
     }
 
     true
+}
+
+fn read_cgroup(pid: i32) -> Option<String> {
+    let path = format!("/proc/{pid}/cgroup");
+    let content = fs::read_to_string(path).ok()?;
+    let line = content.lines().next()?;
+    let cgroup_path = line.rsplit_once(':')?.1;
+    Some(cgroup_path.to_owned())
 }


### PR DESCRIPTION
This allows for applying window rules by cgroup, which is useful when spawning windows into their own systemd slices, e.g. for security reasons.
This requires reading `/proc/<pid>/cgroup`, which takes around 5μs per rule evaluation.
The PID is available for `Mapped` windows only, so any opening properties unfortunately won't work.

An example config, highlighting matching windows in red:
```kdl
window-rule {
    match cgroup="my-slice"
    border {
        active-color "#f38ba8"
        inactive-color "#7d0d2d"
    }
}
```
This can be tested by running a shell in another slice, then spawning a window:
```shell
systemd-run --user --slice=my-slice --shell
kitty &
```
The new window should have the styling applied.
