### PR TITLE
prevent sleeping after resuming from suspend

### DIFF
--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -2906,11 +2906,10 @@ fn suspend() -> anyhow::Result<()> {
 
     let manager = zbus::names::InterfaceName::try_from("org.freedesktop.login1.Manager").unwrap();
 
-    let is_preparing_sleep: bool = proxy.get(manager, "PreparingForSleep")
-    .context("Fail to get PreparingForSleep property from login1.Manager")
-    .and_then(|value| Ok(bool::try_from(value)?))?
-    ;
-
+    let is_preparing_sleep: bool = proxy
+        .get(manager, "PreparingForSleep")
+        .context("Fail to get PreparingForSleep property from login1.Manager")
+        .and_then(|value| Ok(bool::try_from(value)?))?;
 
     if is_preparing_sleep {
         warn!("Refusing to sleep, I just woke up (or going to sleep)");

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -2898,14 +2898,32 @@ fn refresh_interval(mode: DrmMode) -> Duration {
 fn suspend() -> anyhow::Result<()> {
     let conn = zbus::blocking::Connection::system().context("error connecting to system bus")?;
 
-    conn.call_method(
-        Some("org.freedesktop.login1"),
+    let proxy = zbus::blocking::fdo::PropertiesProxy::new(
+        &conn,
+        "org.freedesktop.login1",
         "/org/freedesktop/login1",
-        Some("org.freedesktop.login1.Manager"),
-        "Suspend",
-        &(true),
-    )
-    .context("error suspending")?;
+    )?;
+
+    let manager = zbus::names::InterfaceName::try_from("org.freedesktop.login1.Manager").unwrap();
+
+    let is_preparing_sleep: bool = proxy.get(manager, "PreparingForSleep")
+    .context("Fail to get PreparingForSleep property from login1.Manager")
+    .and_then(|value| Ok(bool::try_from(value)?))?
+    ;
+
+
+    if is_preparing_sleep {
+        warn!("Refusing to sleep, I just woke up (or going to sleep)");
+    } else {
+        conn.call_method(
+            Some("org.freedesktop.login1"),
+            "/org/freedesktop/login1",
+            Some("org.freedesktop.login1.Manager"),
+            "Suspend",
+            &(true),
+        )
+        .context("error suspending")?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
The same power button is used both for suspend and for resuming, which causes devices to immediately sleep after suspending.

~~By adding inhibition to suspend after certain time (hardcoded 3 seconds for now) using the monotonic timer (which doesn't tick during suspend), we can prevent the suspend-resume loop~~

We now check login1 Manager's [PreparingForSleep property](https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.login1.html) on dbus right before suspending. Unfortunately the event doesn't emit any signal so we cannot just watch it

Resolves #2233 