### PR TITLE
Add the option to disable mouse in the MRU

### DIFF
--- a/docs/wiki/Configuration:-Recent-Windows.md
+++ b/docs/wiki/Configuration:-Recent-Windows.md
@@ -36,6 +36,8 @@ recent-windows {
         Mod+grave       { next-window     filter="app-id"; }
         Mod+Shift+grave { previous-window filter="app-id"; }
     }
+
+    // disable-mouse
 }
 ```
 
@@ -191,3 +193,10 @@ For example, if you have <kbd>Mod</kbd><kbd>Shift</kbd><kbd>C</kbd> bound to `cl
 
 This way we don't need to hardcode things like HJKL directional movements.
 If you have, say, Colemak-DH MNEI binds instead, they will work for you in the window switcher (as long as they don't conflict with the hardcoded ones).
+
+### disable-mouse
+
+<sup>Since: next release</sup>
+
+This setting lets you disable your mouse from interacting with the window switcher.
+This option might be useful if you have a graphic tablet, and the pointer messes with the switcher

--- a/niri-config/src/recent_windows.rs
+++ b/niri-config/src/recent_windows.rs
@@ -14,6 +14,7 @@ pub struct RecentWindows {
     pub highlight: MruHighlight,
     pub previews: MruPreviews,
     pub binds: Vec<Bind>,
+    pub enable_mouse: bool,
 }
 
 impl Default for RecentWindows {
@@ -25,6 +26,7 @@ impl Default for RecentWindows {
             highlight: MruHighlight::default(),
             previews: MruPreviews::default(),
             binds: default_binds(),
+            enable_mouse: true
         }
     }
 }
@@ -45,6 +47,10 @@ pub struct RecentWindowsPart {
     pub previews: Option<MruPreviewsPart>,
     #[knuffel(child)]
     pub binds: Option<MruBinds>,
+    #[knuffel(child)]
+    pub enable_mouse: bool,
+    #[knuffel(child)]
+    pub disable_mouse: bool,
 }
 
 impl MergeWith<RecentWindowsPart> for RecentWindows {
@@ -52,6 +58,10 @@ impl MergeWith<RecentWindowsPart> for RecentWindows {
         self.on |= part.on;
         if part.off {
             self.on = false;
+        }
+        self.enable_mouse |= part.enable_mouse;
+        if part.disable_mouse {
+            self.enable_mouse = false;
         }
 
         merge_clone!((self, part), debounce_ms, open_delay_ms);

--- a/niri-config/src/recent_windows.rs
+++ b/niri-config/src/recent_windows.rs
@@ -26,7 +26,7 @@ impl Default for RecentWindows {
             highlight: MruHighlight::default(),
             previews: MruPreviews::default(),
             binds: default_binds(),
-            enable_mouse: true
+            enable_mouse: true,
         }
     }
 }

--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -1028,6 +1028,11 @@ impl WindowMruUi {
         let UiState::Open(inner) = &mut self.state else {
             return None;
         };
+
+        if !inner.config.borrow().recent_windows.enable_mouse{
+            return None;
+        }
+
         // Don't handle pointer until the UI is visible.
         if !inner.is_fully_open() {
             return None;

--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -1029,7 +1029,7 @@ impl WindowMruUi {
             return None;
         };
 
-        if !inner.config.borrow().recent_windows.enable_mouse{
+        if !inner.config.borrow().recent_windows.enable_mouse {
             return None;
         }
 


### PR DESCRIPTION
This pull requests adds an option to disable mouse controls in the window switcher.

I oftentimes use niri with a graphic tablet, and in this case having mouse control when alt-tabbing is really unintuitive because if your cursor just so happens to be on your current window the window won't switch. In this case you need to go out of your way to move the cursor out of the switcher area and only then start alt-tabbing, which is not the most pleasant experience. Hope this isn't too user specific to be accepted