### PR TITLE
input: add tablet stylus button triggers and binds

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -52,6 +52,9 @@ pub enum Trigger {
     TouchpadScrollUp,
     TouchpadScrollLeft,
     TouchpadScrollRight,
+    TabletStylusButton1,
+    TabletStylusButton2,
+    TabletStylusButton3,
 }
 
 bitflags! {
@@ -1000,6 +1003,12 @@ impl FromStr for Key {
             Trigger::TouchpadScrollLeft
         } else if key.eq_ignore_ascii_case("TouchpadScrollRight") {
             Trigger::TouchpadScrollRight
+        } else if key.eq_ignore_ascii_case("TabletStylusButton1") {
+            Trigger::TabletStylusButton1
+        } else if key.eq_ignore_ascii_case("TabletStylusButton2") {
+            Trigger::TabletStylusButton2
+        } else if key.eq_ignore_ascii_case("TabletStylusButton3") {
+            Trigger::TabletStylusButton3
         } else {
             let mut keysym = keysym_from_name(key, KEYSYM_CASE_INSENSITIVE);
             // The keyboard event handling code can receive either

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -51,6 +51,8 @@ pub enum Trigger {
     TouchpadScrollUp,
     TouchpadScrollLeft,
     TouchpadScrollRight,
+    TabletStylusPrimary,
+    TabletStylusSecondary,
 }
 
 bitflags! {
@@ -1012,6 +1014,10 @@ impl FromStr for Key {
             Trigger::TouchpadScrollLeft
         } else if key.eq_ignore_ascii_case("TouchpadScrollRight") {
             Trigger::TouchpadScrollRight
+        } else if key.eq_ignore_ascii_case("TabletStylusPrimary") {
+            Trigger::TabletStylusPrimary
+        } else if key.eq_ignore_ascii_case("TabletStylusSecondary") {
+            Trigger::TabletStylusSecondary
         } else {
             let mut keysym = keysym_from_name(key, KEYSYM_CASE_INSENSITIVE);
             // The keyboard event handling code can receive either

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -52,8 +52,9 @@ pub enum Trigger {
     TouchpadScrollUp,
     TouchpadScrollLeft,
     TouchpadScrollRight,
-    TabletStylusPrimary,
-    TabletStylusSecondary,
+    TabletStylusButton1,
+    TabletStylusButton2,
+    TabletStylusButton3,
 }
 
 bitflags! {
@@ -1002,10 +1003,12 @@ impl FromStr for Key {
             Trigger::TouchpadScrollLeft
         } else if key.eq_ignore_ascii_case("TouchpadScrollRight") {
             Trigger::TouchpadScrollRight
-        } else if key.eq_ignore_ascii_case("TabletStylusPrimary") {
-            Trigger::TabletStylusPrimary
-        } else if key.eq_ignore_ascii_case("TabletStylusSecondary") {
-            Trigger::TabletStylusSecondary
+        } else if key.eq_ignore_ascii_case("TabletStylusButton1") {
+            Trigger::TabletStylusButton1
+        } else if key.eq_ignore_ascii_case("TabletStylusButton2") {
+            Trigger::TabletStylusButton2
+        } else if key.eq_ignore_ascii_case("TabletStylusButton3") {
+            Trigger::TabletStylusButton3
         } else {
             let mut keysym = keysym_from_name(key, KEYSYM_CASE_INSENSITIVE);
             // The keyboard event handling code can receive either

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3778,11 +3778,49 @@ impl State {
     }
 
     fn on_tablet_tool_button<I: InputBackend>(&mut self, event: I::TabletToolButtonEvent) {
+        const BTN_STYLUS3: u32 = 0x149;
+        const BTN_STYLUS: u32 = 0x14b;
+        const BTN_STYLUS2: u32 = 0x14c;
+
         let tool = self.niri.seat.tablet_seat().get_tool(&event.tool());
 
         if let Some(tool) = tool {
+            let button = event.button();
+
+            if self.niri.suppressed_buttons.remove(&button) {
+                return;
+            }
+
+            let trigger = match button {
+                BTN_STYLUS => Some(Trigger::TabletStylusButton1),
+                BTN_STYLUS2 => Some(Trigger::TabletStylusButton2),
+                BTN_STYLUS3 => Some(Trigger::TabletStylusButton3),
+                _ => None,
+            };
+
+            if let Some(trigger) = trigger {
+                if event.button_state() == ButtonState::Pressed {
+                    let mod_key = self.backend.mod_key(&self.niri.config.borrow());
+                    let mods = self.niri.seat.get_keyboard().unwrap().modifier_state();
+                    let modifiers = modifiers_from_state(mods);
+
+                    if self.niri.mods_with_tablet_stylus_binds.contains(&modifiers) {
+                        let bind = {
+                            let config = self.niri.config.borrow();
+                            let bindings = config.binds.0.iter();
+                            find_configured_bind(bindings, mod_key, trigger, mods)
+                        };
+                        if let Some(bind) = bind {
+                            self.niri.suppressed_buttons.insert(button);
+                            self.handle_bind(bind.clone());
+                            return;
+                        }
+                    }
+                }
+            }
+
             tool.button(
-                event.button(),
+                button,
                 event.button_state(),
                 SERIAL_COUNTER.next_serial(),
                 event.time_msec(),
@@ -5065,6 +5103,18 @@ pub fn mods_with_finger_scroll_binds(mod_key: ModKey, binds: &Binds) -> HashSet<
             Trigger::TouchpadScrollDown,
             Trigger::TouchpadScrollLeft,
             Trigger::TouchpadScrollRight,
+        ],
+    )
+}
+
+pub fn mods_with_tablet_stylus_binds(mod_key: ModKey, binds: &Binds) -> HashSet<Modifiers> {
+    mods_with_binds(
+        mod_key,
+        binds,
+        &[
+            Trigger::TabletStylusButton1,
+            Trigger::TabletStylusButton2,
+            Trigger::TabletStylusButton3,
         ],
     )
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3725,11 +3725,38 @@ impl State {
     }
 
     fn on_tablet_tool_button<I: InputBackend>(&mut self, event: I::TabletToolButtonEvent) {
+        const BTN_STYLUS: u32 = 0x14b;
+        const BTN_STYLUS2: u32 = 0x14c;
+
         let tool = self.niri.seat.tablet_seat().get_tool(&event.tool());
 
         if let Some(tool) = tool {
+            let button = event.button();
+            let trigger = match button {
+                BTN_STYLUS => Some(Trigger::TabletStylusPrimary),
+                BTN_STYLUS2 => Some(Trigger::TabletStylusSecondary),
+                _ => None,
+            };
+
+            if let Some(trigger) = trigger {
+                if event.button_state() == ButtonState::Pressed {
+                    let mod_key = self.backend.mod_key(&self.niri.config.borrow());
+                    let mods = self.niri.seat.get_keyboard().unwrap().modifier_state();
+
+                    let bind = {
+                        let config = self.niri.config.borrow();
+                        let bindings = config.binds.0.iter();
+                        find_configured_bind(bindings, mod_key, trigger, mods)
+                    };
+                    if let Some(bind) = bind {
+                        self.handle_bind(bind.clone());
+                        return;
+                    }
+                }
+            }
+
             tool.button(
-                event.button(),
+                button,
                 event.button_state(),
                 SERIAL_COUNTER.next_serial(),
                 event.time_msec(),
@@ -5005,6 +5032,14 @@ pub fn mods_with_finger_scroll_binds(mod_key: ModKey, binds: &Binds) -> HashSet<
             Trigger::TouchpadScrollLeft,
             Trigger::TouchpadScrollRight,
         ],
+    )
+}
+
+pub fn mods_with_tablet_stylus_binds(mod_key: ModKey, binds: &Binds) -> HashSet<Modifiers> {
+    mods_with_binds(
+        mod_key,
+        binds,
+        &[Trigger::TabletStylusPrimary, Trigger::TabletStylusSecondary],
     )
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3726,6 +3726,7 @@ impl State {
     }
 
     fn on_tablet_tool_button<I: InputBackend>(&mut self, event: I::TabletToolButtonEvent) {
+        const BTN_STYLUS3: u32 = 0x149;
         const BTN_STYLUS: u32 = 0x14b;
         const BTN_STYLUS2: u32 = 0x14c;
 
@@ -3733,9 +3734,15 @@ impl State {
 
         if let Some(tool) = tool {
             let button = event.button();
+
+            if self.niri.suppressed_buttons.remove(&button) {
+                return;
+            }
+
             let trigger = match button {
-                BTN_STYLUS => Some(Trigger::TabletStylusPrimary),
-                BTN_STYLUS2 => Some(Trigger::TabletStylusSecondary),
+                BTN_STYLUS => Some(Trigger::TabletStylusButton1),
+                BTN_STYLUS2 => Some(Trigger::TabletStylusButton2),
+                BTN_STYLUS3 => Some(Trigger::TabletStylusButton3),
                 _ => None,
             };
 
@@ -3743,15 +3750,19 @@ impl State {
                 if event.button_state() == ButtonState::Pressed {
                     let mod_key = self.backend.mod_key(&self.niri.config.borrow());
                     let mods = self.niri.seat.get_keyboard().unwrap().modifier_state();
+                    let modifiers = modifiers_from_state(mods);
 
-                    let bind = {
-                        let config = self.niri.config.borrow();
-                        let bindings = config.binds.0.iter();
-                        find_configured_bind(bindings, mod_key, trigger, mods)
-                    };
-                    if let Some(bind) = bind {
-                        self.handle_bind(bind.clone());
-                        return;
+                    if self.niri.mods_with_tablet_stylus_binds.contains(&modifiers) {
+                        let bind = {
+                            let config = self.niri.config.borrow();
+                            let bindings = config.binds.0.iter();
+                            find_configured_bind(bindings, mod_key, trigger, mods)
+                        };
+                        if let Some(bind) = bind {
+                            self.niri.suppressed_buttons.insert(button);
+                            self.handle_bind(bind.clone());
+                            return;
+                        }
                     }
                 }
             }
@@ -5051,7 +5062,11 @@ pub fn mods_with_tablet_stylus_binds(mod_key: ModKey, binds: &Binds) -> HashSet<
     mods_with_binds(
         mod_key,
         binds,
-        &[Trigger::TabletStylusPrimary, Trigger::TabletStylusSecondary],
+        &[
+            Trigger::TabletStylusButton1,
+            Trigger::TabletStylusButton2,
+            Trigger::TabletStylusButton3,
+        ],
     )
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3809,7 +3809,11 @@ impl State {
                             let config = self.niri.config.borrow();
                             let bindings = config.binds.0.iter();
                             find_configured_bind(bindings, mod_key, trigger, mods)
-                        };
+                        }
+                        .filter(|bind| {
+                            !self.niri.screenshot_ui.is_open()
+                                || allowed_during_screenshot(&bind.action)
+                        });
                         if let Some(bind) = bind {
                             self.niri.suppressed_buttons.insert(button);
                             self.handle_bind(bind.clone());

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -130,7 +130,7 @@ use crate::input::scroll_swipe_gesture::ScrollSwipeGesture;
 use crate::input::scroll_tracker::ScrollTracker;
 use crate::input::{
     apply_libinput_settings, mods_with_finger_scroll_binds, mods_with_mouse_binds,
-    mods_with_wheel_binds, TabletData,
+    mods_with_tablet_stylus_binds, mods_with_wheel_binds, TabletData,
 };
 use crate::ipc::server::IpcServer;
 use crate::layer::mapped::LayerSurfaceRenderElement;
@@ -369,6 +369,7 @@ pub struct Niri {
     pub horizontal_wheel_tracker: ScrollTracker,
     pub mods_with_mouse_binds: HashSet<Modifiers>,
     pub mods_with_wheel_binds: HashSet<Modifiers>,
+    pub mods_with_tablet_stylus_binds: HashSet<Modifiers>,
     pub vertical_finger_scroll_tracker: ScrollTracker,
     pub horizontal_finger_scroll_tracker: ScrollTracker,
     pub mods_with_finger_scroll_binds: HashSet<Modifiers>,
@@ -2342,6 +2343,7 @@ impl Niri {
         let mods_with_mouse_binds = mods_with_mouse_binds(mod_key, &config_.binds);
         let mods_with_wheel_binds = mods_with_wheel_binds(mod_key, &config_.binds);
         let mods_with_finger_scroll_binds = mods_with_finger_scroll_binds(mod_key, &config_.binds);
+        let mods_with_tablet_stylus_binds = mods_with_tablet_stylus_binds(mod_key, &config_.binds);
 
         let screenshot_ui = ScreenshotUi::new(animation_clock.clone(), config.clone());
         let window_mru_ui = WindowMruUi::new(config.clone());
@@ -2522,6 +2524,7 @@ impl Niri {
             horizontal_wheel_tracker: ScrollTracker::new(120),
             mods_with_mouse_binds,
             mods_with_wheel_binds,
+            mods_with_tablet_stylus_binds,
 
             // 10 is copied from Clutter: DISCRETE_SCROLL_STEP.
             vertical_finger_scroll_tracker: ScrollTracker::new(10),

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1524,6 +1524,8 @@ impl State {
                 .on_hotkey_config_updated(new_mod_key);
             self.niri.mods_with_mouse_binds = mods_with_mouse_binds(new_mod_key, &config.binds);
             self.niri.mods_with_wheel_binds = mods_with_wheel_binds(new_mod_key, &config.binds);
+            self.niri.mods_with_tablet_stylus_binds =
+                mods_with_tablet_stylus_binds(new_mod_key, &config.binds);
             self.niri.mods_with_finger_scroll_binds =
                 mods_with_finger_scroll_binds(new_mod_key, &config.binds);
         }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -134,7 +134,7 @@ use crate::input::scroll_swipe_gesture::ScrollSwipeGesture;
 use crate::input::scroll_tracker::ScrollTracker;
 use crate::input::{
     apply_libinput_settings, mods_with_finger_scroll_binds, mods_with_mouse_binds,
-    mods_with_wheel_binds, TabletData,
+    mods_with_tablet_stylus_binds, mods_with_wheel_binds, TabletData,
 };
 use crate::ipc::server::IpcServer;
 use crate::layer::mapped::LayerSurfaceRenderElement;
@@ -376,6 +376,7 @@ pub struct Niri {
     pub horizontal_wheel_tracker: ScrollTracker,
     pub mods_with_mouse_binds: HashSet<Modifiers>,
     pub mods_with_wheel_binds: HashSet<Modifiers>,
+    pub mods_with_tablet_stylus_binds: HashSet<Modifiers>,
     pub vertical_finger_scroll_tracker: ScrollTracker,
     pub horizontal_finger_scroll_tracker: ScrollTracker,
     pub mods_with_finger_scroll_binds: HashSet<Modifiers>,
@@ -1534,6 +1535,8 @@ impl State {
                 .on_hotkey_config_updated(new_mod_key);
             self.niri.mods_with_mouse_binds = mods_with_mouse_binds(new_mod_key, &config.binds);
             self.niri.mods_with_wheel_binds = mods_with_wheel_binds(new_mod_key, &config.binds);
+            self.niri.mods_with_tablet_stylus_binds =
+                mods_with_tablet_stylus_binds(new_mod_key, &config.binds);
             self.niri.mods_with_finger_scroll_binds =
                 mods_with_finger_scroll_binds(new_mod_key, &config.binds);
         }
@@ -2407,6 +2410,7 @@ impl Niri {
         let mods_with_mouse_binds = mods_with_mouse_binds(mod_key, &config_.binds);
         let mods_with_wheel_binds = mods_with_wheel_binds(mod_key, &config_.binds);
         let mods_with_finger_scroll_binds = mods_with_finger_scroll_binds(mod_key, &config_.binds);
+        let mods_with_tablet_stylus_binds = mods_with_tablet_stylus_binds(mod_key, &config_.binds);
 
         let screenshot_ui = ScreenshotUi::new(animation_clock.clone(), config.clone());
         let window_mru_ui = WindowMruUi::new(config.clone());
@@ -2588,6 +2592,7 @@ impl Niri {
             horizontal_wheel_tracker: ScrollTracker::new(120),
             mods_with_mouse_binds,
             mods_with_wheel_binds,
+            mods_with_tablet_stylus_binds,
 
             // 10 is copied from Clutter: DISCRETE_SCROLL_STEP.
             vertical_finger_scroll_tracker: ScrollTracker::new(10),

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -560,6 +560,9 @@ fn key_name(screen_reader: bool, mod_key: ModKey, key: &Key) -> String {
         Trigger::TouchpadScrollUp => String::from("Touchpad Scroll Up"),
         Trigger::TouchpadScrollLeft => String::from("Touchpad Scroll Left"),
         Trigger::TouchpadScrollRight => String::from("Touchpad Scroll Right"),
+        Trigger::TabletStylusButton1 => String::from("Tablet Stylus Button 1"),
+        Trigger::TabletStylusButton2 => String::from("Tablet Stylus Button 2"),
+        Trigger::TabletStylusButton3 => String::from("Tablet Stylus Button 3"),
     };
     name.push_str(&pretty);
 

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -560,6 +560,8 @@ fn key_name(screen_reader: bool, mod_key: ModKey, key: &Key) -> String {
         Trigger::TouchpadScrollUp => String::from("Touchpad Scroll Up"),
         Trigger::TouchpadScrollLeft => String::from("Touchpad Scroll Left"),
         Trigger::TouchpadScrollRight => String::from("Touchpad Scroll Right"),
+        Trigger::TabletStylusPrimary => String::from("Tablet Stylus Primary"),
+        Trigger::TabletStylusSecondary => String::from("Tablet Stylus Secondary"),
     };
     name.push_str(&pretty);
 

--- a/src/ui/hotkey_overlay.rs
+++ b/src/ui/hotkey_overlay.rs
@@ -560,8 +560,9 @@ fn key_name(screen_reader: bool, mod_key: ModKey, key: &Key) -> String {
         Trigger::TouchpadScrollUp => String::from("Touchpad Scroll Up"),
         Trigger::TouchpadScrollLeft => String::from("Touchpad Scroll Left"),
         Trigger::TouchpadScrollRight => String::from("Touchpad Scroll Right"),
-        Trigger::TabletStylusPrimary => String::from("Tablet Stylus Primary"),
-        Trigger::TabletStylusSecondary => String::from("Tablet Stylus Secondary"),
+        Trigger::TabletStylusButton1 => String::from("Tablet Stylus Button 1"),
+        Trigger::TabletStylusButton2 => String::from("Tablet Stylus Button 2"),
+        Trigger::TabletStylusButton3 => String::from("Tablet Stylus Button 3"),
     };
     name.push_str(&pretty);
 


### PR DESCRIPTION
Add support for tablet stylus button bindings

**Example**

```kdl
binds {
    Super+TabletStylusPrimary { spawn-sh "some-script.sh"; } 
    TabletStylusSecondary { toggle-overview; }
}
```

**Notes**

I did test with Wacom CTL-472, but it should work on all tablets

Button codes are `BTN_STYLUS`, `BTN_STYLUS2` [`include/uapi/linux/input-event-codes.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/input-event-codes.h) lines 414-L415 as of `4bdb6a1659873dfc625ded30a68cb387e328f34e`

