### PR TITLE
Respect `disable-direct-scanout` in DMA-BUF feedback

### DIFF
--- a/docs/wiki/Configuration:-Debug-Options.md
+++ b/docs/wiki/Configuration:-Debug-Options.md
@@ -84,6 +84,7 @@ debug {
 ### `disable-direct-scanout`
 
 Disable direct scanout to both the primary plane and the overlay planes.
+This also disables the scanout tranches in the DMA-BUF feedback sent to clients.
 
 ```kdl
 debug {

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -2840,13 +2840,7 @@ fn surface_dmabuf_feedback(
         )
         .build()?;
 
-    // If this is the primary node surface, send scanout formats in both tranches to avoid
-    // duplication.
-    let render = if surface_render_node == Some(primary_render_node) {
-        scanout.clone()
-    } else {
-        builder.build()?
-    };
+    let render = builder.build()?;
 
     Ok(SurfaceDmabufFeedback { render, scanout })
 }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -77,7 +77,7 @@ use smithay::wayland::compositor::{
     CompositorState, HookId, SurfaceData, TraversalAction,
 };
 use smithay::wayland::cursor_shape::CursorShapeManagerState;
-use smithay::wayland::dmabuf::DmabufState;
+use smithay::wayland::dmabuf::{DmabufFeedback, DmabufState};
 use smithay::wayland::fractional_scale::FractionalScaleManagerState;
 use smithay::wayland::idle_inhibit::IdleInhibitManagerState;
 use smithay::wayland::idle_notify::IdleNotifierState;
@@ -4930,6 +4930,23 @@ impl Niri {
     ) {
         let _span = tracy_client::span!("Niri::send_dmabuf_feedbacks");
 
+        let disable_direct_scanout = self.config.borrow().debug.disable_direct_scanout;
+        let select_client_dmabuf_feedback =
+            |surface: &WlSurface, _: &SurfaceData| -> &DmabufFeedback {
+                if disable_direct_scanout {
+                    // If direct scanout is disabled, scanout tranches cannot provide their intended
+                    // benefit and can still make clients choose fragile scanout-oriented allocations.
+                    return &feedback.render;
+                }
+
+                select_dmabuf_feedback(
+                    surface,
+                    render_element_states,
+                    &feedback.render,
+                    &feedback.scanout,
+                )
+            };
+
         // We can unconditionally send the current output's feedback to regular and layer-shell
         // surfaces, as they can only be displayed on a single output at a time. Even if a surface
         // is currently invisible, this is the DMABUF feedback that it should know about.
@@ -4937,14 +4954,7 @@ impl Niri {
             mapped.window.send_dmabuf_feedback(
                 output,
                 |_, _| Some(output.clone()),
-                |surface, _| {
-                    select_dmabuf_feedback(
-                        surface,
-                        render_element_states,
-                        &feedback.render,
-                        &feedback.scanout,
-                    )
-                },
+                select_client_dmabuf_feedback,
             );
         }
 
@@ -4952,14 +4962,7 @@ impl Niri {
             surface.send_dmabuf_feedback(
                 output,
                 |_, _| Some(output.clone()),
-                |surface, _| {
-                    select_dmabuf_feedback(
-                        surface,
-                        render_element_states,
-                        &feedback.render,
-                        &feedback.scanout,
-                    )
-                },
+                select_client_dmabuf_feedback,
             );
         }
 
@@ -4968,14 +4971,7 @@ impl Niri {
                 surface.wl_surface(),
                 output,
                 |_, _| Some(output.clone()),
-                |surface, _| {
-                    select_dmabuf_feedback(
-                        surface,
-                        render_element_states,
-                        &feedback.render,
-                        &feedback.scanout,
-                    )
-                },
+                select_client_dmabuf_feedback,
             );
         }
 
@@ -4984,14 +4980,7 @@ impl Niri {
                 surface,
                 output,
                 surface_primary_scanout_output,
-                |surface, _| {
-                    select_dmabuf_feedback(
-                        surface,
-                        render_element_states,
-                        &feedback.render,
-                        &feedback.scanout,
-                    )
-                },
+                select_client_dmabuf_feedback,
             );
         }
 
@@ -5000,14 +4989,7 @@ impl Niri {
                 surface,
                 output,
                 surface_primary_scanout_output,
-                |surface, _| {
-                    select_dmabuf_feedback(
-                        surface,
-                        render_element_states,
-                        &feedback.render,
-                        &feedback.scanout,
-                    )
-                },
+                select_client_dmabuf_feedback,
             );
         }
     }


### PR DESCRIPTION
`debug { disable-direct-scanout }` should disable scanout path consistently, not only final direct-scanout attempt.

When direct scanout is disabled, advertising scanout-preferred DMA-BUF tranches no longer provides the intended benefit, but can still make clients choose scanout-oriented allocations.

This also intentionally keeps the regular render feedback render-only, even when the output is on the primary render node. Previously, in that case, niri reused the scanout feedback as the render feedback:

```rust
let render = if surface_render_node == Some(primary_render_node) {
    scanout.clone()
} else {
    builder.build()?
};
```

That made the default/render path contain scanout tranches too on the primary render node. As a result, Smithay's `select_dmabuf_feedback()` could not meaningfully choose between render feedback and scanout feedback, because both choices advertised scanout-oriented allocations.

This makes scanout feedback less aggressive in general: composited surfaces keep render-oriented feedback, while Smithay can still advertise scanout feedback for surfaces that are actually zero-copy candidates or failed scanout due to buffer properties.

## Additional Context

NVIDIA [595.58.03](https://www.nvidia.com/en-us/drivers/details/265870/) "Improved support for falling back to system memory when available video memory is low, to help prevent Wayland desktop freezes."

But it seems the system-memory fallback is [gated](https://github.com/NVIDIA/open-gpu-kernel-modules/blob/db0c4e65c8e34c678d745ddb1317f53f90d1072b/kernel-open/nvidia-drm/nvidia-drm-gem-nvkms-memory.c#L579-L593) by `NV_GEM_ALLOC_NO_SCANOUT` (seems related to scanout feedback).

This kinda explains why disabling scanout feedback might help under vram pressure.

## Potential Followup

Scanout feedback should only be advertised for surfaces that actually benefit from it, such as active fullscreen surfaces; otherwise, it might cause unintended side effects.