### PR TITLE
Add an option to disable VT switch handling

### DIFF
--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -102,6 +102,7 @@ input {
     }
 
     // disable-power-key-handling
+    // disable-vt-handling
     // warp-mouse-to-focus
     // focus-follows-mouse max-scroll-amount="0%"
     // workspace-auto-back-and-forth
@@ -305,6 +306,17 @@ Set this if you would like to configure the power button elsewhere (i.e. `logind
 ```kdl
 input {
     disable-power-key-handling
+}
+```
+
+#### `disable-vt-handling`
+
+By default, niri will handle VT switch (Ctrl+Alt+F<N>). You can disable VT switching if you want to configure something else, or just let apps have these key events.
+You can still switch to another VT with `sudo chvt N`.
+
+```kdl
+input {
+    disable-vt-handling
 }
 ```
 

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -18,6 +18,7 @@ pub struct Input {
     pub tablet: Tablet,
     pub touch: Touch,
     pub disable_power_key_handling: bool,
+    pub disable_vt_handling: bool,
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
     pub workspace_auto_back_and_forth: bool,
@@ -44,6 +45,8 @@ pub struct InputPart {
     #[knuffel(child)]
     pub disable_power_key_handling: Option<Flag>,
     #[knuffel(child)]
+    pub disable_vt_handling: Option<Flag>,
+    #[knuffel(child)]
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     #[knuffel(child)]
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
@@ -61,6 +64,7 @@ impl MergeWith<InputPart> for Input {
             (self, part),
             keyboard,
             disable_power_key_handling,
+            disable_vt_handling,
             workspace_auto_back_and_forth,
         );
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -539,6 +539,10 @@ impl State {
                     let bindings =
                         make_binds_iter(&config, &mut this.niri.window_mru_ui, modifiers);
 
+                    let config = this.niri.config.borrow();
+                    let disable_power_key_handling = config.input.disable_power_key_handling;
+                    let disable_vt_handling = config.input.disable_vt_handling;
+
                     should_intercept_key(
                         &mut this.niri.suppressed_keys,
                         bindings,
@@ -549,7 +553,8 @@ impl State {
                         pressed,
                         *mods,
                         &this.niri.screenshot_ui,
-                        this.niri.config.borrow().input.disable_power_key_handling,
+                        disable_power_key_handling,
+                        disable_vt_handling,
                         is_inhibiting_shortcuts,
                     )
                 };
@@ -4417,6 +4422,7 @@ fn should_intercept_key<'a>(
     mods: ModifiersState,
     screenshot_ui: &ScreenshotUi,
     disable_power_key_handling: bool,
+    disable_vt_handling: bool,
     is_inhibiting_shortcuts: bool,
 ) -> FilterResult<Option<Bind>> {
     // Actions are only triggered on presses, release of the key
@@ -4433,6 +4439,7 @@ fn should_intercept_key<'a>(
         raw,
         mods,
         disable_power_key_handling,
+        disable_vt_handling,
     );
 
     // Allow only a subset of compositor actions while the screenshot UI is open, since the user
@@ -4497,13 +4504,14 @@ fn find_bind<'a>(
     raw: Option<Keysym>,
     mods: ModifiersState,
     disable_power_key_handling: bool,
+    disable_vt_handling: bool,
 ) -> Option<Bind> {
     use keysyms::*;
 
     // Handle hardcoded binds.
     #[allow(non_upper_case_globals)] // wat
     let hardcoded_action = match modified.raw() {
-        modified @ KEY_XF86Switch_VT_1..=KEY_XF86Switch_VT_12 => {
+        modified @ KEY_XF86Switch_VT_1..=KEY_XF86Switch_VT_12 if !disable_vt_handling => {
             let vt = (modified - KEY_XF86Switch_VT_1 + 1) as i32;
             Some(Action::ChangeVt(vt))
         }
@@ -5207,6 +5215,7 @@ mod tests {
 
         let screenshot_ui = ScreenshotUi::new(Clock::default(), Default::default());
         let disable_power_key_handling = false;
+        let disable_vt_handling = false;
         let is_inhibiting_shortcuts = Cell::new(false);
 
         // The key_code we pick is arbitrary, the only thing
@@ -5225,6 +5234,7 @@ mod tests {
                 mods,
                 &screenshot_ui,
                 disable_power_key_handling,
+                disable_vt_handling,
                 is_inhibiting_shortcuts.get(),
             )
         };
@@ -5242,6 +5252,7 @@ mod tests {
                 mods,
                 &screenshot_ui,
                 disable_power_key_handling,
+                disable_vt_handling,
                 is_inhibiting_shortcuts.get(),
             )
         };


### PR DESCRIPTION
I work with a lot of VMs, and my machine is configured well, I do never use VT switching on the host, I do it quite often in VMs. 

This option lets me disable the VT switching shortcuts, and let the current apps handle the key presses.  

The option defaults to the old behavior, so I'm not expecting it to break anything.