### PR TITLE
feat: add tabbed columns window switch animation

### DIFF
--- a/docs/wiki/Configuration:-Animations.md
+++ b/docs/wiki/Configuration:-Animations.md
@@ -30,6 +30,12 @@ animations {
         curve "ease-out-quad"
     }
 
+    tab-switch {
+        duration-ms 150
+        curve "ease-out-expo"
+        direction "vertical"
+    }
+
     horizontal-view-movement {
         spring damping-ratio=1.0 stiffness=800 epsilon=0.0001
     }
@@ -317,6 +323,32 @@ animations {
     }
 }
 ```
+
+#### `tab-switch`
+
+Animation used when switching the active window inside a tabbed column.
+
+This animation is separate from `window-movement`: it only applies to changes of the active tab,
+for example when using `focus-window-up`, `focus-window-down`, or direct index-based tab focus.
+
+```kdl
+animations {
+    tab-switch {
+        duration-ms 150
+        curve "ease-out-expo"
+        direction "vertical"
+    }
+}
+```
+
+##### `direction`
+
+Controls the axis of the tab-switch animation.
+
+Possible values:
+
+- `"vertical"`: tabs move up and down.
+- `"horizontal"`: tabs move left and right.
 
 #### `window-resize`
 

--- a/docs/wiki/Configuration:-Animations.md
+++ b/docs/wiki/Configuration:-Animations.md
@@ -30,7 +30,7 @@ animations {
         curve "ease-out-quad"
     }
 
-    tab-switch {
+    column-tab-switch {
         duration-ms 150
         curve "ease-out-expo"
         direction "vertical"
@@ -324,7 +324,7 @@ animations {
 }
 ```
 
-#### `tab-switch`
+#### `column-tab-switch`
 
 Animation used when switching the active window inside a tabbed column.
 
@@ -333,7 +333,7 @@ for example when using `focus-window-up`, `focus-window-down`, or direct index-b
 
 ```kdl
 animations {
-    tab-switch {
+    column-tab-switch {
         duration-ms 150
         curve "ease-out-expo"
         direction "vertical"
@@ -343,7 +343,7 @@ animations {
 
 ##### `direction`
 
-Controls the axis of the tab-switch animation.
+Controls the axis of the column-tab-switch animation.
 
 Possible values:
 

--- a/niri-config/src/animations.rs
+++ b/niri-config/src/animations.rs
@@ -13,6 +13,7 @@ pub struct Animations {
     pub window_close: WindowCloseAnim,
     pub horizontal_view_movement: HorizontalViewMovementAnim,
     pub window_movement: WindowMovementAnim,
+    pub tab_switch: TabSwitchAnim,
     pub window_resize: WindowResizeAnim,
     pub config_notification_open_close: ConfigNotificationOpenCloseAnim,
     pub exit_confirmation_open_close: ExitConfirmationOpenCloseAnim,
@@ -29,6 +30,7 @@ impl Default for Animations {
             workspace_switch: Default::default(),
             horizontal_view_movement: Default::default(),
             window_movement: Default::default(),
+            tab_switch: Default::default(),
             window_open: Default::default(),
             window_close: Default::default(),
             window_resize: Default::default(),
@@ -59,6 +61,8 @@ pub struct AnimationsPart {
     pub horizontal_view_movement: Option<HorizontalViewMovementAnim>,
     #[knuffel(child)]
     pub window_movement: Option<WindowMovementAnim>,
+    #[knuffel(child)]
+    pub tab_switch: Option<TabSwitchAnim>,
     #[knuffel(child)]
     pub window_resize: Option<WindowResizeAnim>,
     #[knuffel(child)]
@@ -91,6 +95,7 @@ impl MergeWith<AnimationsPart> for Animations {
             window_close,
             horizontal_view_movement,
             window_movement,
+            tab_switch,
             window_resize,
             config_notification_open_close,
             exit_confirmation_open_close,
@@ -223,6 +228,33 @@ impl Default for WindowMovementAnim {
             }),
         })
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TabSwitchAnim {
+    pub anim: Animation,
+    pub direction: TabSwitchDirection,
+}
+
+impl Default for TabSwitchAnim {
+    fn default() -> Self {
+        Self {
+            anim: Animation {
+                off: false,
+                kind: Kind::Easing(EasingParams {
+                    duration_ms: 150,
+                    curve: Curve::EaseOutExpo,
+                }),
+            },
+            direction: TabSwitchDirection::Vertical,
+        }
+    }
+}
+
+#[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TabSwitchDirection {
+    Horizontal,
+    Vertical,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -368,6 +400,29 @@ where
         Ok(Self(Animation::decode_node(node, ctx, default, |_, _| {
             Ok(false)
         })?))
+    }
+}
+
+impl<S> knuffel::Decode<S> for TabSwitchAnim
+where
+    S: knuffel::traits::ErrorSpan,
+{
+    fn decode_node(
+        node: &knuffel::ast::SpannedNode<S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        let default = Self::default();
+        let mut direction = default.direction;
+        let anim = Animation::decode_node(node, ctx, default.anim, |child, ctx| {
+            if &**child.node_name != "direction" {
+                return Ok(false);
+            }
+
+            direction = parse_arg_node("direction", child, ctx)?;
+            Ok(true)
+        })?;
+
+        Ok(Self { anim, direction })
     }
 }
 

--- a/niri-config/src/animations.rs
+++ b/niri-config/src/animations.rs
@@ -13,7 +13,7 @@ pub struct Animations {
     pub window_close: WindowCloseAnim,
     pub horizontal_view_movement: HorizontalViewMovementAnim,
     pub window_movement: WindowMovementAnim,
-    pub tab_switch: TabSwitchAnim,
+    pub column_tab_switch: ColumnTabSwitchAnim,
     pub window_resize: WindowResizeAnim,
     pub config_notification_open_close: ConfigNotificationOpenCloseAnim,
     pub exit_confirmation_open_close: ExitConfirmationOpenCloseAnim,
@@ -30,7 +30,7 @@ impl Default for Animations {
             workspace_switch: Default::default(),
             horizontal_view_movement: Default::default(),
             window_movement: Default::default(),
-            tab_switch: Default::default(),
+            column_tab_switch: Default::default(),
             window_open: Default::default(),
             window_close: Default::default(),
             window_resize: Default::default(),
@@ -62,7 +62,7 @@ pub struct AnimationsPart {
     #[knuffel(child)]
     pub window_movement: Option<WindowMovementAnim>,
     #[knuffel(child)]
-    pub tab_switch: Option<TabSwitchAnim>,
+    pub column_tab_switch: Option<ColumnTabSwitchAnim>,
     #[knuffel(child)]
     pub window_resize: Option<WindowResizeAnim>,
     #[knuffel(child)]
@@ -95,7 +95,7 @@ impl MergeWith<AnimationsPart> for Animations {
             window_close,
             horizontal_view_movement,
             window_movement,
-            tab_switch,
+            column_tab_switch,
             window_resize,
             config_notification_open_close,
             exit_confirmation_open_close,
@@ -231,12 +231,12 @@ impl Default for WindowMovementAnim {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TabSwitchAnim {
+pub struct ColumnTabSwitchAnim {
     pub anim: Animation,
-    pub direction: TabSwitchDirection,
+    pub direction: ColumnTabSwitchDirection,
 }
 
-impl Default for TabSwitchAnim {
+impl Default for ColumnTabSwitchAnim {
     fn default() -> Self {
         Self {
             anim: Animation {
@@ -246,13 +246,13 @@ impl Default for TabSwitchAnim {
                     curve: Curve::EaseOutExpo,
                 }),
             },
-            direction: TabSwitchDirection::Vertical,
+            direction: ColumnTabSwitchDirection::Vertical,
         }
     }
 }
 
 #[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TabSwitchDirection {
+pub enum ColumnTabSwitchDirection {
     Horizontal,
     Vertical,
 }
@@ -403,7 +403,7 @@ where
     }
 }
 
-impl<S> knuffel::Decode<S> for TabSwitchAnim
+impl<S> knuffel::Decode<S> for ColumnTabSwitchAnim
 where
     S: knuffel::traits::ErrorSpan,
 {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -44,7 +44,7 @@ pub mod utils;
 pub mod window_rule;
 pub mod workspace;
 
-pub use crate::animations::{Animation, Animations};
+pub use crate::animations::{Animation, Animations, TabSwitchAnim, TabSwitchDirection};
 pub use crate::appearance::*;
 pub use crate::binds::*;
 pub use crate::debug::Debug;
@@ -859,6 +859,10 @@ mod tests {
                     curve "cubic-bezier" 0.05 0.7 0.1 1  
                 }
 
+                tab-switch {
+                    direction "vertical"
+                }
+
                 recent-windows-close {
                     off
                 }
@@ -1563,6 +1567,18 @@ mod tests {
                         ),
                     },
                 ),
+                tab_switch: TabSwitchAnim {
+                    anim: Animation {
+                        off: false,
+                        kind: Easing(
+                            EasingParams {
+                                duration_ms: 150,
+                                curve: EaseOutExpo,
+                            },
+                        ),
+                    },
+                    direction: Vertical,
+                },
                 window_resize: WindowResizeAnim {
                     anim: Animation {
                         off: false,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -44,7 +44,7 @@ pub mod utils;
 pub mod window_rule;
 pub mod workspace;
 
-pub use crate::animations::{Animation, Animations, TabSwitchAnim, TabSwitchDirection};
+pub use crate::animations::{Animation, Animations, ColumnTabSwitchAnim, ColumnTabSwitchDirection};
 pub use crate::appearance::*;
 pub use crate::binds::*;
 pub use crate::debug::Debug;
@@ -859,7 +859,7 @@ mod tests {
                     curve "cubic-bezier" 0.05 0.7 0.1 1  
                 }
 
-                tab-switch {
+                column-tab-switch {
                     direction "vertical"
                 }
 
@@ -1567,7 +1567,7 @@ mod tests {
                         ),
                     },
                 ),
-                tab_switch: TabSwitchAnim {
+                column_tab_switch: ColumnTabSwitchAnim {
                     anim: Animation {
                         off: false,
                         kind: Easing(

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -44,7 +44,7 @@ pub mod utils;
 pub mod window_rule;
 pub mod workspace;
 
-pub use crate::animations::{Animation, Animations};
+pub use crate::animations::{Animation, Animations, TabSwitchAnim, TabSwitchDirection};
 pub use crate::appearance::*;
 pub use crate::binds::*;
 pub use crate::debug::Debug;
@@ -860,6 +860,10 @@ mod tests {
                     curve "cubic-bezier" 0.05 0.7 0.1 1  
                 }
 
+                tab-switch {
+                    direction "vertical"
+                }
+
                 recent-windows-close {
                     off
                 }
@@ -1565,6 +1569,18 @@ mod tests {
                         ),
                     },
                 ),
+                tab_switch: TabSwitchAnim {
+                    anim: Animation {
+                        off: false,
+                        kind: Easing(
+                            EasingParams {
+                                duration_ms: 150,
+                                curve: EaseOutExpo,
+                            },
+                        ),
+                    },
+                    direction: Vertical,
+                },
                 window_resize: WindowResizeAnim {
                     anim: Animation {
                         off: false,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -44,7 +44,7 @@ pub mod utils;
 pub mod window_rule;
 pub mod workspace;
 
-pub use crate::animations::{Animation, Animations, TabSwitchAnim, TabSwitchDirection};
+pub use crate::animations::{Animation, Animations, ColumnTabSwitchAnim, ColumnTabSwitchDirection};
 pub use crate::appearance::*;
 pub use crate::binds::*;
 pub use crate::debug::Debug;
@@ -860,7 +860,7 @@ mod tests {
                     curve "cubic-bezier" 0.05 0.7 0.1 1  
                 }
 
-                tab-switch {
+                column-tab-switch {
                     direction "vertical"
                 }
 
@@ -1569,7 +1569,7 @@ mod tests {
                         ),
                     },
                 ),
-                tab_switch: TabSwitchAnim {
+                column_tab_switch: ColumnTabSwitchAnim {
                     anim: Animation {
                         off: false,
                         kind: Easing(

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -44,7 +44,7 @@ pub mod utils;
 pub mod window_rule;
 pub mod workspace;
 
-pub use crate::animations::{Animation, Animations};
+pub use crate::animations::{Animation, Animations, TabSwitchAnim, TabSwitchDirection};
 pub use crate::appearance::*;
 pub use crate::binds::*;
 pub use crate::debug::Debug;
@@ -885,6 +885,10 @@ mod tests {
                     curve "cubic-bezier" 0.05 0.7 0.1 1
                 }
 
+                tab-switch {
+                    direction "vertical"
+                }
+
                 recent-windows-close {
                     off
                 }
@@ -1598,6 +1602,18 @@ mod tests {
                         ),
                     },
                 ),
+                tab_switch: TabSwitchAnim {
+                    anim: Animation {
+                        off: false,
+                        kind: Easing(
+                            EasingParams {
+                                duration_ms: 150,
+                                curve: EaseOutExpo,
+                            },
+                        ),
+                    },
+                    direction: Vertical,
+                },
                 window_resize: WindowResizeAnim {
                     anim: Animation {
                         off: false,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -44,7 +44,7 @@ pub mod utils;
 pub mod window_rule;
 pub mod workspace;
 
-pub use crate::animations::{Animation, Animations, TabSwitchAnim, TabSwitchDirection};
+pub use crate::animations::{Animation, Animations, ColumnTabSwitchAnim, ColumnTabSwitchDirection};
 pub use crate::appearance::*;
 pub use crate::binds::*;
 pub use crate::debug::Debug;
@@ -885,7 +885,7 @@ mod tests {
                     curve "cubic-bezier" 0.05 0.7 0.1 1
                 }
 
-                tab-switch {
+                column-tab-switch {
                     direction "vertical"
                 }
 
@@ -1602,7 +1602,7 @@ mod tests {
                         ),
                     },
                 ),
-                tab_switch: TabSwitchAnim {
+                column_tab_switch: ColumnTabSwitchAnim {
                     anim: Animation {
                         off: false,
                         kind: Easing(

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -302,6 +302,10 @@ animations {
 
     // Slow down all animations by this factor. Values below 1 speed them up instead.
     // slowdown 3.0
+
+    // tab-switch {
+    //     direction "horizontal"
+    // }
 }
 
 // Window rules let you adjust behavior for individual windows.

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -302,10 +302,6 @@ animations {
 
     // Slow down all animations by this factor. Values below 1 speed them up instead.
     // slowdown 3.0
-
-    // tab-switch {
-    //     direction "horizontal"
-    // }
 }
 
 // Window rules let you adjust behavior for individual windows.

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4423,12 +4423,31 @@ impl<W: LayoutElement> Column<W> {
         }
 
         if any_fullscreen {
+            if self.has_lingering_expanded_inactive_tabs() {
+                return SizingMode::Normal;
+            }
+
             SizingMode::Fullscreen
         } else if any_maximized {
+            if self.has_lingering_expanded_inactive_tabs() {
+                return SizingMode::Normal;
+            }
+
             SizingMode::Maximized
         } else {
             SizingMode::Normal
         }
+    }
+
+    fn has_lingering_expanded_inactive_tabs(&self) -> bool {
+        self.display_mode == ColumnDisplay::Tabbed
+            && self.pending_sizing_mode().is_normal()
+            && self.tiles[self.active_tile_idx].sizing_mode().is_normal()
+            && self
+                .tiles
+                .iter()
+                .enumerate()
+                .any(|(idx, tile)| idx != self.active_tile_idx && !tile.sizing_mode().is_normal())
     }
 
     pub fn contains(&self, window: &W::Id) -> bool {
@@ -4895,13 +4914,16 @@ impl<W: LayoutElement> Column<W> {
     }
 
     fn width(&self) -> f64 {
-        let mut tiles_width = self
-            .data
-            .iter()
-            .map(|data| NotNan::new(data.size.w).unwrap())
-            .max()
-            .map(NotNan::into_inner)
-            .unwrap();
+        let mut tiles_width = if self.has_lingering_expanded_inactive_tabs() {
+            self.data[self.active_tile_idx].size.w
+        } else {
+            self.data
+                .iter()
+                .map(|data| NotNan::new(data.size.w).unwrap())
+                .max()
+                .map(NotNan::into_inner)
+                .unwrap()
+        };
 
         if self.display_mode == ColumnDisplay::Tabbed && self.sizing_mode().is_normal() {
             let extra_size = self.tab_indicator.extra_size(self.tiles.len(), self.scale);
@@ -5362,10 +5384,11 @@ impl<W: LayoutElement> Column<W> {
 
         match self.sizing_mode() {
             SizingMode::Normal => (),
-            SizingMode::Maximized => {
+            SizingMode::Maximized if !self.pending_sizing_mode().is_normal() => {
                 origin.y += self.parent_area.loc.y;
                 return origin;
             }
+            SizingMode::Maximized => (),
             SizingMode::Fullscreen => return origin,
         }
 
@@ -5394,13 +5417,16 @@ impl<W: LayoutElement> Column<W> {
         let tabbed = self.display_mode == ColumnDisplay::Tabbed;
 
         // Does not include extra size from the tab indicator.
-        let tiles_width = self
-            .data
-            .iter()
-            .map(|data| NotNan::new(data.size.w).unwrap())
-            .max()
-            .map(NotNan::into_inner)
-            .unwrap_or(0.);
+        let tiles_width = if self.has_lingering_expanded_inactive_tabs() {
+            self.data[self.active_tile_idx].size.w
+        } else {
+            self.data
+                .iter()
+                .map(|data| NotNan::new(data.size.w).unwrap())
+                .max()
+                .map(NotNan::into_inner)
+                .unwrap_or(0.)
+        };
 
         let mut origin = self.tiles_origin();
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -22,7 +22,7 @@ use crate::layout::SizingMode;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::xray::XrayPos;
-use crate::render_helpers::RenderCtx;
+use crate::render_helpers::{RenderCtx, RenderTarget};
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::ResizeEdge;
 use crate::window::ResolvedWindowRules;
@@ -2942,10 +2942,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             }
 
             if col.render_tab_switch(
-                renderer,
+                ctx.renderer,
                 view_off + col_off + col_render_off,
                 focus_ring && first,
-                target,
+                ctx.target,
                 &mut |elem| push(elem.into()),
             ) {
                 first = false;
@@ -4307,7 +4307,7 @@ impl<W: LayoutElement> Column<W> {
                     content_size.w
                 } else {
                     content_size.h
-            };
+                };
             let start = clip_start.max(start);
             let end = clip_end.min(end);
             if end <= start {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri_config::utils::MergeWith as _;
-use niri_config::{CenterFocusedColumn, PresetSize, Struts};
+use niri_config::{CenterFocusedColumn, PresetSize, Struts, TabSwitchDirection};
 use niri_ipc::{ColumnDisplay, SizeChange, WindowLayout};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -195,6 +195,9 @@ pub struct Column<W: LayoutElement> {
     /// Animation of the render offset during window swapping.
     move_animation: Option<MoveAnimation>,
 
+    /// Animation of the tab strip sliding under the active frame.
+    tab_switch_animation: Option<TabSwitchAnimation>,
+
     /// Latest known view size for this column's workspace.
     view_size: Size<f64, Logical>,
 
@@ -280,6 +283,13 @@ pub enum ScrollDirection {
 struct MoveAnimation {
     anim: Animation,
     from: f64,
+}
+
+#[derive(Debug)]
+struct TabSwitchAnimation {
+    anim: Animation,
+    from_idx: usize,
+    to_idx: usize,
 }
 
 impl<W: LayoutElement> ScrollingSpace<W> {
@@ -909,7 +919,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         if activate {
-            target_column.activate_idx(tile_idx);
+            target_column.active_tile_idx = tile_idx;
+            target_column.tiles[tile_idx].ensure_alpha_animates_to_1();
             if self.active_column_idx != col_idx {
                 self.activate_column(col_idx);
             }
@@ -1069,6 +1080,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let column = &mut self.columns[column_idx];
         let prev_width = self.data[column_idx].width;
+        column.tab_switch_animation = None;
 
         let movement_config = anim_config.unwrap_or(self.options.animations.window_movement.0);
 
@@ -1124,13 +1136,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             column.active_tile_idx -= 1;
         } else if tile_idx == column.active_tile_idx {
             // The active tile was removed, so the active tile index shifted to the next tile.
-            if tile_idx == column.tiles.len() {
-                // The bottom tile was removed and it was active, update active idx to remain valid.
-                column.activate_idx(tile_idx - 1);
-            } else {
-                // Ensure the newly active tile animates to opaque.
-                column.tiles[tile_idx].ensure_alpha_animates_to_1();
-            }
+            column.active_tile_idx = min(tile_idx, column.tiles.len() - 1);
+            column.tiles[column.active_tile_idx].ensure_alpha_animates_to_1();
         }
 
         column.update_tile_sizes_with_transaction(true, transaction);
@@ -2934,6 +2941,17 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     .render(ctx.renderer, pos, &mut |elem| push(elem.into()));
             }
 
+            if col.render_tab_switch(
+                renderer,
+                view_off + col_off + col_render_off,
+                focus_ring && first,
+                target,
+                &mut |elem| push(elem.into()),
+            ) {
+                first = false;
+                continue;
+            }
+
             for (tile, tile_off, visible) in col.tiles_in_render_order() {
                 let tile_pos =
                     view_off + col_off + col_render_off + tile_off + tile.render_offset();
@@ -3971,6 +3989,7 @@ impl<W: LayoutElement> Column<W> {
             display_mode,
             tab_indicator: TabIndicator::new(options.layout.tab_indicator),
             move_animation: None,
+            tab_switch_animation: None,
             view_size,
             working_area,
             parent_area,
@@ -4058,6 +4077,10 @@ impl<W: LayoutElement> Column<W> {
         self.scale = scale;
         self.options = options;
 
+        if !self.should_animate_tab_switch() {
+            self.tab_switch_animation = None;
+        }
+
         if update_sizes {
             self.update_tile_sizes(false);
         }
@@ -4078,6 +4101,14 @@ impl<W: LayoutElement> Column<W> {
             }
         }
 
+        if self
+            .tab_switch_animation
+            .as_ref()
+            .is_some_and(|animation| animation.anim.is_done() || !self.should_animate_tab_switch())
+        {
+            self.tab_switch_animation = None;
+        }
+
         for tile in &mut self.tiles {
             tile.advance_animations();
         }
@@ -4087,12 +4118,14 @@ impl<W: LayoutElement> Column<W> {
 
     pub fn are_animations_ongoing(&self) -> bool {
         self.move_animation.is_some()
+            || self.tab_switch_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_animations_ongoing)
     }
 
     pub fn are_transitions_ongoing(&self) -> bool {
         self.move_animation.is_some()
+            || self.tab_switch_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_transitions_ongoing)
     }
@@ -4161,6 +4194,164 @@ impl<W: LayoutElement> Column<W> {
         }
 
         offset
+    }
+
+    fn should_animate_tab_switch(&self) -> bool {
+        self.display_mode == ColumnDisplay::Tabbed
+            && self.tiles.len() > 1
+            && self.sizing_mode().is_normal()
+            && !self.options.animations.tab_switch.anim.off
+    }
+
+    fn animate_tile_on_tab_switch(
+        &self,
+        animation: &TabSwitchAnimation,
+        tile_idx: usize,
+        progress: f64,
+    ) -> Point<f64, Logical> {
+        let strip_offset = |active_idx| -> Point<f64, Logical> {
+            match self.options.animations.tab_switch.direction {
+                TabSwitchDirection::Horizontal => {
+                    Point::from(((tile_idx as f64 - active_idx as f64) * self.width(), 0.))
+                }
+                TabSwitchDirection::Vertical => {
+                    let offset = if tile_idx < active_idx {
+                        -self.data[tile_idx..active_idx]
+                            .iter()
+                            .map(|data| data.size.h)
+                            .sum::<f64>()
+                    } else {
+                        self.data[active_idx..tile_idx]
+                            .iter()
+                            .map(|data| data.size.h)
+                            .sum::<f64>()
+                    };
+                    Point::from((0., offset))
+                }
+            }
+        };
+
+        let from = strip_offset(animation.from_idx);
+        let to = strip_offset(animation.to_idx);
+        Point::from((
+            from.x + (to.x - from.x) * progress,
+            from.y + (to.y - from.y) * progress,
+        ))
+    }
+
+    fn render_tab_switch<R: NiriRenderer>(
+        &self,
+        renderer: &mut R,
+        column_loc: Point<f64, Logical>,
+        focus_ring: bool,
+        target: RenderTarget,
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) -> bool {
+        let Some(animation) = self.tab_switch_animation.as_ref() else {
+            return false;
+        };
+        if !self.should_animate_tab_switch() {
+            return false;
+        }
+
+        let frame_loc = (column_loc + self.tiles_origin())
+            .to_physical_precise_round(self.scale)
+            .to_logical(self.scale);
+        let active_tile = &self.tiles[self.active_tile_idx];
+        let active_content_origin = active_tile.tab_switch_content_origin();
+        let (clip_geo, clip_radius) = active_tile.tab_switch_mask(frame_loc);
+        let progress = animation.anim.clamped_value();
+        let horizontal =
+            self.options.animations.tab_switch.direction == TabSwitchDirection::Horizontal;
+
+        let strip = (0..self.tiles.len())
+            .into_iter()
+            .map(|idx| {
+                let tile = &self.tiles[idx];
+                let offset = self.animate_tile_on_tab_switch(animation, idx, progress);
+                let location =
+                    frame_loc + offset + active_content_origin - tile.tab_switch_content_origin();
+                let content_loc = location + tile.tab_switch_content_origin();
+                (tile, location, content_loc)
+            })
+            .collect::<Vec<_>>();
+
+        let clip_start = if horizontal {
+            clip_geo.loc.x
+        } else {
+            clip_geo.loc.y
+        };
+        let clip_end = clip_start
+            + if horizontal {
+                clip_geo.size.w
+            } else {
+                clip_geo.size.h
+            };
+
+        let mut crops = vec![None; strip.len()];
+        let mut sorted = strip
+            .iter()
+            .enumerate()
+            .map(|(order, (_, _, content_loc))| {
+                (
+                    order,
+                    if horizontal {
+                        content_loc.x
+                    } else {
+                        content_loc.y
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        sorted.sort_by(|(_, lhs), (_, rhs)| lhs.total_cmp(rhs));
+
+        for sorted_idx in 0..sorted.len() {
+            let (order, start) = sorted[sorted_idx];
+            let start = clip_start.max(start);
+            let end = sorted
+                .get(sorted_idx + 1)
+                .map(|(_, next)| clip_end.min(*next))
+                .unwrap_or(clip_end);
+            if end <= start {
+                continue;
+            }
+
+            crops[order] = Some(if horizontal {
+                Rectangle::new(
+                    Point::from((start, clip_geo.loc.y)),
+                    Size::from((end - start, clip_geo.size.h)),
+                )
+            } else {
+                Rectangle::new(
+                    Point::from((clip_geo.loc.x, start)),
+                    Size::from((clip_geo.size.w, end - start)),
+                )
+            });
+        }
+
+        for ((tile, location, _), crop_geo) in zip(strip, crops) {
+            let Some(crop_geo) = crop_geo else {
+                continue;
+            };
+
+            tile.render_tab_switch_contents(
+                renderer,
+                location,
+                clip_geo,
+                crop_geo,
+                clip_radius,
+                target,
+                push,
+            );
+        }
+
+        active_tile.render_frame(
+            renderer,
+            frame_loc + active_tile.bob_offset(),
+            focus_ring,
+            push,
+        );
+        true
     }
 
     pub fn animate_move_from(&mut self, from_x_offset: f64) {
@@ -4278,12 +4469,27 @@ impl<W: LayoutElement> Column<W> {
     }
 
     fn activate_idx(&mut self, idx: usize) -> bool {
-        if self.active_tile_idx == idx {
+        let old_idx = self.active_tile_idx;
+        if old_idx == idx {
             return false;
         }
 
+        self.tab_switch_animation = if self.should_animate_tab_switch() {
+            Some(TabSwitchAnimation {
+                anim: Animation::new(
+                    self.clock.clone(),
+                    0.,
+                    1.,
+                    0.,
+                    self.options.animations.tab_switch.anim,
+                ),
+                from_idx: old_idx,
+                to_idx: idx,
+            })
+        } else {
+            None
+        };
         self.active_tile_idx = idx;
-
         self.tiles[idx].ensure_alpha_animates_to_1();
 
         true
@@ -4296,6 +4502,7 @@ impl<W: LayoutElement> Column<W> {
 
     fn add_tile_at(&mut self, idx: usize, mut tile: Tile<W>) {
         tile.update_config(self.view_size, self.scale, self.options.clone());
+        self.tab_switch_animation = None;
 
         // Inserting a tile pushes down all tiles below it, but also in always-centering mode it
         // will affect the X position of all tiles in the column.
@@ -4753,6 +4960,8 @@ impl<W: LayoutElement> Column<W> {
             return false;
         }
 
+        self.tab_switch_animation = None;
+
         let mut ys = self.tile_offsets().skip(self.active_tile_idx);
         let active_y = ys.next().unwrap().y;
         let next_y = ys.next().unwrap().y;
@@ -4775,6 +4984,8 @@ impl<W: LayoutElement> Column<W> {
         if self.active_tile_idx == new_idx {
             return false;
         }
+
+        self.tab_switch_animation = None;
 
         let mut ys = self.tile_offsets().skip(self.active_tile_idx);
         let active_y = ys.next().unwrap().y;
@@ -5112,6 +5323,8 @@ impl<W: LayoutElement> Column<W> {
         if self.display_mode == display {
             return;
         }
+
+        self.tab_switch_animation = None;
 
         // Animate the movement.
         //

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4209,21 +4209,29 @@ impl<W: LayoutElement> Column<W> {
         tile_idx: usize,
         progress: f64,
     ) -> Point<f64, Logical> {
+        let strip_size = |idx: usize| self.tiles[idx].animated_window_size();
         let strip_offset = |active_idx| -> Point<f64, Logical> {
             match self.options.animations.tab_switch.direction {
                 TabSwitchDirection::Horizontal => {
-                    Point::from(((tile_idx as f64 - active_idx as f64) * self.width(), 0.))
+                    let offset = if tile_idx < active_idx {
+                        -(tile_idx..active_idx)
+                            .map(|idx| strip_size(idx).w)
+                            .sum::<f64>()
+                    } else {
+                        (active_idx..tile_idx)
+                            .map(|idx| strip_size(idx).w)
+                            .sum::<f64>()
+                    };
+                    Point::from((offset, 0.))
                 }
                 TabSwitchDirection::Vertical => {
                     let offset = if tile_idx < active_idx {
-                        -self.data[tile_idx..active_idx]
-                            .iter()
-                            .map(|data| data.size.h)
+                        -(tile_idx..active_idx)
+                            .map(|idx| strip_size(idx).h)
                             .sum::<f64>()
                     } else {
-                        self.data[active_idx..tile_idx]
-                            .iter()
-                            .map(|data| data.size.h)
+                        (active_idx..tile_idx)
+                            .map(|idx| strip_size(idx).h)
                             .sum::<f64>()
                     };
                     Point::from((0., offset))
@@ -4272,7 +4280,8 @@ impl<W: LayoutElement> Column<W> {
                 let location =
                     frame_loc + offset + active_content_origin - tile.tab_switch_content_origin();
                 let content_loc = location + tile.tab_switch_content_origin();
-                (tile, location, content_loc)
+                let content_size = tile.animated_window_size();
+                (tile, location, content_loc, content_size)
             })
             .collect::<Vec<_>>();
 
@@ -4287,36 +4296,25 @@ impl<W: LayoutElement> Column<W> {
             } else {
                 clip_geo.size.h
             };
-
-        let mut crops = vec![None; strip.len()];
-        let mut sorted = strip
-            .iter()
-            .enumerate()
-            .map(|(order, (_, _, content_loc))| {
-                (
-                    order,
-                    if horizontal {
-                        content_loc.x
-                    } else {
-                        content_loc.y
-                    },
-                )
-            })
-            .collect::<Vec<_>>();
-        sorted.sort_by(|(_, lhs), (_, rhs)| lhs.total_cmp(rhs));
-
-        for sorted_idx in 0..sorted.len() {
-            let (order, start) = sorted[sorted_idx];
+        for (tile, location, content_loc, content_size) in strip {
+            let start = if horizontal {
+                content_loc.x
+            } else {
+                content_loc.y
+            };
+            let end = start
+                + if horizontal {
+                    content_size.w
+                } else {
+                    content_size.h
+            };
             let start = clip_start.max(start);
-            let end = sorted
-                .get(sorted_idx + 1)
-                .map(|(_, next)| clip_end.min(*next))
-                .unwrap_or(clip_end);
+            let end = clip_end.min(end);
             if end <= start {
                 continue;
             }
 
-            crops[order] = Some(if horizontal {
+            let crop_geo = if horizontal {
                 Rectangle::new(
                     Point::from((start, clip_geo.loc.y)),
                     Size::from((end - start, clip_geo.size.h)),
@@ -4326,12 +4324,6 @@ impl<W: LayoutElement> Column<W> {
                     Point::from((clip_geo.loc.x, start)),
                     Size::from((clip_geo.size.w, end - start)),
                 )
-            });
-        }
-
-        for ((tile, location, _), crop_geo) in zip(strip, crops) {
-            let Some(crop_geo) = crop_geo else {
-                continue;
             };
 
             tile.render_tab_switch_contents(
@@ -4531,17 +4523,18 @@ impl<W: LayoutElement> Column<W> {
     }
 
     fn update_window(&mut self, window: &W::Id) {
-        let (tile_idx, tile) = self
+        let tile_idx = self
             .tiles
-            .iter_mut()
-            .enumerate()
-            .find(|(_, tile)| tile.window().id() == window)
+            .iter()
+            .position(|tile| tile.window().id() == window)
             .unwrap();
 
         let prev_height = self.data[tile_idx].size.h;
-
-        tile.update_window();
-        self.data[tile_idx].update(tile);
+        {
+            let tile = &mut self.tiles[tile_idx];
+            tile.update_window();
+            self.data[tile_idx].update(tile);
+        }
 
         let offset = prev_height - self.data[tile_idx].size.h;
 
@@ -4554,7 +4547,7 @@ impl<W: LayoutElement> Column<W> {
         // animated vs. non-animated resizes? For example, an animated +20 resize followed by two
         // non-animated -10 resizes.
         if !is_tabbed && offset != 0. {
-            if tile.resize_animation().is_some() {
+            if self.tiles[tile_idx].resize_animation().is_some() {
                 // If there's a resize animation (that may have just started in
                 // tile.update_window()), then the apparent size change is smooth with no sudden
                 // jumps. This corresponds to adding an Y animation to tiles below.

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri_config::utils::MergeWith as _;
-use niri_config::{CenterFocusedColumn, PresetSize, Struts, ColumnTabSwitchDirection};
+use niri_config::{CenterFocusedColumn, ColumnTabSwitchDirection, PresetSize, Struts};
 use niri_ipc::{ColumnDisplay, SizeChange, WindowLayout};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -4104,7 +4104,9 @@ impl<W: LayoutElement> Column<W> {
         if self
             .column_tab_switch_animation
             .as_ref()
-            .is_some_and(|animation| animation.anim.is_done() || !self.should_animate_column_tab_switch())
+            .is_some_and(|animation| {
+                animation.anim.is_done() || !self.should_animate_column_tab_switch()
+            })
         {
             self.column_tab_switch_animation = None;
         }
@@ -4209,42 +4211,31 @@ impl<W: LayoutElement> Column<W> {
         tile_idx: usize,
         progress: f64,
     ) -> Point<f64, Logical> {
-        let strip_size = |idx: usize| self.tiles[idx].animated_window_size();
-        let strip_offset = |active_idx| -> Point<f64, Logical> {
-            match self.options.animations.column_tab_switch.direction {
-                ColumnTabSwitchDirection::Horizontal => {
-                    let offset = if tile_idx < active_idx {
-                        -(tile_idx..active_idx)
-                            .map(|idx| strip_size(idx).w)
-                            .sum::<f64>()
-                    } else {
-                        (active_idx..tile_idx)
-                            .map(|idx| strip_size(idx).w)
-                            .sum::<f64>()
-                    };
-                    Point::from((offset, 0.))
-                }
-                ColumnTabSwitchDirection::Vertical => {
-                    let offset = if tile_idx < active_idx {
-                        -(tile_idx..active_idx)
-                            .map(|idx| strip_size(idx).h)
-                            .sum::<f64>()
-                    } else {
-                        (active_idx..tile_idx)
-                            .map(|idx| strip_size(idx).h)
-                            .sum::<f64>()
-                    };
-                    Point::from((0., offset))
-                }
+        let direction = self.options.animations.column_tab_switch.direction;
+        let strip_size = |idx: usize| {
+            let size = self.tiles[idx].animated_window_size();
+            match direction {
+                ColumnTabSwitchDirection::Horizontal => size.w,
+                ColumnTabSwitchDirection::Vertical => size.h,
+            }
+        };
+
+        let strip_offset = |active_idx| {
+            if tile_idx < active_idx {
+                -(tile_idx..active_idx).map(strip_size).sum::<f64>()
+            } else {
+                (active_idx..tile_idx).map(strip_size).sum::<f64>()
             }
         };
 
         let from = strip_offset(animation.from_idx);
         let to = strip_offset(animation.to_idx);
-        Point::from((
-            from.x + (to.x - from.x) * progress,
-            from.y + (to.y - from.y) * progress,
-        ))
+        let offset = from + (to - from) * progress;
+
+        match direction {
+            ColumnTabSwitchDirection::Horizontal => Point::from((offset, 0.)),
+            ColumnTabSwitchDirection::Vertical => Point::from((0., offset)),
+        }
     }
 
     fn render_column_tab_switch<R: NiriRenderer>(
@@ -4269,21 +4260,8 @@ impl<W: LayoutElement> Column<W> {
         let active_content_origin = active_tile.column_tab_switch_content_origin();
         let (clip_geo, clip_radius) = active_tile.column_tab_switch_mask(frame_loc);
         let progress = animation.anim.clamped_value();
-        let horizontal =
-            self.options.animations.column_tab_switch.direction == ColumnTabSwitchDirection::Horizontal;
-
-        let strip = (0..self.tiles.len())
-            .into_iter()
-            .map(|idx| {
-                let tile = &self.tiles[idx];
-                let offset = self.animate_tile_on_column_tab_switch(animation, idx, progress);
-                let location =
-                    frame_loc + offset + active_content_origin - tile.column_tab_switch_content_origin();
-                let content_loc = location + tile.column_tab_switch_content_origin();
-                let content_size = tile.animated_window_size();
-                (tile, location, content_loc, content_size)
-            })
-            .collect::<Vec<_>>();
+        let horizontal = self.options.animations.column_tab_switch.direction
+            == ColumnTabSwitchDirection::Horizontal;
 
         let clip_start = if horizontal {
             clip_geo.loc.x
@@ -4296,7 +4274,15 @@ impl<W: LayoutElement> Column<W> {
             } else {
                 clip_geo.size.h
             };
-        for (tile, location, content_loc, content_size) in strip {
+        
+        // Go through the tiles in order and apply animation to tiles that are affected.
+        for idx in 0..self.tiles.len() {
+            let tile = &self.tiles[idx];
+            let offset = self.animate_tile_on_column_tab_switch(animation, idx, progress);
+            let content_loc = frame_loc + offset + active_content_origin;
+            let location = content_loc - tile.column_tab_switch_content_origin();
+            let content_size = tile.animated_window_size();
+
             let start = if horizontal {
                 content_loc.x
             } else {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri_config::utils::MergeWith as _;
-use niri_config::{CenterFocusedColumn, PresetSize, Struts, TabSwitchDirection};
+use niri_config::{CenterFocusedColumn, PresetSize, Struts, ColumnTabSwitchDirection};
 use niri_ipc::{ColumnDisplay, SizeChange, WindowLayout};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -196,7 +196,7 @@ pub struct Column<W: LayoutElement> {
     move_animation: Option<MoveAnimation>,
 
     /// Animation of the tab strip sliding under the active frame.
-    tab_switch_animation: Option<TabSwitchAnimation>,
+    column_tab_switch_animation: Option<ColumnTabSwitchAnimation>,
 
     /// Latest known view size for this column's workspace.
     view_size: Size<f64, Logical>,
@@ -286,7 +286,7 @@ struct MoveAnimation {
 }
 
 #[derive(Debug)]
-struct TabSwitchAnimation {
+struct ColumnTabSwitchAnimation {
     anim: Animation,
     from_idx: usize,
     to_idx: usize,
@@ -1080,7 +1080,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let column = &mut self.columns[column_idx];
         let prev_width = self.data[column_idx].width;
-        column.tab_switch_animation = None;
+        column.column_tab_switch_animation = None;
 
         let movement_config = anim_config.unwrap_or(self.options.animations.window_movement.0);
 
@@ -2941,7 +2941,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     .render(ctx.renderer, pos, &mut |elem| push(elem.into()));
             }
 
-            if col.render_tab_switch(
+            if col.render_column_tab_switch(
                 ctx.renderer,
                 view_off + col_off + col_render_off,
                 focus_ring && first,
@@ -3989,7 +3989,7 @@ impl<W: LayoutElement> Column<W> {
             display_mode,
             tab_indicator: TabIndicator::new(options.layout.tab_indicator),
             move_animation: None,
-            tab_switch_animation: None,
+            column_tab_switch_animation: None,
             view_size,
             working_area,
             parent_area,
@@ -4077,8 +4077,8 @@ impl<W: LayoutElement> Column<W> {
         self.scale = scale;
         self.options = options;
 
-        if !self.should_animate_tab_switch() {
-            self.tab_switch_animation = None;
+        if !self.should_animate_column_tab_switch() {
+            self.column_tab_switch_animation = None;
         }
 
         if update_sizes {
@@ -4102,11 +4102,11 @@ impl<W: LayoutElement> Column<W> {
         }
 
         if self
-            .tab_switch_animation
+            .column_tab_switch_animation
             .as_ref()
-            .is_some_and(|animation| animation.anim.is_done() || !self.should_animate_tab_switch())
+            .is_some_and(|animation| animation.anim.is_done() || !self.should_animate_column_tab_switch())
         {
-            self.tab_switch_animation = None;
+            self.column_tab_switch_animation = None;
         }
 
         for tile in &mut self.tiles {
@@ -4118,14 +4118,14 @@ impl<W: LayoutElement> Column<W> {
 
     pub fn are_animations_ongoing(&self) -> bool {
         self.move_animation.is_some()
-            || self.tab_switch_animation.is_some()
+            || self.column_tab_switch_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_animations_ongoing)
     }
 
     pub fn are_transitions_ongoing(&self) -> bool {
         self.move_animation.is_some()
-            || self.tab_switch_animation.is_some()
+            || self.column_tab_switch_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_transitions_ongoing)
     }
@@ -4196,23 +4196,23 @@ impl<W: LayoutElement> Column<W> {
         offset
     }
 
-    fn should_animate_tab_switch(&self) -> bool {
+    fn should_animate_column_tab_switch(&self) -> bool {
         self.display_mode == ColumnDisplay::Tabbed
             && self.tiles.len() > 1
             && self.sizing_mode().is_normal()
-            && !self.options.animations.tab_switch.anim.off
+            && !self.options.animations.column_tab_switch.anim.off
     }
 
-    fn animate_tile_on_tab_switch(
+    fn animate_tile_on_column_tab_switch(
         &self,
-        animation: &TabSwitchAnimation,
+        animation: &ColumnTabSwitchAnimation,
         tile_idx: usize,
         progress: f64,
     ) -> Point<f64, Logical> {
         let strip_size = |idx: usize| self.tiles[idx].animated_window_size();
         let strip_offset = |active_idx| -> Point<f64, Logical> {
-            match self.options.animations.tab_switch.direction {
-                TabSwitchDirection::Horizontal => {
+            match self.options.animations.column_tab_switch.direction {
+                ColumnTabSwitchDirection::Horizontal => {
                     let offset = if tile_idx < active_idx {
                         -(tile_idx..active_idx)
                             .map(|idx| strip_size(idx).w)
@@ -4224,7 +4224,7 @@ impl<W: LayoutElement> Column<W> {
                     };
                     Point::from((offset, 0.))
                 }
-                TabSwitchDirection::Vertical => {
+                ColumnTabSwitchDirection::Vertical => {
                     let offset = if tile_idx < active_idx {
                         -(tile_idx..active_idx)
                             .map(|idx| strip_size(idx).h)
@@ -4247,7 +4247,7 @@ impl<W: LayoutElement> Column<W> {
         ))
     }
 
-    fn render_tab_switch<R: NiriRenderer>(
+    fn render_column_tab_switch<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         column_loc: Point<f64, Logical>,
@@ -4255,10 +4255,10 @@ impl<W: LayoutElement> Column<W> {
         target: RenderTarget,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) -> bool {
-        let Some(animation) = self.tab_switch_animation.as_ref() else {
+        let Some(animation) = self.column_tab_switch_animation.as_ref() else {
             return false;
         };
-        if !self.should_animate_tab_switch() {
+        if !self.should_animate_column_tab_switch() {
             return false;
         }
 
@@ -4266,20 +4266,20 @@ impl<W: LayoutElement> Column<W> {
             .to_physical_precise_round(self.scale)
             .to_logical(self.scale);
         let active_tile = &self.tiles[self.active_tile_idx];
-        let active_content_origin = active_tile.tab_switch_content_origin();
-        let (clip_geo, clip_radius) = active_tile.tab_switch_mask(frame_loc);
+        let active_content_origin = active_tile.column_tab_switch_content_origin();
+        let (clip_geo, clip_radius) = active_tile.column_tab_switch_mask(frame_loc);
         let progress = animation.anim.clamped_value();
         let horizontal =
-            self.options.animations.tab_switch.direction == TabSwitchDirection::Horizontal;
+            self.options.animations.column_tab_switch.direction == ColumnTabSwitchDirection::Horizontal;
 
         let strip = (0..self.tiles.len())
             .into_iter()
             .map(|idx| {
                 let tile = &self.tiles[idx];
-                let offset = self.animate_tile_on_tab_switch(animation, idx, progress);
+                let offset = self.animate_tile_on_column_tab_switch(animation, idx, progress);
                 let location =
-                    frame_loc + offset + active_content_origin - tile.tab_switch_content_origin();
-                let content_loc = location + tile.tab_switch_content_origin();
+                    frame_loc + offset + active_content_origin - tile.column_tab_switch_content_origin();
+                let content_loc = location + tile.column_tab_switch_content_origin();
                 let content_size = tile.animated_window_size();
                 (tile, location, content_loc, content_size)
             })
@@ -4466,14 +4466,14 @@ impl<W: LayoutElement> Column<W> {
             return false;
         }
 
-        self.tab_switch_animation = if self.should_animate_tab_switch() {
-            Some(TabSwitchAnimation {
+        self.column_tab_switch_animation = if self.should_animate_column_tab_switch() {
+            Some(ColumnTabSwitchAnimation {
                 anim: Animation::new(
                     self.clock.clone(),
                     0.,
                     1.,
                     0.,
-                    self.options.animations.tab_switch.anim,
+                    self.options.animations.column_tab_switch.anim,
                 ),
                 from_idx: old_idx,
                 to_idx: idx,
@@ -4494,7 +4494,7 @@ impl<W: LayoutElement> Column<W> {
 
     fn add_tile_at(&mut self, idx: usize, mut tile: Tile<W>) {
         tile.update_config(self.view_size, self.scale, self.options.clone());
-        self.tab_switch_animation = None;
+        self.column_tab_switch_animation = None;
 
         // Inserting a tile pushes down all tiles below it, but also in always-centering mode it
         // will affect the X position of all tiles in the column.
@@ -4953,7 +4953,7 @@ impl<W: LayoutElement> Column<W> {
             return false;
         }
 
-        self.tab_switch_animation = None;
+        self.column_tab_switch_animation = None;
 
         let mut ys = self.tile_offsets().skip(self.active_tile_idx);
         let active_y = ys.next().unwrap().y;
@@ -4978,7 +4978,7 @@ impl<W: LayoutElement> Column<W> {
             return false;
         }
 
-        self.tab_switch_animation = None;
+        self.column_tab_switch_animation = None;
 
         let mut ys = self.tile_offsets().skip(self.active_tile_idx);
         let active_y = ys.next().unwrap().y;
@@ -5317,7 +5317,7 @@ impl<W: LayoutElement> Column<W> {
             return;
         }
 
-        self.tab_switch_animation = None;
+        self.column_tab_switch_animation = None;
 
         // Animate the movement.
         //

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4274,7 +4274,7 @@ impl<W: LayoutElement> Column<W> {
             } else {
                 clip_geo.size.h
             };
-        
+
         // Go through the tiles in order and apply animation to tiles that are affected.
         for idx in 0..self.tiles.len() {
             let tile = &self.tiles[idx];

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4201,7 +4201,6 @@ impl<W: LayoutElement> Column<W> {
     fn should_animate_column_tab_switch(&self) -> bool {
         self.display_mode == ColumnDisplay::Tabbed
             && self.tiles.len() > 1
-            && self.sizing_mode().is_normal()
             && !self.options.animations.column_tab_switch.anim.off
     }
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4219,13 +4219,12 @@ impl<W: LayoutElement> Column<W> {
 
     fn should_animate_column_tab_switch(&self) -> bool {
         self.display_mode == ColumnDisplay::Tabbed
-            && self.tiles.len() > 1
+            && (self.tiles.len() > 1 || self.column_tab_switch_animation.is_some())
             && !self.options.animations.column_tab_switch.anim.off
     }
 
     fn start_column_tab_switch_animation(&mut self, from_idx: usize, to_idx: usize) {
         if self.display_mode != ColumnDisplay::Tabbed
-            || self.tiles.len() <= 1
             || self.options.animations.column_tab_switch.anim.off
             || to_idx >= self.tiles.len()
             || from_idx > self.tiles.len()

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -22,7 +22,7 @@ use crate::layout::SizingMode;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::xray::XrayPos;
-use crate::render_helpers::{RenderCtx, RenderTarget};
+use crate::render_helpers::RenderCtx;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::ResizeEdge;
 use crate::window::ResolvedWindowRules;
@@ -2021,9 +2021,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         let source_tile_idx = source_column.tiles.len() - 1;
-        let expelled_active_tab =
-            source_column.display_mode == ColumnDisplay::Tabbed
-                && source_column.active_tile_idx == source_tile_idx;
+        let expelled_active_tab = source_column.display_mode == ColumnDisplay::Tabbed
+            && source_column.active_tile_idx == source_tile_idx;
 
         let mut offset = Point::from((source_column.render_offset().x, 0.));
         let prev_off = source_column.tile_offset(source_tile_idx);
@@ -2033,10 +2032,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         if expelled_active_tab {
             let source_column = &mut self.columns[source_col_idx];
-            source_column.start_column_tab_switch_animation(
-                source_tile_idx,
-                source_column.active_tile_idx,
-            );
+            source_column
+                .start_column_tab_switch_animation(source_tile_idx, source_column.active_tile_idx);
         }
 
         self.add_tile(
@@ -2961,10 +2958,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             }
 
             if col.render_column_tab_switch(
-                ctx.renderer,
+                ctx.r(),
                 view_off + col_off + col_render_off,
+                xray_pos,
                 focus_ring && first,
-                ctx.target,
                 &mut |elem| push(elem.into()),
             ) {
                 first = false;
@@ -4282,10 +4279,10 @@ impl<W: LayoutElement> Column<W> {
 
     fn render_column_tab_switch<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        mut ctx: RenderCtx<R>,
         column_loc: Point<f64, Logical>,
+        xray_pos: XrayPos,
         focus_ring: bool,
-        target: RenderTarget,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) -> bool {
         let Some(animation) = self.column_tab_switch_animation.as_ref() else {
@@ -4355,18 +4352,25 @@ impl<W: LayoutElement> Column<W> {
             };
 
             tile.render_tab_switch_contents(
-                renderer,
+                ctx.renderer,
                 location,
                 clip_geo,
                 crop_geo,
                 clip_radius,
-                target,
+                ctx.target,
+                push,
+            );
+            tile.render_tab_switch_background_effect(
+                ctx.r(),
+                location,
+                crop_geo,
+                xray_pos.offset(location),
                 push,
             );
         }
 
         active_tile.render_frame(
-            renderer,
+            ctx.renderer,
             frame_loc + active_tile.bob_offset(),
             focus_ring,
             push,

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1555,6 +1555,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             .any(|col| col.start_open_animation(id))
     }
 
+    #[cfg(test)]
+    pub fn active_column_tab_switch_animation(&self) -> Option<(usize, usize)> {
+        self.columns
+            .get(self.active_column_idx)
+            .and_then(|col| col.column_tab_switch_animation.as_ref())
+            .map(|anim| (anim.from_idx, anim.to_idx))
+    }
+
     pub fn focus_left(&mut self) -> bool {
         if self.active_column_idx == 0 {
             return false;
@@ -2013,12 +2021,23 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         let source_tile_idx = source_column.tiles.len() - 1;
+        let expelled_active_tab =
+            source_column.display_mode == ColumnDisplay::Tabbed
+                && source_column.active_tile_idx == source_tile_idx;
 
         let mut offset = Point::from((source_column.render_offset().x, 0.));
         let prev_off = source_column.tile_offset(source_tile_idx);
 
         let removed =
             self.remove_tile_by_idx(source_col_idx, source_tile_idx, Transaction::new(), None);
+
+        if expelled_active_tab {
+            let source_column = &mut self.columns[source_col_idx];
+            source_column.start_column_tab_switch_animation(
+                source_tile_idx,
+                source_column.active_tile_idx,
+            );
+        }
 
         self.add_tile(
             Some(target_col_idx),
@@ -4204,6 +4223,31 @@ impl<W: LayoutElement> Column<W> {
             && !self.options.animations.column_tab_switch.anim.off
     }
 
+    fn start_column_tab_switch_animation(&mut self, from_idx: usize, to_idx: usize) {
+        if self.display_mode != ColumnDisplay::Tabbed
+            || self.tiles.len() <= 1
+            || self.options.animations.column_tab_switch.anim.off
+            || to_idx >= self.tiles.len()
+            || from_idx > self.tiles.len()
+            || from_idx == to_idx
+        {
+            self.column_tab_switch_animation = None;
+            return;
+        }
+
+        self.column_tab_switch_animation = Some(ColumnTabSwitchAnimation {
+            anim: Animation::new(
+                self.clock.clone(),
+                0.,
+                1.,
+                0.,
+                self.options.animations.column_tab_switch.anim,
+            ),
+            from_idx,
+            to_idx,
+        });
+    }
+
     fn animate_tile_on_column_tab_switch(
         &self,
         animation: &ColumnTabSwitchAnimation,
@@ -4470,21 +4514,7 @@ impl<W: LayoutElement> Column<W> {
             return false;
         }
 
-        self.column_tab_switch_animation = if self.should_animate_column_tab_switch() {
-            Some(ColumnTabSwitchAnimation {
-                anim: Animation::new(
-                    self.clock.clone(),
-                    0.,
-                    1.,
-                    0.,
-                    self.options.animations.column_tab_switch.anim,
-                ),
-                from_idx: old_idx,
-                to_idx: idx,
-            })
-        } else {
-            None
-        };
+        self.start_column_tab_switch_animation(old_idx, idx);
         self.active_tile_idx = idx;
         self.tiles[idx].ensure_alpha_animates_to_1();
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri_config::utils::MergeWith as _;
-use niri_config::{CenterFocusedColumn, PresetSize, Struts};
+use niri_config::{CenterFocusedColumn, PresetSize, Struts, TabSwitchDirection};
 use niri_ipc::{ColumnDisplay, SizeChange, WindowLayout};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -22,7 +22,7 @@ use crate::layout::{RenderLayer, SizingMode};
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::xray::XrayPos;
-use crate::render_helpers::RenderCtx;
+use crate::render_helpers::{RenderCtx, RenderTarget};
 use crate::utils::id::IdCounter;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::ResizeEdge;
@@ -218,6 +218,9 @@ pub struct Column<W: LayoutElement> {
     /// Animation of a column visually moving vertically.
     move_y_animation: Option<MoveAnimation>,
 
+    /// Animation of the tab strip sliding under the active frame.
+    tab_switch_animation: Option<TabSwitchAnimation>,
+
     /// Latest known view size for this column's workspace.
     view_size: Size<f64, Logical>,
 
@@ -310,6 +313,13 @@ struct MoveAnimation {
     ///
     /// Controls whether the tile is rendered uncropped and above others.
     is_between_workspaces: bool,
+}
+
+#[derive(Debug)]
+struct TabSwitchAnimation {
+    anim: Animation,
+    from_idx: usize,
+    to_idx: usize,
 }
 
 impl<W: LayoutElement> ScrollingSpace<W> {
@@ -944,7 +954,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         if activate {
-            target_column.activate_idx(tile_idx);
+            target_column.active_tile_idx = tile_idx;
+            target_column.tiles[tile_idx].ensure_alpha_animates_to_1();
             if self.active_column_idx != col_idx {
                 self.activate_column(col_idx);
             }
@@ -1091,6 +1102,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let column = &mut self.columns[column_idx];
         let prev_width = self.data[column_idx].width;
+        column.tab_switch_animation = None;
 
         let movement_config = anim_config.unwrap_or(self.options.animations.window_movement.0);
 
@@ -1146,13 +1158,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             column.active_tile_idx -= 1;
         } else if tile_idx == column.active_tile_idx {
             // The active tile was removed, so the active tile index shifted to the next tile.
-            if tile_idx == column.tiles.len() {
-                // The bottom tile was removed and it was active, update active idx to remain valid.
-                column.activate_idx(tile_idx - 1);
-            } else {
-                // Ensure the newly active tile animates to opaque.
-                column.tiles[tile_idx].ensure_alpha_animates_to_1();
-            }
+            column.active_tile_idx = min(tile_idx, column.tiles.len() - 1);
+            column.tiles[column.active_tile_idx].ensure_alpha_animates_to_1();
         }
 
         column.update_tile_sizes_with_transaction(true, transaction);
@@ -2983,6 +2990,17 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     .render(ctx.renderer, pos, &mut |elem| push(elem.into()));
             }
 
+            if col.render_tab_switch(
+                ctx.renderer,
+                col_pos,
+                focus_ring && first,
+                ctx.target,
+                &mut |elem| push(elem.into()),
+            ) {
+                first = false;
+                continue;
+            }
+
             for (tile, tile_off, visible) in col.tiles_in_render_order() {
                 let tile_pos = col_pos + tile_off + tile.render_offset();
                 // Round to physical pixels.
@@ -4014,6 +4032,7 @@ impl<W: LayoutElement> Column<W> {
             tab_indicator: TabIndicator::new(options.layout.tab_indicator),
             move_x_animation: None,
             move_y_animation: None,
+            tab_switch_animation: None,
             view_size,
             working_area,
             parent_area,
@@ -4106,6 +4125,10 @@ impl<W: LayoutElement> Column<W> {
         self.scale = scale;
         self.options = options;
 
+        if !self.should_animate_tab_switch() {
+            self.tab_switch_animation = None;
+        }
+
         if update_sizes {
             self.update_tile_sizes(false);
         }
@@ -4131,6 +4154,14 @@ impl<W: LayoutElement> Column<W> {
             }
         }
 
+        if self
+            .tab_switch_animation
+            .as_ref()
+            .is_some_and(|animation| animation.anim.is_done() || !self.should_animate_tab_switch())
+        {
+            self.tab_switch_animation = None;
+        }
+
         for tile in &mut self.tiles {
             tile.advance_animations();
         }
@@ -4141,6 +4172,7 @@ impl<W: LayoutElement> Column<W> {
     pub fn are_animations_ongoing(&self) -> bool {
         self.move_x_animation.is_some()
             || self.move_y_animation.is_some()
+            || self.tab_switch_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_animations_ongoing)
     }
@@ -4148,6 +4180,7 @@ impl<W: LayoutElement> Column<W> {
     pub fn are_transitions_ongoing(&self) -> bool {
         self.move_x_animation.is_some()
             || self.move_y_animation.is_some()
+            || self.tab_switch_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_transitions_ongoing)
     }
@@ -4247,6 +4280,164 @@ impl<W: LayoutElement> Column<W> {
         }
 
         offset
+    }
+
+    fn should_animate_tab_switch(&self) -> bool {
+        self.display_mode == ColumnDisplay::Tabbed
+            && self.tiles.len() > 1
+            && self.sizing_mode().is_normal()
+            && !self.options.animations.tab_switch.anim.off
+    }
+
+    fn animate_tile_on_tab_switch(
+        &self,
+        animation: &TabSwitchAnimation,
+        tile_idx: usize,
+        progress: f64,
+    ) -> Point<f64, Logical> {
+        let strip_offset = |active_idx| -> Point<f64, Logical> {
+            match self.options.animations.tab_switch.direction {
+                TabSwitchDirection::Horizontal => {
+                    Point::from(((tile_idx as f64 - active_idx as f64) * self.width(), 0.))
+                }
+                TabSwitchDirection::Vertical => {
+                    let offset = if tile_idx < active_idx {
+                        -self.data[tile_idx..active_idx]
+                            .iter()
+                            .map(|data| data.size.h)
+                            .sum::<f64>()
+                    } else {
+                        self.data[active_idx..tile_idx]
+                            .iter()
+                            .map(|data| data.size.h)
+                            .sum::<f64>()
+                    };
+                    Point::from((0., offset))
+                }
+            }
+        };
+
+        let from = strip_offset(animation.from_idx);
+        let to = strip_offset(animation.to_idx);
+        Point::from((
+            from.x + (to.x - from.x) * progress,
+            from.y + (to.y - from.y) * progress,
+        ))
+    }
+
+    fn render_tab_switch<R: NiriRenderer>(
+        &self,
+        renderer: &mut R,
+        column_loc: Point<f64, Logical>,
+        focus_ring: bool,
+        target: RenderTarget,
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) -> bool {
+        let Some(animation) = self.tab_switch_animation.as_ref() else {
+            return false;
+        };
+        if !self.should_animate_tab_switch() {
+            return false;
+        }
+
+        let frame_loc = (column_loc + self.tiles_origin())
+            .to_physical_precise_round(self.scale)
+            .to_logical(self.scale);
+        let active_tile = &self.tiles[self.active_tile_idx];
+        let active_content_origin = active_tile.tab_switch_content_origin();
+        let (clip_geo, clip_radius) = active_tile.tab_switch_mask(frame_loc);
+        let progress = animation.anim.clamped_value();
+        let horizontal =
+            self.options.animations.tab_switch.direction == TabSwitchDirection::Horizontal;
+
+        let strip = (0..self.tiles.len())
+            .into_iter()
+            .map(|idx| {
+                let tile = &self.tiles[idx];
+                let offset = self.animate_tile_on_tab_switch(animation, idx, progress);
+                let location =
+                    frame_loc + offset + active_content_origin - tile.tab_switch_content_origin();
+                let content_loc = location + tile.tab_switch_content_origin();
+                (tile, location, content_loc)
+            })
+            .collect::<Vec<_>>();
+
+        let clip_start = if horizontal {
+            clip_geo.loc.x
+        } else {
+            clip_geo.loc.y
+        };
+        let clip_end = clip_start
+            + if horizontal {
+                clip_geo.size.w
+            } else {
+                clip_geo.size.h
+            };
+
+        let mut crops = vec![None; strip.len()];
+        let mut sorted = strip
+            .iter()
+            .enumerate()
+            .map(|(order, (_, _, content_loc))| {
+                (
+                    order,
+                    if horizontal {
+                        content_loc.x
+                    } else {
+                        content_loc.y
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        sorted.sort_by(|(_, lhs), (_, rhs)| lhs.total_cmp(rhs));
+
+        for sorted_idx in 0..sorted.len() {
+            let (order, start) = sorted[sorted_idx];
+            let start = clip_start.max(start);
+            let end = sorted
+                .get(sorted_idx + 1)
+                .map(|(_, next)| clip_end.min(*next))
+                .unwrap_or(clip_end);
+            if end <= start {
+                continue;
+            }
+
+            crops[order] = Some(if horizontal {
+                Rectangle::new(
+                    Point::from((start, clip_geo.loc.y)),
+                    Size::from((end - start, clip_geo.size.h)),
+                )
+            } else {
+                Rectangle::new(
+                    Point::from((clip_geo.loc.x, start)),
+                    Size::from((clip_geo.size.w, end - start)),
+                )
+            });
+        }
+
+        for ((tile, location, _), crop_geo) in zip(strip, crops) {
+            let Some(crop_geo) = crop_geo else {
+                continue;
+            };
+
+            tile.render_tab_switch_contents(
+                renderer,
+                location,
+                clip_geo,
+                crop_geo,
+                clip_radius,
+                target,
+                push,
+            );
+        }
+
+        active_tile.render_frame(
+            renderer,
+            frame_loc + active_tile.bob_offset(),
+            focus_ring,
+            push,
+        );
+        true
     }
 
     pub fn animate_move_from(&mut self, from: Point<f64, Logical>) {
@@ -4409,12 +4600,27 @@ impl<W: LayoutElement> Column<W> {
     }
 
     fn activate_idx(&mut self, idx: usize) -> bool {
-        if self.active_tile_idx == idx {
+        let old_idx = self.active_tile_idx;
+        if old_idx == idx {
             return false;
         }
 
+        self.tab_switch_animation = if self.should_animate_tab_switch() {
+            Some(TabSwitchAnimation {
+                anim: Animation::new(
+                    self.clock.clone(),
+                    0.,
+                    1.,
+                    0.,
+                    self.options.animations.tab_switch.anim,
+                ),
+                from_idx: old_idx,
+                to_idx: idx,
+            })
+        } else {
+            None
+        };
         self.active_tile_idx = idx;
-
         self.tiles[idx].ensure_alpha_animates_to_1();
 
         true
@@ -4427,6 +4633,7 @@ impl<W: LayoutElement> Column<W> {
 
     fn add_tile_at(&mut self, idx: usize, mut tile: Tile<W>) {
         tile.update_config(self.view_size, self.scale, self.options.clone());
+        self.tab_switch_animation = None;
 
         // Inserting a tile pushes down all tiles below it, but also in always-centering mode it
         // will affect the X position of all tiles in the column.
@@ -4884,6 +5091,8 @@ impl<W: LayoutElement> Column<W> {
             return false;
         }
 
+        self.tab_switch_animation = None;
+
         let mut ys = self.tile_offsets().skip(self.active_tile_idx);
         let active_y = ys.next().unwrap().y;
         let next_y = ys.next().unwrap().y;
@@ -4906,6 +5115,8 @@ impl<W: LayoutElement> Column<W> {
         if self.active_tile_idx == new_idx {
             return false;
         }
+
+        self.tab_switch_animation = None;
 
         let mut ys = self.tile_offsets().skip(self.active_tile_idx);
         let active_y = ys.next().unwrap().y;
@@ -5243,6 +5454,8 @@ impl<W: LayoutElement> Column<W> {
         if self.display_mode == display {
             return;
         }
+
+        self.tab_switch_animation = None;
 
         // Animate the movement.
         //

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4295,21 +4295,29 @@ impl<W: LayoutElement> Column<W> {
         tile_idx: usize,
         progress: f64,
     ) -> Point<f64, Logical> {
+        let strip_size = |idx: usize| self.tiles[idx].animated_window_size();
         let strip_offset = |active_idx| -> Point<f64, Logical> {
             match self.options.animations.tab_switch.direction {
                 TabSwitchDirection::Horizontal => {
-                    Point::from(((tile_idx as f64 - active_idx as f64) * self.width(), 0.))
+                    let offset = if tile_idx < active_idx {
+                        -(tile_idx..active_idx)
+                            .map(|idx| strip_size(idx).w)
+                            .sum::<f64>()
+                    } else {
+                        (active_idx..tile_idx)
+                            .map(|idx| strip_size(idx).w)
+                            .sum::<f64>()
+                    };
+                    Point::from((offset, 0.))
                 }
                 TabSwitchDirection::Vertical => {
                     let offset = if tile_idx < active_idx {
-                        -self.data[tile_idx..active_idx]
-                            .iter()
-                            .map(|data| data.size.h)
+                        -(tile_idx..active_idx)
+                            .map(|idx| strip_size(idx).h)
                             .sum::<f64>()
                     } else {
-                        self.data[active_idx..tile_idx]
-                            .iter()
-                            .map(|data| data.size.h)
+                        (active_idx..tile_idx)
+                            .map(|idx| strip_size(idx).h)
                             .sum::<f64>()
                     };
                     Point::from((0., offset))
@@ -4358,7 +4366,8 @@ impl<W: LayoutElement> Column<W> {
                 let location =
                     frame_loc + offset + active_content_origin - tile.tab_switch_content_origin();
                 let content_loc = location + tile.tab_switch_content_origin();
-                (tile, location, content_loc)
+                let content_size = tile.animated_window_size();
+                (tile, location, content_loc, content_size)
             })
             .collect::<Vec<_>>();
 
@@ -4373,36 +4382,25 @@ impl<W: LayoutElement> Column<W> {
             } else {
                 clip_geo.size.h
             };
-
-        let mut crops = vec![None; strip.len()];
-        let mut sorted = strip
-            .iter()
-            .enumerate()
-            .map(|(order, (_, _, content_loc))| {
-                (
-                    order,
-                    if horizontal {
-                        content_loc.x
-                    } else {
-                        content_loc.y
-                    },
-                )
-            })
-            .collect::<Vec<_>>();
-        sorted.sort_by(|(_, lhs), (_, rhs)| lhs.total_cmp(rhs));
-
-        for sorted_idx in 0..sorted.len() {
-            let (order, start) = sorted[sorted_idx];
+        for (tile, location, content_loc, content_size) in strip {
+            let start = if horizontal {
+                content_loc.x
+            } else {
+                content_loc.y
+            };
+            let end = start
+                + if horizontal {
+                    content_size.w
+                } else {
+                    content_size.h
+            };
             let start = clip_start.max(start);
-            let end = sorted
-                .get(sorted_idx + 1)
-                .map(|(_, next)| clip_end.min(*next))
-                .unwrap_or(clip_end);
+            let end = clip_end.min(end);
             if end <= start {
                 continue;
             }
 
-            crops[order] = Some(if horizontal {
+            let crop_geo = if horizontal {
                 Rectangle::new(
                     Point::from((start, clip_geo.loc.y)),
                     Size::from((end - start, clip_geo.size.h)),
@@ -4412,12 +4410,6 @@ impl<W: LayoutElement> Column<W> {
                     Point::from((clip_geo.loc.x, start)),
                     Size::from((clip_geo.size.w, end - start)),
                 )
-            });
-        }
-
-        for ((tile, location, _), crop_geo) in zip(strip, crops) {
-            let Some(crop_geo) = crop_geo else {
-                continue;
             };
 
             tile.render_tab_switch_contents(
@@ -4662,17 +4654,18 @@ impl<W: LayoutElement> Column<W> {
     }
 
     fn update_window(&mut self, window: &W::Id) {
-        let (tile_idx, tile) = self
+        let tile_idx = self
             .tiles
-            .iter_mut()
-            .enumerate()
-            .find(|(_, tile)| tile.window().id() == window)
+            .iter()
+            .position(|tile| tile.window().id() == window)
             .unwrap();
 
         let prev_height = self.data[tile_idx].size.h;
-
-        tile.update_window();
-        self.data[tile_idx].update(tile);
+        {
+            let tile = &mut self.tiles[tile_idx];
+            tile.update_window();
+            self.data[tile_idx].update(tile);
+        }
 
         let offset = prev_height - self.data[tile_idx].size.h;
 
@@ -4685,7 +4678,7 @@ impl<W: LayoutElement> Column<W> {
         // animated vs. non-animated resizes? For example, an animated +20 resize followed by two
         // non-animated -10 resizes.
         if !is_tabbed && offset != 0. {
-            if tile.resize_animation().is_some() {
+            if self.tiles[tile_idx].resize_animation().is_some() {
                 // If there's a resize animation (that may have just started in
                 // tile.update_window()), then the apparent size change is smooth with no sudden
                 // jumps. This corresponds to adding an Y animation to tiles below.

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4287,7 +4287,6 @@ impl<W: LayoutElement> Column<W> {
     fn should_animate_column_tab_switch(&self) -> bool {
         self.display_mode == ColumnDisplay::Tabbed
             && self.tiles.len() > 1
-            && self.sizing_mode().is_normal()
             && !self.options.animations.column_tab_switch.anim.off
     }
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -22,7 +22,7 @@ use crate::layout::{RenderLayer, SizingMode};
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::xray::XrayPos;
-use crate::render_helpers::{RenderCtx, RenderTarget};
+use crate::render_helpers::RenderCtx;
 use crate::utils::id::IdCounter;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::ResizeEdge;
@@ -2050,9 +2050,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         let source_tile_idx = source_column.tiles.len() - 1;
-        let expelled_active_tab =
-            source_column.display_mode == ColumnDisplay::Tabbed
-                && source_column.active_tile_idx == source_tile_idx;
+        let expelled_active_tab = source_column.display_mode == ColumnDisplay::Tabbed
+            && source_column.active_tile_idx == source_tile_idx;
 
         let mut offset = source_column.render_offset();
         let prev_off = source_column.tile_offset(source_tile_idx);
@@ -2062,10 +2061,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         if expelled_active_tab {
             let source_column = &mut self.columns[source_col_idx];
-            source_column.start_column_tab_switch_animation(
-                source_tile_idx,
-                source_column.active_tile_idx,
-            );
+            source_column
+                .start_column_tab_switch_animation(source_tile_idx, source_column.active_tile_idx);
         }
 
         self.add_tile(
@@ -3010,10 +3007,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             }
 
             if col.render_column_tab_switch(
-                ctx.renderer,
+                ctx.r(),
                 col_pos,
+                xray_pos,
                 focus_ring && first,
-                ctx.target,
                 &mut |elem| push(elem.into()),
             ) {
                 first = false;
@@ -4368,10 +4365,10 @@ impl<W: LayoutElement> Column<W> {
 
     fn render_column_tab_switch<R: NiriRenderer>(
         &self,
-        renderer: &mut R,
+        mut ctx: RenderCtx<R>,
         column_loc: Point<f64, Logical>,
+        xray_pos: XrayPos,
         focus_ring: bool,
-        target: RenderTarget,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) -> bool {
         let Some(animation) = self.column_tab_switch_animation.as_ref() else {
@@ -4441,18 +4438,25 @@ impl<W: LayoutElement> Column<W> {
             };
 
             tile.render_tab_switch_contents(
-                renderer,
+                ctx.renderer,
                 location,
                 clip_geo,
                 crop_geo,
                 clip_radius,
-                target,
+                ctx.target,
+                push,
+            );
+            tile.render_tab_switch_background_effect(
+                ctx.r(),
+                location,
+                crop_geo,
+                xray_pos.offset(location),
                 push,
             );
         }
 
         active_tile.render_frame(
-            renderer,
+            ctx.renderer,
             frame_loc + active_tile.bob_offset(),
             focus_ring,
             push,

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri_config::utils::MergeWith as _;
-use niri_config::{CenterFocusedColumn, PresetSize, Struts, TabSwitchDirection};
+use niri_config::{CenterFocusedColumn, PresetSize, Struts, ColumnTabSwitchDirection};
 use niri_ipc::{ColumnDisplay, SizeChange, WindowLayout};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -219,7 +219,7 @@ pub struct Column<W: LayoutElement> {
     move_y_animation: Option<MoveAnimation>,
 
     /// Animation of the tab strip sliding under the active frame.
-    tab_switch_animation: Option<TabSwitchAnimation>,
+    column_tab_switch_animation: Option<ColumnTabSwitchAnimation>,
 
     /// Latest known view size for this column's workspace.
     view_size: Size<f64, Logical>,
@@ -316,7 +316,7 @@ struct MoveAnimation {
 }
 
 #[derive(Debug)]
-struct TabSwitchAnimation {
+struct ColumnTabSwitchAnimation {
     anim: Animation,
     from_idx: usize,
     to_idx: usize,
@@ -1102,7 +1102,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let column = &mut self.columns[column_idx];
         let prev_width = self.data[column_idx].width;
-        column.tab_switch_animation = None;
+        column.column_tab_switch_animation = None;
 
         let movement_config = anim_config.unwrap_or(self.options.animations.window_movement.0);
 
@@ -2990,7 +2990,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     .render(ctx.renderer, pos, &mut |elem| push(elem.into()));
             }
 
-            if col.render_tab_switch(
+            if col.render_column_tab_switch(
                 ctx.renderer,
                 col_pos,
                 focus_ring && first,
@@ -4032,7 +4032,7 @@ impl<W: LayoutElement> Column<W> {
             tab_indicator: TabIndicator::new(options.layout.tab_indicator),
             move_x_animation: None,
             move_y_animation: None,
-            tab_switch_animation: None,
+            column_tab_switch_animation: None,
             view_size,
             working_area,
             parent_area,
@@ -4125,8 +4125,8 @@ impl<W: LayoutElement> Column<W> {
         self.scale = scale;
         self.options = options;
 
-        if !self.should_animate_tab_switch() {
-            self.tab_switch_animation = None;
+        if !self.should_animate_column_tab_switch() {
+            self.column_tab_switch_animation = None;
         }
 
         if update_sizes {
@@ -4155,11 +4155,11 @@ impl<W: LayoutElement> Column<W> {
         }
 
         if self
-            .tab_switch_animation
+            .column_tab_switch_animation
             .as_ref()
-            .is_some_and(|animation| animation.anim.is_done() || !self.should_animate_tab_switch())
+            .is_some_and(|animation| animation.anim.is_done() || !self.should_animate_column_tab_switch())
         {
-            self.tab_switch_animation = None;
+            self.column_tab_switch_animation = None;
         }
 
         for tile in &mut self.tiles {
@@ -4172,7 +4172,7 @@ impl<W: LayoutElement> Column<W> {
     pub fn are_animations_ongoing(&self) -> bool {
         self.move_x_animation.is_some()
             || self.move_y_animation.is_some()
-            || self.tab_switch_animation.is_some()
+            || self.column_tab_switch_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_animations_ongoing)
     }
@@ -4180,7 +4180,7 @@ impl<W: LayoutElement> Column<W> {
     pub fn are_transitions_ongoing(&self) -> bool {
         self.move_x_animation.is_some()
             || self.move_y_animation.is_some()
-            || self.tab_switch_animation.is_some()
+            || self.column_tab_switch_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_transitions_ongoing)
     }
@@ -4282,23 +4282,23 @@ impl<W: LayoutElement> Column<W> {
         offset
     }
 
-    fn should_animate_tab_switch(&self) -> bool {
+    fn should_animate_column_tab_switch(&self) -> bool {
         self.display_mode == ColumnDisplay::Tabbed
             && self.tiles.len() > 1
             && self.sizing_mode().is_normal()
-            && !self.options.animations.tab_switch.anim.off
+            && !self.options.animations.column_tab_switch.anim.off
     }
 
-    fn animate_tile_on_tab_switch(
+    fn animate_tile_on_column_tab_switch(
         &self,
-        animation: &TabSwitchAnimation,
+        animation: &ColumnTabSwitchAnimation,
         tile_idx: usize,
         progress: f64,
     ) -> Point<f64, Logical> {
         let strip_size = |idx: usize| self.tiles[idx].animated_window_size();
         let strip_offset = |active_idx| -> Point<f64, Logical> {
-            match self.options.animations.tab_switch.direction {
-                TabSwitchDirection::Horizontal => {
+            match self.options.animations.column_tab_switch.direction {
+                ColumnTabSwitchDirection::Horizontal => {
                     let offset = if tile_idx < active_idx {
                         -(tile_idx..active_idx)
                             .map(|idx| strip_size(idx).w)
@@ -4310,7 +4310,7 @@ impl<W: LayoutElement> Column<W> {
                     };
                     Point::from((offset, 0.))
                 }
-                TabSwitchDirection::Vertical => {
+                ColumnTabSwitchDirection::Vertical => {
                     let offset = if tile_idx < active_idx {
                         -(tile_idx..active_idx)
                             .map(|idx| strip_size(idx).h)
@@ -4333,7 +4333,7 @@ impl<W: LayoutElement> Column<W> {
         ))
     }
 
-    fn render_tab_switch<R: NiriRenderer>(
+    fn render_column_tab_switch<R: NiriRenderer>(
         &self,
         renderer: &mut R,
         column_loc: Point<f64, Logical>,
@@ -4341,10 +4341,10 @@ impl<W: LayoutElement> Column<W> {
         target: RenderTarget,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) -> bool {
-        let Some(animation) = self.tab_switch_animation.as_ref() else {
+        let Some(animation) = self.column_tab_switch_animation.as_ref() else {
             return false;
         };
-        if !self.should_animate_tab_switch() {
+        if !self.should_animate_column_tab_switch() {
             return false;
         }
 
@@ -4352,20 +4352,20 @@ impl<W: LayoutElement> Column<W> {
             .to_physical_precise_round(self.scale)
             .to_logical(self.scale);
         let active_tile = &self.tiles[self.active_tile_idx];
-        let active_content_origin = active_tile.tab_switch_content_origin();
-        let (clip_geo, clip_radius) = active_tile.tab_switch_mask(frame_loc);
+        let active_content_origin = active_tile.column_tab_switch_content_origin();
+        let (clip_geo, clip_radius) = active_tile.column_tab_switch_mask(frame_loc);
         let progress = animation.anim.clamped_value();
         let horizontal =
-            self.options.animations.tab_switch.direction == TabSwitchDirection::Horizontal;
+            self.options.animations.column_tab_switch.direction == ColumnTabSwitchDirection::Horizontal;
 
         let strip = (0..self.tiles.len())
             .into_iter()
             .map(|idx| {
                 let tile = &self.tiles[idx];
-                let offset = self.animate_tile_on_tab_switch(animation, idx, progress);
+                let offset = self.animate_tile_on_column_tab_switch(animation, idx, progress);
                 let location =
-                    frame_loc + offset + active_content_origin - tile.tab_switch_content_origin();
-                let content_loc = location + tile.tab_switch_content_origin();
+                    frame_loc + offset + active_content_origin - tile.column_tab_switch_content_origin();
+                let content_loc = location + tile.column_tab_switch_content_origin();
                 let content_size = tile.animated_window_size();
                 (tile, location, content_loc, content_size)
             })
@@ -4597,14 +4597,14 @@ impl<W: LayoutElement> Column<W> {
             return false;
         }
 
-        self.tab_switch_animation = if self.should_animate_tab_switch() {
-            Some(TabSwitchAnimation {
+        self.column_tab_switch_animation = if self.should_animate_column_tab_switch() {
+            Some(ColumnTabSwitchAnimation {
                 anim: Animation::new(
                     self.clock.clone(),
                     0.,
                     1.,
                     0.,
-                    self.options.animations.tab_switch.anim,
+                    self.options.animations.column_tab_switch.anim,
                 ),
                 from_idx: old_idx,
                 to_idx: idx,
@@ -4625,7 +4625,7 @@ impl<W: LayoutElement> Column<W> {
 
     fn add_tile_at(&mut self, idx: usize, mut tile: Tile<W>) {
         tile.update_config(self.view_size, self.scale, self.options.clone());
-        self.tab_switch_animation = None;
+        self.column_tab_switch_animation = None;
 
         // Inserting a tile pushes down all tiles below it, but also in always-centering mode it
         // will affect the X position of all tiles in the column.
@@ -5084,7 +5084,7 @@ impl<W: LayoutElement> Column<W> {
             return false;
         }
 
-        self.tab_switch_animation = None;
+        self.column_tab_switch_animation = None;
 
         let mut ys = self.tile_offsets().skip(self.active_tile_idx);
         let active_y = ys.next().unwrap().y;
@@ -5109,7 +5109,7 @@ impl<W: LayoutElement> Column<W> {
             return false;
         }
 
-        self.tab_switch_animation = None;
+        self.column_tab_switch_animation = None;
 
         let mut ys = self.tile_offsets().skip(self.active_tile_idx);
         let active_y = ys.next().unwrap().y;
@@ -5448,7 +5448,7 @@ impl<W: LayoutElement> Column<W> {
             return;
         }
 
-        self.tab_switch_animation = None;
+        self.column_tab_switch_animation = None;
 
         // Animate the movement.
         //

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri_config::utils::MergeWith as _;
-use niri_config::{CenterFocusedColumn, PresetSize, Struts, ColumnTabSwitchDirection};
+use niri_config::{CenterFocusedColumn, ColumnTabSwitchDirection, PresetSize, Struts};
 use niri_ipc::{ColumnDisplay, SizeChange, WindowLayout};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -4157,7 +4157,9 @@ impl<W: LayoutElement> Column<W> {
         if self
             .column_tab_switch_animation
             .as_ref()
-            .is_some_and(|animation| animation.anim.is_done() || !self.should_animate_column_tab_switch())
+            .is_some_and(|animation| {
+                animation.anim.is_done() || !self.should_animate_column_tab_switch()
+            })
         {
             self.column_tab_switch_animation = None;
         }
@@ -4295,42 +4297,31 @@ impl<W: LayoutElement> Column<W> {
         tile_idx: usize,
         progress: f64,
     ) -> Point<f64, Logical> {
-        let strip_size = |idx: usize| self.tiles[idx].animated_window_size();
-        let strip_offset = |active_idx| -> Point<f64, Logical> {
-            match self.options.animations.column_tab_switch.direction {
-                ColumnTabSwitchDirection::Horizontal => {
-                    let offset = if tile_idx < active_idx {
-                        -(tile_idx..active_idx)
-                            .map(|idx| strip_size(idx).w)
-                            .sum::<f64>()
-                    } else {
-                        (active_idx..tile_idx)
-                            .map(|idx| strip_size(idx).w)
-                            .sum::<f64>()
-                    };
-                    Point::from((offset, 0.))
-                }
-                ColumnTabSwitchDirection::Vertical => {
-                    let offset = if tile_idx < active_idx {
-                        -(tile_idx..active_idx)
-                            .map(|idx| strip_size(idx).h)
-                            .sum::<f64>()
-                    } else {
-                        (active_idx..tile_idx)
-                            .map(|idx| strip_size(idx).h)
-                            .sum::<f64>()
-                    };
-                    Point::from((0., offset))
-                }
+        let direction = self.options.animations.column_tab_switch.direction;
+        let strip_size = |idx: usize| {
+            let size = self.tiles[idx].animated_window_size();
+            match direction {
+                ColumnTabSwitchDirection::Horizontal => size.w,
+                ColumnTabSwitchDirection::Vertical => size.h,
+            }
+        };
+
+        let strip_offset = |active_idx| {
+            if tile_idx < active_idx {
+                -(tile_idx..active_idx).map(strip_size).sum::<f64>()
+            } else {
+                (active_idx..tile_idx).map(strip_size).sum::<f64>()
             }
         };
 
         let from = strip_offset(animation.from_idx);
         let to = strip_offset(animation.to_idx);
-        Point::from((
-            from.x + (to.x - from.x) * progress,
-            from.y + (to.y - from.y) * progress,
-        ))
+        let offset = from + (to - from) * progress;
+
+        match direction {
+            ColumnTabSwitchDirection::Horizontal => Point::from((offset, 0.)),
+            ColumnTabSwitchDirection::Vertical => Point::from((0., offset)),
+        }
     }
 
     fn render_column_tab_switch<R: NiriRenderer>(
@@ -4355,21 +4346,8 @@ impl<W: LayoutElement> Column<W> {
         let active_content_origin = active_tile.column_tab_switch_content_origin();
         let (clip_geo, clip_radius) = active_tile.column_tab_switch_mask(frame_loc);
         let progress = animation.anim.clamped_value();
-        let horizontal =
-            self.options.animations.column_tab_switch.direction == ColumnTabSwitchDirection::Horizontal;
-
-        let strip = (0..self.tiles.len())
-            .into_iter()
-            .map(|idx| {
-                let tile = &self.tiles[idx];
-                let offset = self.animate_tile_on_column_tab_switch(animation, idx, progress);
-                let location =
-                    frame_loc + offset + active_content_origin - tile.column_tab_switch_content_origin();
-                let content_loc = location + tile.column_tab_switch_content_origin();
-                let content_size = tile.animated_window_size();
-                (tile, location, content_loc, content_size)
-            })
-            .collect::<Vec<_>>();
+        let horizontal = self.options.animations.column_tab_switch.direction
+            == ColumnTabSwitchDirection::Horizontal;
 
         let clip_start = if horizontal {
             clip_geo.loc.x
@@ -4382,7 +4360,15 @@ impl<W: LayoutElement> Column<W> {
             } else {
                 clip_geo.size.h
             };
-        for (tile, location, content_loc, content_size) in strip {
+        
+        // Go through the tiles in order and apply animation to tiles that are affected.
+        for idx in 0..self.tiles.len() {
+            let tile = &self.tiles[idx];
+            let offset = self.animate_tile_on_column_tab_switch(animation, idx, progress);
+            let content_loc = frame_loc + offset + active_content_origin;
+            let location = content_loc - tile.column_tab_switch_content_origin();
+            let content_size = tile.animated_window_size();
+
             let start = if horizontal {
                 content_loc.x
             } else {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4305,13 +4305,12 @@ impl<W: LayoutElement> Column<W> {
 
     fn should_animate_column_tab_switch(&self) -> bool {
         self.display_mode == ColumnDisplay::Tabbed
-            && self.tiles.len() > 1
+            && (self.tiles.len() > 1 || self.column_tab_switch_animation.is_some())
             && !self.options.animations.column_tab_switch.anim.off
     }
 
     fn start_column_tab_switch_animation(&mut self, from_idx: usize, to_idx: usize) {
         if self.display_mode != ColumnDisplay::Tabbed
-            || self.tiles.len() <= 1
             || self.options.animations.column_tab_switch.anim.off
             || to_idx >= self.tiles.len()
             || from_idx > self.tiles.len()

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1585,6 +1585,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             .any(|col| col.start_open_animation(id))
     }
 
+    #[cfg(test)]
+    pub fn active_column_tab_switch_animation(&self) -> Option<(usize, usize)> {
+        self.columns
+            .get(self.active_column_idx)
+            .and_then(|col| col.column_tab_switch_animation.as_ref())
+            .map(|anim| (anim.from_idx, anim.to_idx))
+    }
+
     pub fn focus_left(&mut self) -> bool {
         if self.active_column_idx == 0 {
             return false;
@@ -2042,12 +2050,23 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         let source_tile_idx = source_column.tiles.len() - 1;
+        let expelled_active_tab =
+            source_column.display_mode == ColumnDisplay::Tabbed
+                && source_column.active_tile_idx == source_tile_idx;
 
         let mut offset = source_column.render_offset();
         let prev_off = source_column.tile_offset(source_tile_idx);
 
         let removed =
             self.remove_tile_by_idx(source_col_idx, source_tile_idx, Transaction::new(), None);
+
+        if expelled_active_tab {
+            let source_column = &mut self.columns[source_col_idx];
+            source_column.start_column_tab_switch_animation(
+                source_tile_idx,
+                source_column.active_tile_idx,
+            );
+        }
 
         self.add_tile(
             Some(target_col_idx),
@@ -4290,6 +4309,31 @@ impl<W: LayoutElement> Column<W> {
             && !self.options.animations.column_tab_switch.anim.off
     }
 
+    fn start_column_tab_switch_animation(&mut self, from_idx: usize, to_idx: usize) {
+        if self.display_mode != ColumnDisplay::Tabbed
+            || self.tiles.len() <= 1
+            || self.options.animations.column_tab_switch.anim.off
+            || to_idx >= self.tiles.len()
+            || from_idx > self.tiles.len()
+            || from_idx == to_idx
+        {
+            self.column_tab_switch_animation = None;
+            return;
+        }
+
+        self.column_tab_switch_animation = Some(ColumnTabSwitchAnimation {
+            anim: Animation::new(
+                self.clock.clone(),
+                0.,
+                1.,
+                0.,
+                self.options.animations.column_tab_switch.anim,
+            ),
+            from_idx,
+            to_idx,
+        });
+    }
+
     fn animate_tile_on_column_tab_switch(
         &self,
         animation: &ColumnTabSwitchAnimation,
@@ -4601,21 +4645,7 @@ impl<W: LayoutElement> Column<W> {
             return false;
         }
 
-        self.column_tab_switch_animation = if self.should_animate_column_tab_switch() {
-            Some(ColumnTabSwitchAnimation {
-                anim: Animation::new(
-                    self.clock.clone(),
-                    0.,
-                    1.,
-                    0.,
-                    self.options.animations.column_tab_switch.anim,
-                ),
-                from_idx: old_idx,
-                to_idx: idx,
-            })
-        } else {
-            None
-        };
+        self.start_column_tab_switch_animation(old_idx, idx);
         self.active_tile_idx = idx;
         self.tiles[idx].ensure_alpha_animates_to_1();
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -843,6 +843,26 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
     }
 
+    fn update_column_width(&mut self, col_idx: usize, config: niri_config::Animation) {
+        let prev_width = self.data[col_idx].width;
+        self.data[col_idx].update(&self.columns[col_idx]);
+        let offset = prev_width - self.data[col_idx].width;
+
+        if offset == 0. {
+            return;
+        }
+
+        if self.active_column_idx <= col_idx {
+            for col in &mut self.columns[col_idx + 1..] {
+                col.animate_move_x_from_with_config(offset, config);
+            }
+        } else {
+            for col in &mut self.columns[..=col_idx] {
+                col.animate_move_x_from_with_config(-offset, config);
+            }
+        }
+    }
+
     pub(super) fn insert_position(&self, pos: Point<f64, Logical>) -> InsertPosition {
         if self.columns.is_empty() {
             return InsertPosition::NewColumn(0);
@@ -946,7 +966,6 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let mut prev_active_tile_idx = target_column.active_tile_idx;
 
         target_column.add_tile_at(tile_idx, tile);
-        self.data[col_idx].update(target_column);
 
         if tile_idx <= prev_active_tile_idx {
             target_column.active_tile_idx += 1;
@@ -973,6 +992,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 tile.animate_alpha(1., 0., self.options.animations.window_movement.0);
             }
         }
+
+        self.data[col_idx].update(target_column);
 
         // Adding a wider window into a column increases its width now (even if the window will
         // shrink later). Move the columns to account for this.
@@ -1477,6 +1498,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let column = &mut self.columns[column_idx];
 
         column.activate_window(window);
+        self.update_column_width(column_idx, self.options.animations.window_movement.0);
         self.activate_column(column_idx);
 
         true
@@ -1636,6 +1658,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         self.columns[self.active_column_idx].focus_index(index);
+        self.update_column_width(
+            self.active_column_idx,
+            self.options.animations.window_movement.0,
+        );
     }
 
     pub fn focus_down(&mut self) -> bool {
@@ -1643,7 +1669,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return false;
         }
 
-        self.columns[self.active_column_idx].focus_down()
+        let changed = self.columns[self.active_column_idx].focus_down();
+        if changed {
+            self.update_column_width(
+                self.active_column_idx,
+                self.options.animations.window_movement.0,
+            );
+        }
+        changed
     }
 
     pub fn focus_up(&mut self) -> bool {
@@ -1651,7 +1684,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return false;
         }
 
-        self.columns[self.active_column_idx].focus_up()
+        let changed = self.columns[self.active_column_idx].focus_up();
+        if changed {
+            self.update_column_width(
+                self.active_column_idx,
+                self.options.animations.window_movement.0,
+            );
+        }
+        changed
     }
 
     pub fn focus_down_or_left(&mut self) {
@@ -1659,8 +1699,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return;
         }
 
-        let column = &mut self.columns[self.active_column_idx];
-        if !column.focus_down() {
+        let idx = self.active_column_idx;
+        if self.columns[idx].focus_down() {
+            self.update_column_width(idx, self.options.animations.window_movement.0);
+        } else {
             self.focus_left();
         }
     }
@@ -1670,8 +1712,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return;
         }
 
-        let column = &mut self.columns[self.active_column_idx];
-        if !column.focus_down() {
+        let idx = self.active_column_idx;
+        if self.columns[idx].focus_down() {
+            self.update_column_width(idx, self.options.animations.window_movement.0);
+        } else {
             self.focus_right();
         }
     }
@@ -1681,8 +1725,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return;
         }
 
-        let column = &mut self.columns[self.active_column_idx];
-        if !column.focus_up() {
+        let idx = self.active_column_idx;
+        if self.columns[idx].focus_up() {
+            self.update_column_width(idx, self.options.animations.window_movement.0);
+        } else {
             self.focus_left();
         }
     }
@@ -1692,8 +1738,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return;
         }
 
-        let column = &mut self.columns[self.active_column_idx];
-        if !column.focus_up() {
+        let idx = self.active_column_idx;
+        if self.columns[idx].focus_up() {
+            self.update_column_width(idx, self.options.animations.window_movement.0);
+        } else {
             self.focus_right();
         }
     }
@@ -1703,7 +1751,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return;
         }
 
-        self.columns[self.active_column_idx].focus_top()
+        self.columns[self.active_column_idx].focus_top();
+        self.update_column_width(
+            self.active_column_idx,
+            self.options.animations.window_movement.0,
+        );
     }
 
     pub fn focus_bottom(&mut self) {
@@ -1711,7 +1763,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return;
         }
 
-        self.columns[self.active_column_idx].focus_bottom()
+        self.columns[self.active_column_idx].focus_bottom();
+        self.update_column_width(
+            self.active_column_idx,
+            self.options.animations.window_movement.0,
+        );
     }
 
     pub fn move_column_to_index(&mut self, index: usize) {
@@ -2190,6 +2246,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         // update the active tile in the modified columns
         self.columns[source_column_idx].active_tile_idx = source_tile_idx;
         self.columns[target_column_idx].active_tile_idx = target_tile_idx;
+        self.data[source_column_idx].update(&self.columns[source_column_idx]);
+        self.data[target_column_idx].update(&self.columns[target_column_idx]);
 
         // Animations
         self.columns[target_column_idx].tiles[target_tile_idx]
@@ -5078,7 +5136,7 @@ impl<W: LayoutElement> Column<W> {
     }
 
     fn width(&self) -> f64 {
-        let mut tiles_width = if self.has_lingering_expanded_inactive_tabs() {
+        let mut tiles_width = if self.display_mode == ColumnDisplay::Tabbed {
             self.data[self.active_tile_idx].size.w
         } else {
             self.data
@@ -5581,7 +5639,7 @@ impl<W: LayoutElement> Column<W> {
         let tabbed = self.display_mode == ColumnDisplay::Tabbed;
 
         // Does not include extra size from the tab indicator.
-        let tiles_width = if self.has_lingering_expanded_inactive_tabs() {
+        let tiles_width = if tabbed {
             self.data[self.active_tile_idx].size.w
         } else {
             self.data

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4393,7 +4393,7 @@ impl<W: LayoutElement> Column<W> {
                     content_size.w
                 } else {
                     content_size.h
-            };
+                };
             let start = clip_start.max(start);
             let end = clip_end.min(end);
             if end <= start {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4554,12 +4554,31 @@ impl<W: LayoutElement> Column<W> {
         }
 
         if any_fullscreen {
+            if self.has_lingering_expanded_inactive_tabs() {
+                return SizingMode::Normal;
+            }
+
             SizingMode::Fullscreen
         } else if any_maximized {
+            if self.has_lingering_expanded_inactive_tabs() {
+                return SizingMode::Normal;
+            }
+
             SizingMode::Maximized
         } else {
             SizingMode::Normal
         }
+    }
+
+    fn has_lingering_expanded_inactive_tabs(&self) -> bool {
+        self.display_mode == ColumnDisplay::Tabbed
+            && self.pending_sizing_mode().is_normal()
+            && self.tiles[self.active_tile_idx].sizing_mode().is_normal()
+            && self
+                .tiles
+                .iter()
+                .enumerate()
+                .any(|(idx, tile)| idx != self.active_tile_idx && !tile.sizing_mode().is_normal())
     }
 
     pub fn contains(&self, window: &W::Id) -> bool {
@@ -5026,13 +5045,16 @@ impl<W: LayoutElement> Column<W> {
     }
 
     fn width(&self) -> f64 {
-        let mut tiles_width = self
-            .data
-            .iter()
-            .map(|data| NotNan::new(data.size.w).unwrap())
-            .max()
-            .map(NotNan::into_inner)
-            .unwrap();
+        let mut tiles_width = if self.has_lingering_expanded_inactive_tabs() {
+            self.data[self.active_tile_idx].size.w
+        } else {
+            self.data
+                .iter()
+                .map(|data| NotNan::new(data.size.w).unwrap())
+                .max()
+                .map(NotNan::into_inner)
+                .unwrap()
+        };
 
         if self.display_mode == ColumnDisplay::Tabbed && self.sizing_mode().is_normal() {
             let extra_size = self.tab_indicator.extra_size(self.tiles.len(), self.scale);
@@ -5493,10 +5515,11 @@ impl<W: LayoutElement> Column<W> {
 
         match self.sizing_mode() {
             SizingMode::Normal => (),
-            SizingMode::Maximized => {
+            SizingMode::Maximized if !self.pending_sizing_mode().is_normal() => {
                 origin.y += self.parent_area.loc.y;
                 return origin;
             }
+            SizingMode::Maximized => (),
             SizingMode::Fullscreen => return origin,
         }
 
@@ -5525,13 +5548,16 @@ impl<W: LayoutElement> Column<W> {
         let tabbed = self.display_mode == ColumnDisplay::Tabbed;
 
         // Does not include extra size from the tab indicator.
-        let tiles_width = self
-            .data
-            .iter()
-            .map(|data| NotNan::new(data.size.w).unwrap())
-            .max()
-            .map(NotNan::into_inner)
-            .unwrap_or(0.);
+        let tiles_width = if self.has_lingering_expanded_inactive_tabs() {
+            self.data[self.active_tile_idx].size.w
+        } else {
+            self.data
+                .iter()
+                .map(|data| NotNan::new(data.size.w).unwrap())
+                .max()
+                .map(NotNan::into_inner)
+                .unwrap_or(0.)
+        };
 
         let mut origin = self.tiles_origin();
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4360,7 +4360,7 @@ impl<W: LayoutElement> Column<W> {
             } else {
                 clip_geo.size.h
             };
-        
+
         // Go through the tiles in order and apply animation to tiles that are affected.
         for idx in 0..self.tiles.len() {
             let tile = &self.tiles[idx];

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -3413,6 +3413,62 @@ fn preset_column_width_reset_after_set_width() {
 }
 
 #[test]
+fn tabbed_column_width_tracks_active_tab() {
+    let ops = [
+        Op::AddOutput(0),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::SetForcedSize {
+            id: 1,
+            size: Some(Size::from((400, 200))),
+        },
+        Op::Communicate(1),
+        Op::SetColumnDisplay(ColumnDisplay::Tabbed),
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::SetForcedSize {
+            id: 2,
+            size: Some(Size::from((400, 200))),
+        },
+        Op::Communicate(2),
+        Op::ConsumeOrExpelWindowLeft { id: None },
+        Op::AddWindow {
+            params: TestWindowParams::new(3),
+        },
+        Op::FocusColumnLeft,
+        Op::CompleteAnimations,
+        Op::SetForcedSize {
+            id: 2,
+            size: Some(Size::from((200, 200))),
+        },
+        Op::Communicate(2),
+    ];
+
+    let options = Options {
+        layout: niri_config::Layout {
+            gaps: 0.,
+            center_focused_column: CenterFocusedColumn::Never,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let layout = check_ops_with_options(options, ops);
+    let ws = layout.active_workspace().unwrap();
+
+    let mut tiles = ws
+        .tiles_with_render_positions()
+        .filter(|(_, _, visible)| *visible);
+    let (active_tab, active_pos, _) = tiles.next().unwrap();
+    let (right, right_pos, _) = tiles.next().unwrap();
+
+    assert_eq!(active_tab.window().0.id, 2);
+    assert_eq!(right.window().0.id, 3);
+    assert_eq!(active_pos.x + active_tab.tile_size().w, right_pos.x);
+}
+
+#[test]
 fn move_column_to_workspace_unfocused_with_multiple_monitors() {
     let ops = [
         Op::AddOutput(1),

--- a/src/layout/tests/animations.rs
+++ b/src/layout/tests/animations.rs
@@ -126,24 +126,19 @@ fn expel_active_bottom_tab_starts_remaining_tab_switch_animation() {
         Op::FocusColumnLeft,
         Op::ConsumeWindowIntoColumn,
         Op::ToggleColumnTabbedDisplay,
-        Op::AddWindow {
-            params: TestWindowParams::new(3),
-        },
-        Op::FocusColumnLeft,
-        Op::ConsumeWindowIntoColumn,
         Op::FocusWindowBottom,
     ];
     let mut layout = check_ops_with_options(make_options(), ops);
 
     check_ops_on_layout(&mut layout, [Op::ExpelWindowFromColumn]);
 
-    assert_eq!(layout.focus().unwrap().id(), &2);
+    assert_eq!(layout.focus().unwrap().id(), &1);
     assert_eq!(
         layout
             .active_workspace()
             .unwrap()
             .active_column_tab_switch_animation(),
-        Some((2, 1))
+        Some((1, 0))
     );
 }
 

--- a/src/layout/tests/animations.rs
+++ b/src/layout/tests/animations.rs
@@ -114,6 +114,40 @@ fn height_resize_animates_next_y() {
 }
 
 #[test]
+fn expel_active_bottom_tab_starts_remaining_tab_switch_animation() {
+    let ops = [
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::FocusColumnLeft,
+        Op::ConsumeWindowIntoColumn,
+        Op::ToggleColumnTabbedDisplay,
+        Op::AddWindow {
+            params: TestWindowParams::new(3),
+        },
+        Op::FocusColumnLeft,
+        Op::ConsumeWindowIntoColumn,
+        Op::FocusWindowBottom,
+    ];
+    let mut layout = check_ops_with_options(make_options(), ops);
+
+    check_ops_on_layout(&mut layout, [Op::ExpelWindowFromColumn]);
+
+    assert_eq!(layout.focus().unwrap().id(), &2);
+    assert_eq!(
+        layout
+            .active_workspace()
+            .unwrap()
+            .active_column_tab_switch_animation(),
+        Some((2, 1))
+    );
+}
+
+#[test]
 fn clientside_height_change_doesnt_animate() {
     let mut layout = set_up_two_in_column();
 

--- a/src/layout/tests/fullscreen.rs
+++ b/src/layout/tests/fullscreen.rs
@@ -541,8 +541,17 @@ fn unfullscreen_of_tabbed_preserves_view_pos() {
     ];
     check_ops_on_layout(&mut layout, ops);
 
-    // View pos is still on the second column because the second tile hasn't unfullscreened yet.
-    assert_snapshot!(layout.active_workspace().unwrap().scrolling().view_pos(), @"116");
+    // View pos is back to showing the first window; inactive fullscreen tabs must not keep the
+    // visible tab at the fullscreen origin.
+    assert_snapshot!(layout.active_workspace().unwrap().scrolling().view_pos(), @"-16");
+    let focused = *layout.focus().unwrap().id();
+    let (_, pos, _) = layout
+        .active_workspace()
+        .unwrap()
+        .tiles_with_render_positions()
+        .find(|(tile, _, _)| tile.window().id() == &focused)
+        .unwrap();
+    assert_eq!(pos.y, 16.);
 
     let ops = [Op::Communicate(2), Op::CompleteAnimations];
     check_ops_on_layout(&mut layout, ops);
@@ -643,8 +652,8 @@ fn removing_only_fullscreen_tile_updates_view_offset() {
     ];
     check_ops_on_layout(&mut layout, ops);
 
-    // View pos without gap because other tile is still fullscreen.
-    assert_snapshot!(layout.active_workspace().unwrap().scrolling().view_pos(), @"0");
+    // View pos includes the gap because the active tab has unfullscreened.
+    assert_snapshot!(layout.active_workspace().unwrap().scrolling().view_pos(), @"-16");
 
     let ops = [
         // Expel the fullscreen window from the column, changing the column to non-fullscreen.
@@ -653,7 +662,6 @@ fn removing_only_fullscreen_tile_updates_view_offset() {
     ];
     check_ops_on_layout(&mut layout, ops);
 
-    // View pos should include gap now that the column is no longer fullscreen.
-    // FIXME: currently, removing a tile doesn't cause the view offset to update.
-    assert_snapshot!(layout.active_workspace().unwrap().scrolling().view_pos(), @"0");
+    // View pos still includes the gap now that the column is no longer fullscreen.
+    assert_snapshot!(layout.active_workspace().unwrap().scrolling().view_pos(), @"-16");
 }

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1314,7 +1314,6 @@ impl<W: LayoutElement> Tile<W> {
         let scale = Scale::from(self.scale);
         let fullscreen_progress = self.fullscreen_progress();
         let expanded_progress = self.expanded_progress();
-        let rules = self.window.rules();
         let has_border_shader = BorderRenderElement::has_shader(renderer);
 
         if fullscreen_progress > 0. {

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use niri_config::utils::MergeWith as _;
 use niri_config::{Color, CornerRadius, GradientInterpolation};
 use niri_ipc::WindowLayout;
+use smithay::backend::renderer::element::utils::CropRenderElement;
 use smithay::backend::renderer::element::{Element, Kind};
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Size};
@@ -22,6 +23,7 @@ use crate::render_helpers::background_effect::BackgroundEffectElement;
 use crate::render_helpers::border::BorderRenderElement;
 use crate::render_helpers::clipped_surface::{ClippedSurfaceRenderElement, RoundedCornerDamage};
 use crate::render_helpers::damage::ExtraDamage;
+use crate::render_helpers::masked_offscreen::MaskedOffscreenRenderElement;
 use crate::render_helpers::offscreen::{OffscreenBuffer, OffscreenRenderElement};
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::resize::ResizeRenderElement;
@@ -102,6 +104,9 @@ pub struct Tile<W: LayoutElement> {
     /// Snapshot of the last render for use in the close animation.
     unmap_snapshot: Option<TileRenderSnapshot>,
 
+    /// Cached offscreen for the tab-switch strip.
+    tab_switch_offscreen: OffscreenBuffer,
+
     /// Extra damage for clipped surface corner radius changes.
     rounded_corner_damage: RoundedCornerDamage,
 
@@ -129,6 +134,7 @@ niri_render_elements! {
         Resize = ResizeRenderElement,
         Border = BorderRenderElement,
         Shadow = ShadowRenderElement,
+        CroppedMaskedOffscreen = CropRenderElement<MaskedOffscreenRenderElement>,
         ClippedSurface = ClippedSurfaceRenderElement<R>,
         Offscreen = OffscreenRenderElement,
         ExtraDamage = ExtraDamage,
@@ -207,6 +213,7 @@ impl<W: LayoutElement> Tile<W> {
             alpha_animation: None,
             interactive_move_offset: Point::from((0., 0.)),
             unmap_snapshot: None,
+            tab_switch_offscreen: Default::default(),
             rounded_corner_damage: Default::default(),
             view_size,
             scale,
@@ -1021,15 +1028,14 @@ impl<W: LayoutElement> Tile<W> {
         Point::from((0., y))
     }
 
-    fn render_inner<R: NiriRenderer>(
+    fn render_contents<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
         mut xray_pos: XrayPos,
-        focus_ring: bool,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) {
-        let _span = tracy_client::span!("Tile::render_inner");
+        let _span = tracy_client::span!("Tile::render_contents");
 
         let scale = Scale::from(self.scale);
         let fullscreen_progress = self.fullscreen_progress();
@@ -1237,6 +1243,79 @@ impl<W: LayoutElement> Tile<W> {
                     push(clip(elem))
                 });
         }
+    }
+
+    fn render_inner<R: NiriRenderer>(
+        &self,
+        mut ctx: RenderCtx<R>,
+        location: Point<f64, Logical>,
+        xray_pos: XrayPos,
+        focus_ring: bool,
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) {
+        let _span = tracy_client::span!("Tile::render_inner");
+
+        let bob_offset = self.bob_offset();
+        let location = location + bob_offset;
+
+        self.render_contents(ctx.r(), location - bob_offset, xray_pos, push);
+        self.render_frame(ctx.renderer, location, focus_ring, push);
+
+        let window_loc = self.window_loc();
+        let window_size = self.window_size();
+        let animated_window_size = self.animated_window_size();
+        let area = Rectangle::new(location + window_loc, animated_window_size);
+        let rules = self.window.rules();
+        let clip_to_geometry =
+            self.fullscreen_progress() < 1. && rules.clip_to_geometry == Some(true);
+        let radius = self
+            .window
+            .geometry_corner_radius()
+            .scaled_by(1. - self.expanded_progress() as f32);
+        let surface_anim_scale = animated_window_size / window_size;
+        self.window.render_background_effect(
+            ctx.as_gles(),
+            area,
+            self.scale,
+            clip_to_geometry,
+            surface_anim_scale,
+            radius,
+            xray_pos.offset(window_loc),
+            &mut |elem| push(elem.into()),
+        );
+    }
+
+    fn collect_render_contents(
+        &self,
+        renderer: &mut GlesRenderer,
+        target: RenderTarget,
+    ) -> Vec<TileRenderElement<GlesRenderer>> {
+        let mut elements = Vec::new();
+        self.render_contents(
+            RenderCtx {
+                renderer,
+                target,
+                xray: None,
+            },
+            Point::from((0., 0.)),
+            XrayPos::default(),
+            &mut |elem| elements.push(elem),
+        );
+        elements
+    }
+
+    pub fn render_frame<R: NiriRenderer>(
+        &self,
+        renderer: &mut R,
+        location: Point<f64, Logical>,
+        focus_ring: bool,
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) {
+        let scale = Scale::from(self.scale);
+        let fullscreen_progress = self.fullscreen_progress();
+        let expanded_progress = self.expanded_progress();
+        let rules = self.window.rules();
+        let has_border_shader = BorderRenderElement::has_shader(renderer);
 
         if fullscreen_progress > 0. {
             let alpha = fullscreen_progress as f32;
@@ -1281,7 +1360,7 @@ impl<W: LayoutElement> Tile<W> {
 
         if let Some(width) = self.visual_border_width() {
             self.border.render(
-                ctx.renderer,
+                renderer,
                 location + Point::from((width, width)),
                 &mut |elem| push(elem.into()),
             );
@@ -1293,25 +1372,93 @@ impl<W: LayoutElement> Tile<W> {
         // a bit weird).
         if focus_ring && expanded_progress < 1. {
             self.focus_ring
-                .render(ctx.renderer, location, &mut |elem| push(elem.into()));
+                .render(renderer, location, &mut |elem| push(elem.into()));
         }
 
         if expanded_progress < 1. {
             self.shadow
-                .render(ctx.renderer, location, &mut |elem| push(elem.into()));
+                .render(renderer, location, &mut |elem| push(elem.into()));
         }
+    }
 
-        let surface_anim_scale = animated_window_size / window_size;
-        self.window.render_background_effect(
-            ctx.as_gles(),
-            area,
-            self.scale,
-            clip_to_geometry,
-            surface_anim_scale,
-            radius,
-            xray_pos,
-            &mut |elem| push(elem.into()),
+    pub fn tab_switch_content_origin(&self) -> Point<f64, Logical> {
+        self.bob_offset() + self.window_loc()
+    }
+
+    pub fn tab_switch_mask(
+        &self,
+        location: Point<f64, Logical>,
+    ) -> (Rectangle<f64, Logical>, CornerRadius) {
+        let geometry = Rectangle::new(
+            location + self.tab_switch_content_origin(),
+            self.animated_window_size(),
         );
+        let radius = self
+            .window
+            .rules()
+            .geometry_corner_radius
+            .unwrap_or_default()
+            .scaled_by(1. - self.expanded_progress() as f32)
+            .fit_to(geometry.size.w as f32, geometry.size.h as f32);
+
+        (geometry, radius)
+    }
+
+    pub fn render_tab_switch_contents<R: NiriRenderer>(
+        &self,
+        renderer: &mut R,
+        location: Point<f64, Logical>,
+        clip_geo: Rectangle<f64, Logical>,
+        crop_geo: Rectangle<f64, Logical>,
+        clip_radius: CornerRadius,
+        target: RenderTarget,
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) {
+        self.window().set_offscreen_data(None);
+
+        let scale = Scale::from(self.scale);
+        let Some(shader) = MaskedOffscreenRenderElement::shader(renderer).cloned() else {
+            self.render_contents(
+                RenderCtx {
+                    renderer,
+                    target,
+                    xray: None,
+                },
+                location,
+                XrayPos::default(),
+                push,
+            );
+            return;
+        };
+
+        let gles = renderer.as_gles_renderer();
+        let elements = self.collect_render_contents(gles, target);
+        match self.tab_switch_offscreen.render(gles, scale, &elements) {
+            Ok((elem, _sync, data)) => {
+                self.window().set_offscreen_data(Some(data));
+                let offset = elem.offset();
+                let elem = elem.with_offset(location + offset);
+                let elem =
+                    MaskedOffscreenRenderElement::new(elem, scale, clip_geo, shader, clip_radius);
+                let crop = crop_geo.to_physical_precise_round(scale);
+                if let Some(elem) = CropRenderElement::from_element(elem, scale, crop) {
+                    push(elem.into());
+                }
+            }
+            Err(err) => {
+                warn!("error rendering tab switch contents to offscreen: {err:?}");
+                self.render_contents(
+                    RenderCtx {
+                        renderer,
+                        target,
+                        xray: None,
+                    },
+                    location,
+                    XrayPos::default(),
+                    push,
+                );
+            }
+        }
     }
 
     pub fn render<R: NiriRenderer>(

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -104,8 +104,8 @@ pub struct Tile<W: LayoutElement> {
     /// Snapshot of the last render for use in the close animation.
     unmap_snapshot: Option<TileRenderSnapshot>,
 
-    /// Cached offscreen for the tab-switch strip.
-    tab_switch_offscreen: OffscreenBuffer,
+    /// Cached offscreen for the column-tab-switch strip.
+    column_tab_switch_offscreen: OffscreenBuffer,
 
     /// Extra damage for clipped surface corner radius changes.
     rounded_corner_damage: RoundedCornerDamage,
@@ -213,7 +213,7 @@ impl<W: LayoutElement> Tile<W> {
             alpha_animation: None,
             interactive_move_offset: Point::from((0., 0.)),
             unmap_snapshot: None,
-            tab_switch_offscreen: Default::default(),
+            column_tab_switch_offscreen: Default::default(),
             rounded_corner_damage: Default::default(),
             view_size,
             scale,
@@ -1380,16 +1380,16 @@ impl<W: LayoutElement> Tile<W> {
         }
     }
 
-    pub fn tab_switch_content_origin(&self) -> Point<f64, Logical> {
+    pub fn column_tab_switch_content_origin(&self) -> Point<f64, Logical> {
         self.bob_offset() + self.window_loc()
     }
 
-    pub fn tab_switch_mask(
+    pub fn column_tab_switch_mask(
         &self,
         location: Point<f64, Logical>,
     ) -> (Rectangle<f64, Logical>, CornerRadius) {
         let geometry = Rectangle::new(
-            location + self.tab_switch_content_origin(),
+            location + self.column_tab_switch_content_origin(),
             self.animated_window_size(),
         );
         let radius = self
@@ -1432,7 +1432,7 @@ impl<W: LayoutElement> Tile<W> {
 
         let gles = renderer.as_gles_renderer();
         let elements = self.collect_render_contents(gles, target);
-        match self.tab_switch_offscreen.render(gles, scale, &elements) {
+        match self.column_tab_switch_offscreen.render(gles, scale, &elements) {
             Ok((elem, _sync, data)) => {
                 self.window().set_offscreen_data(Some(data));
                 let offset = elem.offset();

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1432,7 +1432,10 @@ impl<W: LayoutElement> Tile<W> {
 
         let gles = renderer.as_gles_renderer();
         let elements = self.collect_render_contents(gles, target);
-        match self.column_tab_switch_offscreen.render(gles, scale, &elements) {
+        match self
+            .column_tab_switch_offscreen
+            .render(gles, scale, &elements)
+        {
             Ok((elem, _sync, data)) => {
                 self.window().set_offscreen_data(Some(data));
                 let offset = elem.offset();

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -135,6 +135,7 @@ niri_render_elements! {
         Border = BorderRenderElement,
         Shadow = ShadowRenderElement,
         CroppedMaskedOffscreen = CropRenderElement<MaskedOffscreenRenderElement>,
+        CroppedBackgroundEffect = CropRenderElement<BackgroundEffectElement>,
         ClippedSurface = ClippedSurfaceRenderElement<R>,
         Offscreen = OffscreenRenderElement,
         ExtraDamage = ExtraDamage,
@@ -1461,6 +1462,48 @@ impl<W: LayoutElement> Tile<W> {
                 );
             }
         }
+    }
+
+    pub fn render_tab_switch_background_effect<R: NiriRenderer>(
+        &self,
+        mut ctx: RenderCtx<R>,
+        location: Point<f64, Logical>,
+        crop_geo: Rectangle<f64, Logical>,
+        xray_pos: XrayPos,
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) {
+        let window_loc = self.window_loc();
+        let window_size = self.window_size();
+        let animated_window_size = self.animated_window_size();
+        let area = Rectangle::new(
+            location + self.column_tab_switch_content_origin(),
+            animated_window_size,
+        );
+        let rules = self.window.rules();
+        let clip_to_geometry =
+            self.fullscreen_progress() < 1. && rules.clip_to_geometry == Some(true);
+        let radius = self
+            .window
+            .geometry_corner_radius()
+            .scaled_by(1. - self.expanded_progress() as f32);
+        let surface_anim_scale = animated_window_size / window_size;
+        let scale = Scale::from(self.scale);
+        let crop = crop_geo.to_physical_precise_round(scale);
+
+        self.window.render_background_effect(
+            ctx.as_gles(),
+            area,
+            self.scale,
+            clip_to_geometry,
+            surface_anim_scale,
+            radius,
+            xray_pos.offset(window_loc),
+            &mut |elem| {
+                if let Some(elem) = CropRenderElement::from_element(elem, scale, crop) {
+                    push(elem.into());
+                }
+            },
+        );
     }
 
     pub fn render<R: NiriRenderer>(

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use niri_config::utils::MergeWith as _;
 use niri_config::{Color, CornerRadius, GradientInterpolation};
 use niri_ipc::WindowLayout;
+use smithay::backend::renderer::element::utils::CropRenderElement;
 use smithay::backend::renderer::element::{Element, Kind};
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Size};
@@ -22,6 +23,7 @@ use crate::render_helpers::background_effect::BackgroundEffectElement;
 use crate::render_helpers::border::BorderRenderElement;
 use crate::render_helpers::clipped_surface::{ClippedSurfaceRenderElement, RoundedCornerDamage};
 use crate::render_helpers::damage::ExtraDamage;
+use crate::render_helpers::masked_offscreen::MaskedOffscreenRenderElement;
 use crate::render_helpers::offscreen::{OffscreenBuffer, OffscreenRenderElement};
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::resize::ResizeRenderElement;
@@ -102,6 +104,9 @@ pub struct Tile<W: LayoutElement> {
     /// Snapshot of the last render for use in the close animation.
     unmap_snapshot: Option<TileRenderSnapshot>,
 
+    /// Cached offscreen for the tab-switch strip.
+    tab_switch_offscreen: OffscreenBuffer,
+
     /// Extra damage for clipped surface corner radius changes.
     rounded_corner_damage: RoundedCornerDamage,
 
@@ -129,6 +134,7 @@ niri_render_elements! {
         Resize = ResizeRenderElement,
         Border = BorderRenderElement,
         Shadow = ShadowRenderElement,
+        CroppedMaskedOffscreen = CropRenderElement<MaskedOffscreenRenderElement>,
         ClippedSurface = ClippedSurfaceRenderElement<R>,
         Offscreen = OffscreenRenderElement,
         ExtraDamage = ExtraDamage,
@@ -211,6 +217,7 @@ impl<W: LayoutElement> Tile<W> {
             alpha_animation: None,
             interactive_move_offset: Point::from((0., 0.)),
             unmap_snapshot: None,
+            tab_switch_offscreen: Default::default(),
             rounded_corner_damage: Default::default(),
             view_size,
             scale,
@@ -1059,15 +1066,14 @@ impl<W: LayoutElement> Tile<W> {
         Point::from((0., y))
     }
 
-    fn render_inner<R: NiriRenderer>(
+    fn render_contents<R: NiriRenderer>(
         &self,
         mut ctx: RenderCtx<R>,
         location: Point<f64, Logical>,
         mut xray_pos: XrayPos,
-        focus_ring: bool,
         push: &mut dyn FnMut(TileRenderElement<R>),
     ) {
-        let _span = tracy_client::span!("Tile::render_inner");
+        let _span = tracy_client::span!("Tile::render_contents");
 
         let scale = Scale::from(self.scale);
         let fullscreen_progress = self.fullscreen_progress();
@@ -1275,6 +1281,79 @@ impl<W: LayoutElement> Tile<W> {
                     push(clip(elem))
                 });
         }
+    }
+
+    fn render_inner<R: NiriRenderer>(
+        &self,
+        mut ctx: RenderCtx<R>,
+        location: Point<f64, Logical>,
+        xray_pos: XrayPos,
+        focus_ring: bool,
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) {
+        let _span = tracy_client::span!("Tile::render_inner");
+
+        let bob_offset = self.bob_offset();
+        let location = location + bob_offset;
+
+        self.render_contents(ctx.r(), location - bob_offset, xray_pos, push);
+        self.render_frame(ctx.renderer, location, focus_ring, push);
+
+        let window_loc = self.window_loc();
+        let window_size = self.window_size();
+        let animated_window_size = self.animated_window_size();
+        let area = Rectangle::new(location + window_loc, animated_window_size);
+        let rules = self.window.rules();
+        let clip_to_geometry =
+            self.fullscreen_progress() < 1. && rules.clip_to_geometry == Some(true);
+        let radius = self
+            .window
+            .geometry_corner_radius()
+            .scaled_by(1. - self.expanded_progress() as f32);
+        let surface_anim_scale = animated_window_size / window_size;
+        self.window.render_background_effect(
+            ctx.as_gles(),
+            area,
+            self.scale,
+            clip_to_geometry,
+            surface_anim_scale,
+            radius,
+            xray_pos.offset(window_loc),
+            &mut |elem| push(elem.into()),
+        );
+    }
+
+    fn collect_render_contents(
+        &self,
+        renderer: &mut GlesRenderer,
+        target: RenderTarget,
+    ) -> Vec<TileRenderElement<GlesRenderer>> {
+        let mut elements = Vec::new();
+        self.render_contents(
+            RenderCtx {
+                renderer,
+                target,
+                xray: None,
+            },
+            Point::from((0., 0.)),
+            XrayPos::default(),
+            &mut |elem| elements.push(elem),
+        );
+        elements
+    }
+
+    pub fn render_frame<R: NiriRenderer>(
+        &self,
+        renderer: &mut R,
+        location: Point<f64, Logical>,
+        focus_ring: bool,
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) {
+        let scale = Scale::from(self.scale);
+        let fullscreen_progress = self.fullscreen_progress();
+        let expanded_progress = self.expanded_progress();
+        let rules = self.window.rules();
+        let has_border_shader = BorderRenderElement::has_shader(renderer);
 
         if fullscreen_progress > 0. {
             let alpha = fullscreen_progress as f32;
@@ -1319,7 +1398,7 @@ impl<W: LayoutElement> Tile<W> {
 
         if let Some(width) = self.visual_border_width() {
             self.border.render(
-                ctx.renderer,
+                renderer,
                 location + Point::from((width, width)),
                 &mut |elem| push(elem.into()),
             );
@@ -1331,25 +1410,93 @@ impl<W: LayoutElement> Tile<W> {
         // a bit weird).
         if focus_ring && expanded_progress < 1. {
             self.focus_ring
-                .render(ctx.renderer, location, &mut |elem| push(elem.into()));
+                .render(renderer, location, &mut |elem| push(elem.into()));
         }
 
         if expanded_progress < 1. {
             self.shadow
-                .render(ctx.renderer, location, &mut |elem| push(elem.into()));
+                .render(renderer, location, &mut |elem| push(elem.into()));
         }
+    }
 
-        let surface_anim_scale = animated_window_size / window_size;
-        self.window.render_background_effect(
-            ctx.as_gles(),
-            area,
-            self.scale,
-            clip_to_geometry,
-            surface_anim_scale,
-            radius,
-            xray_pos,
-            &mut |elem| push(elem.into()),
+    pub fn tab_switch_content_origin(&self) -> Point<f64, Logical> {
+        self.bob_offset() + self.window_loc()
+    }
+
+    pub fn tab_switch_mask(
+        &self,
+        location: Point<f64, Logical>,
+    ) -> (Rectangle<f64, Logical>, CornerRadius) {
+        let geometry = Rectangle::new(
+            location + self.tab_switch_content_origin(),
+            self.animated_window_size(),
         );
+        let radius = self
+            .window
+            .rules()
+            .geometry_corner_radius
+            .unwrap_or_default()
+            .scaled_by(1. - self.expanded_progress() as f32)
+            .fit_to(geometry.size.w as f32, geometry.size.h as f32);
+
+        (geometry, radius)
+    }
+
+    pub fn render_tab_switch_contents<R: NiriRenderer>(
+        &self,
+        renderer: &mut R,
+        location: Point<f64, Logical>,
+        clip_geo: Rectangle<f64, Logical>,
+        crop_geo: Rectangle<f64, Logical>,
+        clip_radius: CornerRadius,
+        target: RenderTarget,
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) {
+        self.window().set_offscreen_data(None);
+
+        let scale = Scale::from(self.scale);
+        let Some(shader) = MaskedOffscreenRenderElement::shader(renderer).cloned() else {
+            self.render_contents(
+                RenderCtx {
+                    renderer,
+                    target,
+                    xray: None,
+                },
+                location,
+                XrayPos::default(),
+                push,
+            );
+            return;
+        };
+
+        let gles = renderer.as_gles_renderer();
+        let elements = self.collect_render_contents(gles, target);
+        match self.tab_switch_offscreen.render(gles, scale, &elements) {
+            Ok((elem, _sync, data)) => {
+                self.window().set_offscreen_data(Some(data));
+                let offset = elem.offset();
+                let elem = elem.with_offset(location + offset);
+                let elem =
+                    MaskedOffscreenRenderElement::new(elem, scale, clip_geo, shader, clip_radius);
+                let crop = crop_geo.to_physical_precise_round(scale);
+                if let Some(elem) = CropRenderElement::from_element(elem, scale, crop) {
+                    push(elem.into());
+                }
+            }
+            Err(err) => {
+                warn!("error rendering tab switch contents to offscreen: {err:?}");
+                self.render_contents(
+                    RenderCtx {
+                        renderer,
+                        target,
+                        xray: None,
+                    },
+                    location,
+                    XrayPos::default(),
+                    push,
+                );
+            }
+        }
     }
 
     pub fn render<R: NiriRenderer>(

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -104,8 +104,8 @@ pub struct Tile<W: LayoutElement> {
     /// Snapshot of the last render for use in the close animation.
     unmap_snapshot: Option<TileRenderSnapshot>,
 
-    /// Cached offscreen for the tab-switch strip.
-    tab_switch_offscreen: OffscreenBuffer,
+    /// Cached offscreen for the column-tab-switch strip.
+    column_tab_switch_offscreen: OffscreenBuffer,
 
     /// Extra damage for clipped surface corner radius changes.
     rounded_corner_damage: RoundedCornerDamage,
@@ -217,7 +217,7 @@ impl<W: LayoutElement> Tile<W> {
             alpha_animation: None,
             interactive_move_offset: Point::from((0., 0.)),
             unmap_snapshot: None,
-            tab_switch_offscreen: Default::default(),
+            column_tab_switch_offscreen: Default::default(),
             rounded_corner_damage: Default::default(),
             view_size,
             scale,
@@ -1418,16 +1418,16 @@ impl<W: LayoutElement> Tile<W> {
         }
     }
 
-    pub fn tab_switch_content_origin(&self) -> Point<f64, Logical> {
+    pub fn column_tab_switch_content_origin(&self) -> Point<f64, Logical> {
         self.bob_offset() + self.window_loc()
     }
 
-    pub fn tab_switch_mask(
+    pub fn column_tab_switch_mask(
         &self,
         location: Point<f64, Logical>,
     ) -> (Rectangle<f64, Logical>, CornerRadius) {
         let geometry = Rectangle::new(
-            location + self.tab_switch_content_origin(),
+            location + self.column_tab_switch_content_origin(),
             self.animated_window_size(),
         );
         let radius = self
@@ -1470,7 +1470,7 @@ impl<W: LayoutElement> Tile<W> {
 
         let gles = renderer.as_gles_renderer();
         let elements = self.collect_render_contents(gles, target);
-        match self.tab_switch_offscreen.render(gles, scale, &elements) {
+        match self.column_tab_switch_offscreen.render(gles, scale, &elements) {
             Ok((elem, _sync, data)) => {
                 self.window().set_offscreen_data(Some(data));
                 let offset = elem.offset();

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1470,7 +1470,10 @@ impl<W: LayoutElement> Tile<W> {
 
         let gles = renderer.as_gles_renderer();
         let elements = self.collect_render_contents(gles, target);
-        match self.column_tab_switch_offscreen.render(gles, scale, &elements) {
+        match self
+            .column_tab_switch_offscreen
+            .render(gles, scale, &elements)
+        {
             Ok((elem, _sync, data)) => {
                 self.window().set_offscreen_data(Some(data));
                 let offset = elem.offset();

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -1352,7 +1352,6 @@ impl<W: LayoutElement> Tile<W> {
         let scale = Scale::from(self.scale);
         let fullscreen_progress = self.fullscreen_progress();
         let expanded_progress = self.expanded_progress();
-        let rules = self.window.rules();
         let has_border_shader = BorderRenderElement::has_shader(renderer);
 
         if fullscreen_progress > 0. {

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -135,6 +135,7 @@ niri_render_elements! {
         Border = BorderRenderElement,
         Shadow = ShadowRenderElement,
         CroppedMaskedOffscreen = CropRenderElement<MaskedOffscreenRenderElement>,
+        CroppedBackgroundEffect = CropRenderElement<BackgroundEffectElement>,
         ClippedSurface = ClippedSurfaceRenderElement<R>,
         Offscreen = OffscreenRenderElement,
         ExtraDamage = ExtraDamage,
@@ -1499,6 +1500,48 @@ impl<W: LayoutElement> Tile<W> {
                 );
             }
         }
+    }
+
+    pub fn render_tab_switch_background_effect<R: NiriRenderer>(
+        &self,
+        mut ctx: RenderCtx<R>,
+        location: Point<f64, Logical>,
+        crop_geo: Rectangle<f64, Logical>,
+        xray_pos: XrayPos,
+        push: &mut dyn FnMut(TileRenderElement<R>),
+    ) {
+        let window_loc = self.window_loc();
+        let window_size = self.window_size();
+        let animated_window_size = self.animated_window_size();
+        let area = Rectangle::new(
+            location + self.column_tab_switch_content_origin(),
+            animated_window_size,
+        );
+        let rules = self.window.rules();
+        let clip_to_geometry =
+            self.fullscreen_progress() < 1. && rules.clip_to_geometry == Some(true);
+        let radius = self
+            .window
+            .geometry_corner_radius()
+            .scaled_by(1. - self.expanded_progress() as f32);
+        let surface_anim_scale = animated_window_size / window_size;
+        let scale = Scale::from(self.scale);
+        let crop = crop_geo.to_physical_precise_round(scale);
+
+        self.window.render_background_effect(
+            ctx.as_gles(),
+            area,
+            self.scale,
+            clip_to_geometry,
+            surface_anim_scale,
+            radius,
+            xray_pos.offset(window_loc),
+            &mut |elem| {
+                if let Some(elem) = CropRenderElement::from_element(elem, scale, crop) {
+                    push(elem.into());
+                }
+            },
+        );
     }
 
     pub fn render<R: NiriRenderer>(

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1753,6 +1753,11 @@ impl<W: LayoutElement> Workspace<W> {
         self.scrolling.start_open_animation(id) || self.floating.start_open_animation(id)
     }
 
+    #[cfg(test)]
+    pub fn active_column_tab_switch_animation(&self) -> Option<(usize, usize)> {
+        self.scrolling.active_column_tab_switch_animation()
+    }
+
     pub fn window_under(&self, pos: Point<f64, Logical>) -> Option<(&W, HitType)> {
         // This logic is consistent with tiles_with_render_positions().
         if self.is_floating_visible() {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1761,6 +1761,11 @@ impl<W: LayoutElement> Workspace<W> {
         self.scrolling.start_open_animation(id) || self.floating.start_open_animation(id)
     }
 
+    #[cfg(test)]
+    pub fn active_column_tab_switch_animation(&self) -> Option<(usize, usize)> {
+        self.scrolling.active_column_tab_switch_animation()
+    }
+
     pub fn window_under(&self, pos: Point<f64, Logical>) -> Option<(&W, HitType)> {
         // This logic is consistent with tiles_with_render_positions().
         if self.is_floating_visible() {

--- a/src/protocols/foreign_toplevel.rs
+++ b/src/protocols/foreign_toplevel.rs
@@ -5,11 +5,13 @@ use std::sync::Arc;
 use arrayvec::ArrayVec;
 use smithay::output::Output;
 use smithay::reexports::wayland_protocols::ext::foreign_toplevel_list::v1::server::{
-    ext_foreign_toplevel_handle_v1::{self, ExtForeignToplevelHandleV1}, ext_foreign_toplevel_list_v1::{self, ExtForeignToplevelListV1},
+    ext_foreign_toplevel_handle_v1::{self, ExtForeignToplevelHandleV1},
+    ext_foreign_toplevel_list_v1::{self, ExtForeignToplevelListV1},
 };
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_protocols_wlr::foreign_toplevel::v1::server::{
-    zwlr_foreign_toplevel_handle_v1::{self, ZwlrForeignToplevelHandleV1}, zwlr_foreign_toplevel_manager_v1::{self, ZwlrForeignToplevelManagerV1},
+    zwlr_foreign_toplevel_handle_v1::{self, ZwlrForeignToplevelHandleV1},
+    zwlr_foreign_toplevel_manager_v1::{self, ZwlrForeignToplevelManagerV1},
 };
 use smithay::reexports::wayland_server::backend::ClientId;
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
@@ -18,12 +20,12 @@ use smithay::reexports::wayland_server::{
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
 use smithay::wayland::shell::xdg::{
-    ToplevelState, ToplevelStateSet, XdgToplevelSurfaceRoleAttributes
+    ToplevelState, ToplevelStateSet, XdgToplevelSurfaceRoleAttributes,
 };
 
 use crate::niri::State;
-use crate::window::mapped::MappedId;
 use crate::utils::with_toplevel_role_and_current;
+use crate::window::mapped::MappedId;
 
 const EXT_LIST_VERSION: u32 = 1;
 const WLR_MANAGEMENT_VERSION: u32 = 3;

--- a/src/protocols/foreign_toplevel.rs
+++ b/src/protocols/foreign_toplevel.rs
@@ -5,11 +5,13 @@ use std::sync::Arc;
 use arrayvec::ArrayVec;
 use smithay::output::Output;
 use smithay::reexports::wayland_protocols::ext::foreign_toplevel_list::v1::server::{
-    ext_foreign_toplevel_handle_v1::{self, ExtForeignToplevelHandleV1}, ext_foreign_toplevel_list_v1::{self, ExtForeignToplevelListV1},
+    ext_foreign_toplevel_handle_v1::{self, ExtForeignToplevelHandleV1},
+    ext_foreign_toplevel_list_v1::{self, ExtForeignToplevelListV1},
 };
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_protocols_wlr::foreign_toplevel::v1::server::{
-    zwlr_foreign_toplevel_handle_v1::{self, ZwlrForeignToplevelHandleV1}, zwlr_foreign_toplevel_manager_v1::{self, ZwlrForeignToplevelManagerV1},
+    zwlr_foreign_toplevel_handle_v1::{self, ZwlrForeignToplevelHandleV1},
+    zwlr_foreign_toplevel_manager_v1::{self, ZwlrForeignToplevelManagerV1},
 };
 use smithay::reexports::wayland_server::backend::ClientId;
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
@@ -19,13 +21,13 @@ use smithay::reexports::wayland_server::{
 };
 use smithay::wayland::{Dispatch2, GlobalDispatch2};
 use smithay::wayland::shell::xdg::{
-    ToplevelState, ToplevelStateSet, XdgToplevelSurfaceRoleAttributes
+    ToplevelState, ToplevelStateSet, XdgToplevelSurfaceRoleAttributes,
 };
 
 use crate::niri::State;
 use crate::protocols::EmptyData;
-use crate::window::mapped::MappedId;
 use crate::utils::with_toplevel_role_and_current;
+use crate::window::mapped::MappedId;
 
 const EXT_LIST_VERSION: u32 = 1;
 const WLR_MANAGEMENT_VERSION: u32 = 3;

--- a/src/protocols/foreign_toplevel.rs
+++ b/src/protocols/foreign_toplevel.rs
@@ -19,10 +19,10 @@ use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::{
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
 };
-use smithay::wayland::{Dispatch2, GlobalDispatch2};
 use smithay::wayland::shell::xdg::{
     ToplevelState, ToplevelStateSet, XdgToplevelSurfaceRoleAttributes,
 };
+use smithay::wayland::{Dispatch2, GlobalDispatch2};
 
 use crate::niri::State;
 use crate::protocols::EmptyData;

--- a/src/render_helpers/masked_offscreen.rs
+++ b/src/render_helpers/masked_offscreen.rs
@@ -5,6 +5,7 @@ use smithay::backend::renderer::gles::{
     GlesError, GlesFrame, GlesRenderer, GlesTexProgram, Uniform,
 };
 use smithay::backend::renderer::utils::{CommitCounter, DamageSet, OpaqueRegions};
+use smithay::utils::user_data::UserDataMap;
 use smithay::utils::{Buffer, Logical, Physical, Rectangle, Scale, Transform};
 
 use super::offscreen::OffscreenRenderElement;
@@ -125,9 +126,18 @@ impl RenderElement<GlesRenderer> for MaskedOffscreenRenderElement {
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), GlesError> {
         frame.override_default_tex_program(self.program.clone(), self.compute_uniforms());
-        RenderElement::<GlesRenderer>::draw(&self.inner, frame, src, dst, damage, opaque_regions)?;
+        RenderElement::<GlesRenderer>::draw(
+            &self.inner,
+            frame,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+            cache,
+        )?;
         frame.clear_tex_program_override();
         Ok(())
     }
@@ -145,6 +155,7 @@ impl<'render> RenderElement<TtyRenderer<'render>> for MaskedOffscreenRenderEleme
         dst: Rectangle<i32, Physical>,
         damage: &[Rectangle<i32, Physical>],
         opaque_regions: &[Rectangle<i32, Physical>],
+        cache: Option<&UserDataMap>,
     ) -> Result<(), TtyRendererError<'render>> {
         frame
             .as_gles_frame()
@@ -156,6 +167,7 @@ impl<'render> RenderElement<TtyRenderer<'render>> for MaskedOffscreenRenderEleme
             dst,
             damage,
             opaque_regions,
+            cache,
         )?;
         frame.as_gles_frame().clear_tex_program_override();
         Ok(())

--- a/src/render_helpers/masked_offscreen.rs
+++ b/src/render_helpers/masked_offscreen.rs
@@ -1,0 +1,170 @@
+use glam::{Mat3, Vec2};
+use niri_config::CornerRadius;
+use smithay::backend::renderer::element::{Element, Id, Kind, RenderElement, UnderlyingStorage};
+use smithay::backend::renderer::gles::{
+    GlesError, GlesFrame, GlesRenderer, GlesTexProgram, Uniform,
+};
+use smithay::backend::renderer::utils::{CommitCounter, DamageSet, OpaqueRegions};
+use smithay::utils::{Buffer, Logical, Physical, Rectangle, Scale, Transform};
+
+use super::offscreen::OffscreenRenderElement;
+use super::renderer::{AsGlesFrame as _, NiriRenderer};
+use super::shaders::{mat3_uniform, Shaders};
+use crate::backend::tty::{TtyFrame, TtyRenderer, TtyRendererError};
+
+#[derive(Debug, Clone)]
+pub struct MaskedOffscreenRenderElement {
+    inner: OffscreenRenderElement,
+    program: GlesTexProgram,
+    corner_radius: CornerRadius,
+    geometry: Rectangle<f64, Logical>,
+    scale: f32,
+}
+
+impl MaskedOffscreenRenderElement {
+    pub fn new(
+        inner: OffscreenRenderElement,
+        scale: Scale<f64>,
+        geometry: Rectangle<f64, Logical>,
+        program: GlesTexProgram,
+        corner_radius: CornerRadius,
+    ) -> Self {
+        Self {
+            inner,
+            program,
+            corner_radius,
+            geometry,
+            scale: scale.x as f32,
+        }
+    }
+
+    pub fn shader(renderer: &mut impl NiriRenderer) -> Option<&GlesTexProgram> {
+        Shaders::get(renderer).clipped_surface.as_ref()
+    }
+
+    fn compute_uniforms(&self) -> Vec<Uniform<'static>> {
+        let scale = Scale::from(f64::from(self.scale));
+        let elem_geo = self.inner.geometry(scale);
+
+        let elem_geo_loc = Vec2::new(elem_geo.loc.x as f32, elem_geo.loc.y as f32);
+        let elem_geo_size = Vec2::new(elem_geo.size.w as f32, elem_geo.size.h as f32);
+
+        let geo = self.geometry.to_physical_precise_round(scale);
+        let geo_loc = Vec2::new(geo.loc.x, geo.loc.y);
+        let geo_size = Vec2::new(geo.size.w, geo.size.h);
+
+        let input_to_geo = Mat3::from_scale(elem_geo_size / geo_size)
+            * Mat3::from_translation((elem_geo_loc - geo_loc) / elem_geo_size);
+
+        vec![
+            Uniform::new("niri_scale", self.scale),
+            Uniform::new(
+                "geo_size",
+                [self.geometry.size.w as f32, self.geometry.size.h as f32],
+            ),
+            Uniform::new("corner_radius", <[f32; 4]>::from(self.corner_radius)),
+            mat3_uniform("input_to_geo", input_to_geo),
+        ]
+    }
+}
+
+impl Element for MaskedOffscreenRenderElement {
+    fn id(&self) -> &Id {
+        self.inner.id()
+    }
+
+    fn current_commit(&self) -> CommitCounter {
+        self.inner.current_commit()
+    }
+
+    fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
+        self.inner.geometry(scale)
+    }
+
+    fn transform(&self) -> Transform {
+        self.inner.transform()
+    }
+
+    fn src(&self) -> Rectangle<f64, Buffer> {
+        self.inner.src()
+    }
+
+    fn damage_since(
+        &self,
+        scale: Scale<f64>,
+        commit: Option<CommitCounter>,
+    ) -> DamageSet<i32, Physical> {
+        let damage = self.inner.damage_since(scale, commit);
+
+        let mut geo = self.geometry.to_physical_precise_round(scale);
+        geo.loc -= self.geometry(scale).loc;
+        damage
+            .into_iter()
+            .filter_map(|rect| rect.intersection(geo))
+            .collect()
+    }
+
+    fn opaque_regions(&self, _scale: Scale<f64>) -> OpaqueRegions<i32, Physical> {
+        OpaqueRegions::default()
+    }
+
+    fn alpha(&self) -> f32 {
+        self.inner.alpha()
+    }
+
+    fn kind(&self) -> Kind {
+        self.inner.kind()
+    }
+}
+
+impl RenderElement<GlesRenderer> for MaskedOffscreenRenderElement {
+    fn draw(
+        &self,
+        frame: &mut GlesFrame<'_, '_>,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
+    ) -> Result<(), GlesError> {
+        frame.override_default_tex_program(self.program.clone(), self.compute_uniforms());
+        RenderElement::<GlesRenderer>::draw(&self.inner, frame, src, dst, damage, opaque_regions)?;
+        frame.clear_tex_program_override();
+        Ok(())
+    }
+
+    fn underlying_storage(&self, _renderer: &mut GlesRenderer) -> Option<UnderlyingStorage<'_>> {
+        None
+    }
+}
+
+impl<'render> RenderElement<TtyRenderer<'render>> for MaskedOffscreenRenderElement {
+    fn draw(
+        &self,
+        frame: &mut TtyFrame<'render, '_, '_>,
+        src: Rectangle<f64, Buffer>,
+        dst: Rectangle<i32, Physical>,
+        damage: &[Rectangle<i32, Physical>],
+        opaque_regions: &[Rectangle<i32, Physical>],
+    ) -> Result<(), TtyRendererError<'render>> {
+        frame
+            .as_gles_frame()
+            .override_default_tex_program(self.program.clone(), self.compute_uniforms());
+        <OffscreenRenderElement as RenderElement<TtyRenderer<'render>>>::draw(
+            &self.inner,
+            frame,
+            src,
+            dst,
+            damage,
+            opaque_regions,
+        )?;
+        frame.as_gles_frame().clear_tex_program_override();
+        Ok(())
+    }
+
+    fn underlying_storage(
+        &self,
+        _renderer: &mut TtyRenderer<'render>,
+    ) -> Option<UnderlyingStorage<'_>> {
+        None
+    }
+}

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -35,6 +35,7 @@ pub mod debug;
 pub mod effect_buffer;
 pub mod framebuffer_effect;
 pub mod gradient_fade_texture;
+pub mod masked_offscreen;
 pub mod memory;
 pub mod offscreen;
 pub mod primary_gpu_texture;

--- a/src/render_helpers/offscreen.rs
+++ b/src/render_helpers/offscreen.rs
@@ -103,9 +103,11 @@ impl OffscreenBuffer {
         }) = inner.as_mut()
         {
             let old_size = texture.size();
-            if old_size.w < src_size.w || old_size.h < src_size.h {
+            // Recreate on any size change. Reusing a larger texture after shrink can preserve
+            // stale pixels and damage history, which is incorrect for subsequent renders.
+            if old_size != src_size {
                 size_string = format!(
-                    "size increased from {} × {} to {} × {}",
+                    "size changed from {} × {} to {} × {}",
                     old_size.w, old_size.h, src_size.w, src_size.h
                 );
                 reason = &size_string;


### PR DESCRIPTION
Niri has awesome animations, but currently column tab switching is a rare exception. I mentioned this in a [discussion here](https://github.com/niri-wm/niri/discussions/3814) and got some community interest, so I went on and implemented it. The implementation is straightforward and I strove to make the functions descriptive and central. I will place a video here to demonstrate what it looks like.

https://github.com/user-attachments/assets/ef9a2158-bcd5-4d6d-8a8b-96293dbe4a83

All tests passed.