### PR TITLE
Recency heuristic for ambiguous output selection

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -334,7 +334,7 @@ pub trait LayoutElement {
 
 #[derive(Debug)]
 pub struct Layout<W: LayoutElement> {
-    /// Monitors and workspaes in the layout.
+    /// Monitors and workspaces in the layout.
     monitor_set: MonitorSet<W>,
     /// Focused outputs ordered from least to most recently focused.
     output_focus_stack: Vec<Output>,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -336,6 +336,8 @@ pub trait LayoutElement {
 pub struct Layout<W: LayoutElement> {
     /// Monitors and workspaes in the layout.
     monitor_set: MonitorSet<W>,
+    /// Focused outputs ordered from least to most recently focused.
+    output_focus_stack: Vec<Output>,
     /// Whether the layout should draw as active.
     ///
     /// This normally indicates that the layout has keyboard focus, but not always. E.g. when the
@@ -688,6 +690,15 @@ impl OverviewProgress {
 }
 
 impl<W: LayoutElement> Layout<W> {
+    pub fn outputs_by_recent_focus(&self) -> impl DoubleEndedIterator<Item = &Output> {
+        self.output_focus_stack.iter()
+    }
+
+    fn record_output_focus(output_focus_stack: &mut Vec<Output>, output: &Output) {
+        output_focus_stack.retain(|focused| focused != output);
+        output_focus_stack.push(output.clone());
+    }
+
     pub fn new(clock: Clock, config: &Config) -> Self {
         Self::with_options_and_workspaces(clock, config, Options::from_config(config))
     }
@@ -695,6 +706,7 @@ impl<W: LayoutElement> Layout<W> {
     pub fn with_options(clock: Clock, options: Options) -> Self {
         Self {
             monitor_set: MonitorSet::NoOutputs { workspaces: vec![] },
+            output_focus_stack: vec![],
             is_active: true,
             last_active_workspace_id: HashMap::new(),
             interactive_move: None,
@@ -720,6 +732,7 @@ impl<W: LayoutElement> Layout<W> {
 
         Self {
             monitor_set: MonitorSet::NoOutputs { workspaces },
+            output_focus_stack: vec![],
             is_active: true,
             last_active_workspace_id: HashMap::new(),
             interactive_move: None,
@@ -831,6 +844,9 @@ impl<W: LayoutElement> Layout<W> {
                 monitor.overview_open = self.overview_open;
                 monitor.set_overview_progress(self.overview_progress.as_ref());
 
+                self.output_focus_stack.clear();
+                self.output_focus_stack.push(monitor.output.clone());
+
                 MonitorSet::Normal {
                     monitors: vec![monitor],
                     primary_idx: 0,
@@ -841,6 +857,7 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn remove_output(&mut self, output: &Output) {
+        self.output_focus_stack.retain(|focused| focused != output);
         self.monitor_set = match mem::take(&mut self.monitor_set) {
             MonitorSet::Normal {
                 mut monitors,
@@ -918,6 +935,7 @@ impl<W: LayoutElement> Layout<W> {
 
         if activate {
             *active_monitor_idx = monitor_idx;
+            Self::record_output_focus(&mut self.output_focus_stack, &monitors[monitor_idx].output);
         }
     }
 
@@ -1017,6 +1035,7 @@ impl<W: LayoutElement> Layout<W> {
 
                 if activate.map_smart(|| false) {
                     *active_monitor_idx = mon_idx;
+                    Self::record_output_focus(&mut self.output_focus_stack, &mon.output);
                 }
 
                 // Set the default height for scrolling windows.
@@ -1531,6 +1550,7 @@ impl<W: LayoutElement> Layout<W> {
             for (workspace_idx, ws) in mon.workspaces.iter_mut().enumerate() {
                 if ws.activate_window(window) {
                     *active_monitor_idx = monitor_idx;
+                    Self::record_output_focus(&mut self.output_focus_stack, &mon.output);
 
                     // If currently in the middle of a vertical swipe between the target workspace
                     // and some other, don't switch the workspace.
@@ -1567,6 +1587,7 @@ impl<W: LayoutElement> Layout<W> {
             for (workspace_idx, ws) in mon.workspaces.iter_mut().enumerate() {
                 if ws.activate_window_without_raising(window) {
                     *active_monitor_idx = monitor_idx;
+                    Self::record_output_focus(&mut self.output_focus_stack, &mon.output);
 
                     // If currently in the middle of a vertical swipe between the target workspace
                     // and some other, don't switch the workspace.
@@ -3274,6 +3295,7 @@ impl<W: LayoutElement> Layout<W> {
             for (idx, mon) in monitors.iter().enumerate() {
                 if &mon.output == output {
                     *active_monitor_idx = idx;
+                    Self::record_output_focus(&mut self.output_focus_stack, output);
                     return;
                 }
             }
@@ -3373,6 +3395,7 @@ impl<W: LayoutElement> Layout<W> {
             );
             if activate.map_smart(|| false) {
                 *active_monitor_idx = new_idx;
+                Self::record_output_focus(&mut self.output_focus_stack, &monitors[new_idx].output);
             }
 
             let mon = &mut monitors[mon_idx];
@@ -3488,6 +3511,7 @@ impl<W: LayoutElement> Layout<W> {
 
         if activate {
             *active_monitor_idx = target_idx;
+            Self::record_output_focus(&mut self.output_focus_stack, &monitors[target_idx].output);
         }
 
         activate

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -341,7 +341,7 @@ pub trait LayoutElement {
 
 #[derive(Debug)]
 pub struct Layout<W: LayoutElement> {
-    /// Monitors and workspaes in the layout.
+    /// Monitors and workspaces in the layout.
     monitor_set: MonitorSet<W>,
     /// Focused outputs ordered from least to most recently focused.
     output_focus_stack: Vec<Output>,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -343,6 +343,8 @@ pub trait LayoutElement {
 pub struct Layout<W: LayoutElement> {
     /// Monitors and workspaes in the layout.
     monitor_set: MonitorSet<W>,
+    /// Focused outputs ordered from least to most recently focused.
+    output_focus_stack: Vec<Output>,
     /// Whether the layout should draw as active.
     ///
     /// This normally indicates that the layout has keyboard focus, but not always. E.g. when the
@@ -713,6 +715,15 @@ impl RenderLayer {
 }
 
 impl<W: LayoutElement> Layout<W> {
+    pub fn outputs_by_recent_focus(&self) -> impl DoubleEndedIterator<Item = &Output> {
+        self.output_focus_stack.iter()
+    }
+
+    fn record_output_focus(output_focus_stack: &mut Vec<Output>, output: &Output) {
+        output_focus_stack.retain(|focused| focused != output);
+        output_focus_stack.push(output.clone());
+    }
+
     pub fn new(clock: Clock, config: &Config) -> Self {
         Self::with_options_and_workspaces(clock, config, Options::from_config(config))
     }
@@ -720,6 +731,7 @@ impl<W: LayoutElement> Layout<W> {
     pub fn with_options(clock: Clock, options: Options) -> Self {
         Self {
             monitor_set: MonitorSet::NoOutputs { workspaces: vec![] },
+            output_focus_stack: vec![],
             is_active: true,
             last_active_workspace_id: HashMap::new(),
             interactive_move: None,
@@ -745,6 +757,7 @@ impl<W: LayoutElement> Layout<W> {
 
         Self {
             monitor_set: MonitorSet::NoOutputs { workspaces },
+            output_focus_stack: vec![],
             is_active: true,
             last_active_workspace_id: HashMap::new(),
             interactive_move: None,
@@ -856,6 +869,9 @@ impl<W: LayoutElement> Layout<W> {
                 monitor.overview_open = self.overview_open;
                 monitor.set_overview_progress(self.overview_progress.as_ref());
 
+                self.output_focus_stack.clear();
+                self.output_focus_stack.push(monitor.output.clone());
+
                 MonitorSet::Normal {
                     monitors: vec![monitor],
                     primary_idx: 0,
@@ -866,6 +882,7 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn remove_output(&mut self, output: &Output) {
+        self.output_focus_stack.retain(|focused| focused != output);
         self.monitor_set = match mem::take(&mut self.monitor_set) {
             MonitorSet::Normal {
                 mut monitors,
@@ -943,6 +960,7 @@ impl<W: LayoutElement> Layout<W> {
 
         if activate {
             *active_monitor_idx = monitor_idx;
+            Self::record_output_focus(&mut self.output_focus_stack, &monitors[monitor_idx].output);
         }
     }
 
@@ -1039,6 +1057,7 @@ impl<W: LayoutElement> Layout<W> {
 
                 if activate.map_smart(|| false) {
                     *active_monitor_idx = mon_idx;
+                    Self::record_output_focus(&mut self.output_focus_stack, &mon.output);
                 }
 
                 // Set the default height for scrolling windows.
@@ -1550,6 +1569,7 @@ impl<W: LayoutElement> Layout<W> {
             for (workspace_idx, ws) in mon.workspaces.iter_mut().enumerate() {
                 if ws.activate_window(window) {
                     *active_monitor_idx = monitor_idx;
+                    Self::record_output_focus(&mut self.output_focus_stack, &mon.output);
 
                     // If currently in the middle of a vertical swipe between the target workspace
                     // and some other, don't switch the workspace.
@@ -1586,6 +1606,7 @@ impl<W: LayoutElement> Layout<W> {
             for (workspace_idx, ws) in mon.workspaces.iter_mut().enumerate() {
                 if ws.activate_window_without_raising(window) {
                     *active_monitor_idx = monitor_idx;
+                    Self::record_output_focus(&mut self.output_focus_stack, &mon.output);
 
                     // If currently in the middle of a vertical swipe between the target workspace
                     // and some other, don't switch the workspace.
@@ -3294,6 +3315,7 @@ impl<W: LayoutElement> Layout<W> {
             for (idx, mon) in monitors.iter().enumerate() {
                 if &mon.output == output {
                     *active_monitor_idx = idx;
+                    Self::record_output_focus(&mut self.output_focus_stack, output);
                     return;
                 }
             }
@@ -3393,6 +3415,7 @@ impl<W: LayoutElement> Layout<W> {
             );
             if activate.map_smart(|| false) {
                 *active_monitor_idx = new_idx;
+                Self::record_output_focus(&mut self.output_focus_stack, &monitors[new_idx].output);
             }
 
             let mon = &mut monitors[mon_idx];
@@ -3508,6 +3531,7 @@ impl<W: LayoutElement> Layout<W> {
 
         if activate {
             *active_monitor_idx = target_idx;
+            Self::record_output_focus(&mut self.output_focus_stack, &monitors[target_idx].output);
         }
 
         activate

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -3475,6 +3475,52 @@ impl Niri {
         self.global_space.output_under(pos).next().cloned()
     }
 
+    fn closest_output_in_direction(
+        &self,
+        current: &Output,
+        extended_geo: Rectangle<i32, Logical>,
+        metrics: impl Fn(Rectangle<i32, Logical>, Rectangle<i32, Logical>) -> Option<(i32, i32)>,
+    ) -> Option<Output> {
+        let current_geo = self.global_space.output_geometry(current)?;
+
+        let candidates = self
+            .global_space
+            .outputs()
+            .filter(|&output| output != current)
+            .filter_map(|output| {
+                let geo = self.global_space.output_geometry(output).unwrap();
+                let metrics = metrics(current_geo, geo)?;
+                geo.overlaps(extended_geo).then_some((output, metrics))
+            })
+            .collect::<Vec<_>>();
+
+        Self::pick_closest_output(self.layout.outputs_by_recent_focus(), candidates)
+    }
+
+    fn pick_closest_output<'a>(
+        recent_focus: impl DoubleEndedIterator<Item = &'a Output>,
+        candidates: impl IntoIterator<Item = (&'a Output, (i32, i32))>,
+    ) -> Option<Output> {
+        let candidates = candidates.into_iter().collect::<Vec<_>>();
+        let best_edge = candidates.iter().map(|(_, (edge, _))| *edge).max()?;
+
+        recent_focus
+            .rev()
+            .find(|focused| {
+                candidates
+                    .iter()
+                    .any(|(candidate, (edge, _))| *edge == best_edge && *candidate == *focused)
+            })
+            .cloned()
+            .or_else(|| {
+                candidates
+                    .iter()
+                    .filter(|(_, (edge, _))| *edge == best_edge)
+                    .min_by_key(|(_, (_, orthogonal_distance))| *orthogonal_distance)
+                    .map(|(output, _)| (*output).clone())
+            })
+    }
+
     pub fn output_left_of(&self, current: &Output) -> Option<Output> {
         let current_geo = self.global_space.output_geometry(current)?;
         let extended_geo = Rectangle::new(
@@ -3482,13 +3528,12 @@ impl Niri {
             Size::from((i32::MAX, current_geo.size.h)),
         );
 
-        self.global_space
-            .outputs()
-            .map(|output| (output, self.global_space.output_geometry(output).unwrap()))
-            .filter(|(_, geo)| center(*geo).x < center(current_geo).x && geo.overlaps(extended_geo))
-            .min_by_key(|(_, geo)| center(current_geo).x - center(*geo).x)
-            .map(|(output, _)| output)
-            .cloned()
+        self.closest_output_in_direction(current, extended_geo, |current_geo, geo| {
+            (center(geo).x < center(current_geo).x).then_some((
+                geo.loc.x + geo.size.w,
+                (center(geo).y - center(current_geo).y).abs(),
+            ))
+        })
     }
 
     pub fn output_right_of(&self, current: &Output) -> Option<Output> {
@@ -3498,13 +3543,10 @@ impl Niri {
             Size::from((i32::MAX, current_geo.size.h)),
         );
 
-        self.global_space
-            .outputs()
-            .map(|output| (output, self.global_space.output_geometry(output).unwrap()))
-            .filter(|(_, geo)| center(*geo).x > center(current_geo).x && geo.overlaps(extended_geo))
-            .min_by_key(|(_, geo)| center(*geo).x - center(current_geo).x)
-            .map(|(output, _)| output)
-            .cloned()
+        self.closest_output_in_direction(current, extended_geo, |current_geo, geo| {
+            (center(geo).x > center(current_geo).x)
+                .then_some((-geo.loc.x, (center(geo).y - center(current_geo).y).abs()))
+        })
     }
 
     pub fn output_up_of(&self, current: &Output) -> Option<Output> {
@@ -3514,13 +3556,12 @@ impl Niri {
             Size::from((current_geo.size.w, i32::MAX)),
         );
 
-        self.global_space
-            .outputs()
-            .map(|output| (output, self.global_space.output_geometry(output).unwrap()))
-            .filter(|(_, geo)| center(*geo).y < center(current_geo).y && geo.overlaps(extended_geo))
-            .min_by_key(|(_, geo)| center(current_geo).y - center(*geo).y)
-            .map(|(output, _)| output)
-            .cloned()
+        self.closest_output_in_direction(current, extended_geo, |current_geo, geo| {
+            (center(geo).y < center(current_geo).y).then_some((
+                geo.loc.y + geo.size.h,
+                (center(geo).x - center(current_geo).x).abs(),
+            ))
+        })
     }
 
     pub fn output_down_of(&self, current: &Output) -> Option<Output> {
@@ -3530,13 +3571,10 @@ impl Niri {
             Size::from((current_geo.size.w, i32::MAX)),
         );
 
-        self.global_space
-            .outputs()
-            .map(|output| (output, self.global_space.output_geometry(output).unwrap()))
-            .filter(|(_, geo)| center(*geo).y > center(current_geo).y && geo.overlaps(extended_geo))
-            .min_by_key(|(_, geo)| center(*geo).y - center(current_geo).y)
-            .map(|(output, _)| output)
-            .cloned()
+        self.closest_output_in_direction(current, extended_geo, |current_geo, geo| {
+            (center(geo).y > center(current_geo).y)
+                .then_some((-geo.loc.y, (center(geo).x - center(current_geo).x).abs()))
+        })
     }
 
     pub fn output_previous_of(&self, current: &Output) -> Option<Output> {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -3496,6 +3496,52 @@ impl Niri {
         self.global_space.output_under(pos).next().cloned()
     }
 
+    fn closest_output_in_direction(
+        &self,
+        current: &Output,
+        extended_geo: Rectangle<i32, Logical>,
+        metrics: impl Fn(Rectangle<i32, Logical>, Rectangle<i32, Logical>) -> Option<(i32, i32)>,
+    ) -> Option<Output> {
+        let current_geo = self.global_space.output_geometry(current)?;
+
+        let candidates = self
+            .global_space
+            .outputs()
+            .filter(|&output| output != current)
+            .filter_map(|output| {
+                let geo = self.global_space.output_geometry(output).unwrap();
+                let metrics = metrics(current_geo, geo)?;
+                geo.overlaps(extended_geo).then_some((output, metrics))
+            })
+            .collect::<Vec<_>>();
+
+        Self::pick_closest_output(self.layout.outputs_by_recent_focus(), candidates)
+    }
+
+    fn pick_closest_output<'a>(
+        recent_focus: impl DoubleEndedIterator<Item = &'a Output>,
+        candidates: impl IntoIterator<Item = (&'a Output, (i32, i32))>,
+    ) -> Option<Output> {
+        let candidates = candidates.into_iter().collect::<Vec<_>>();
+        let best_edge = candidates.iter().map(|(_, (edge, _))| *edge).max()?;
+
+        recent_focus
+            .rev()
+            .find(|focused| {
+                candidates
+                    .iter()
+                    .any(|(candidate, (edge, _))| *edge == best_edge && *candidate == *focused)
+            })
+            .cloned()
+            .or_else(|| {
+                candidates
+                    .iter()
+                    .filter(|(_, (edge, _))| *edge == best_edge)
+                    .min_by_key(|(_, (_, orthogonal_distance))| *orthogonal_distance)
+                    .map(|(output, _)| (*output).clone())
+            })
+    }
+
     pub fn output_left_of(&self, current: &Output) -> Option<Output> {
         let current_geo = self.global_space.output_geometry(current)?;
         let extended_geo = Rectangle::new(
@@ -3503,13 +3549,12 @@ impl Niri {
             Size::from((i32::MAX, current_geo.size.h)),
         );
 
-        self.global_space
-            .outputs()
-            .map(|output| (output, self.global_space.output_geometry(output).unwrap()))
-            .filter(|(_, geo)| center(*geo).x < center(current_geo).x && geo.overlaps(extended_geo))
-            .min_by_key(|(_, geo)| center(current_geo).x - center(*geo).x)
-            .map(|(output, _)| output)
-            .cloned()
+        self.closest_output_in_direction(current, extended_geo, |current_geo, geo| {
+            (center(geo).x < center(current_geo).x).then_some((
+                geo.loc.x + geo.size.w,
+                (center(geo).y - center(current_geo).y).abs(),
+            ))
+        })
     }
 
     pub fn output_right_of(&self, current: &Output) -> Option<Output> {
@@ -3519,13 +3564,10 @@ impl Niri {
             Size::from((i32::MAX, current_geo.size.h)),
         );
 
-        self.global_space
-            .outputs()
-            .map(|output| (output, self.global_space.output_geometry(output).unwrap()))
-            .filter(|(_, geo)| center(*geo).x > center(current_geo).x && geo.overlaps(extended_geo))
-            .min_by_key(|(_, geo)| center(*geo).x - center(current_geo).x)
-            .map(|(output, _)| output)
-            .cloned()
+        self.closest_output_in_direction(current, extended_geo, |current_geo, geo| {
+            (center(geo).x > center(current_geo).x)
+                .then_some((-geo.loc.x, (center(geo).y - center(current_geo).y).abs()))
+        })
     }
 
     pub fn output_up_of(&self, current: &Output) -> Option<Output> {
@@ -3535,13 +3577,12 @@ impl Niri {
             Size::from((current_geo.size.w, i32::MAX)),
         );
 
-        self.global_space
-            .outputs()
-            .map(|output| (output, self.global_space.output_geometry(output).unwrap()))
-            .filter(|(_, geo)| center(*geo).y < center(current_geo).y && geo.overlaps(extended_geo))
-            .min_by_key(|(_, geo)| center(current_geo).y - center(*geo).y)
-            .map(|(output, _)| output)
-            .cloned()
+        self.closest_output_in_direction(current, extended_geo, |current_geo, geo| {
+            (center(geo).y < center(current_geo).y).then_some((
+                geo.loc.y + geo.size.h,
+                (center(geo).x - center(current_geo).x).abs(),
+            ))
+        })
     }
 
     pub fn output_down_of(&self, current: &Output) -> Option<Output> {
@@ -3551,13 +3592,10 @@ impl Niri {
             Size::from((current_geo.size.w, i32::MAX)),
         );
 
-        self.global_space
-            .outputs()
-            .map(|output| (output, self.global_space.output_geometry(output).unwrap()))
-            .filter(|(_, geo)| center(*geo).y > center(current_geo).y && geo.overlaps(extended_geo))
-            .min_by_key(|(_, geo)| center(*geo).y - center(current_geo).y)
-            .map(|(output, _)| output)
-            .cloned()
+        self.closest_output_in_direction(current, extended_geo, |current_geo, geo| {
+            (center(geo).y > center(current_geo).y)
+                .then_some((-geo.loc.y, (center(geo).x - center(current_geo).x).abs()))
+        })
     }
 
     pub fn output_previous_of(&self, current: &Output) -> Option<Output> {


### PR DESCRIPTION
Discussed in: https://github.com/niri-wm/niri/discussions/2897

This Pull Request changes the algorithm to determine which output to target when going up, down, left or right: it implements some MRU heuristic for all the commands that have to do with choosing an output up, down, left or right.

I also considered making it opt-in, with, say:

```kdl
Mod+Shift+Left  { focus-monitor-left  use-focus-history=true; }
```

But there are *so* many such functions; at least all of these, in 4 directions:

```kdl
Mod+Ctrl+Down          { move-window-down-or-to-workspace-down; }
Mod+Ctrl+WheelScrollUp { move-column-to-workspace-up;           }
Mod+Shift+Ctrl+Left    { move-window-to-monitor-left;           }
Mod+Shift+Left         { focus-monitor-left                     }
Mod+Up                 { focus-window-or-workspace-up;          }
```

And I figured people would generally want to have a single selection scheme for all their output selection commands. In any case, we can discuss this and think about it some more, but I think there's something pretty usable here as is it.

---

Just like before, the candidate outputs are:

- in the correct direction, and
- they are at least partially in the (virtually) infinite "strip"
  obtained from extending the active output either vertically, for up
  and down motions, or horizontally for horizontal movements.

Unlike before, we now rank the candidate outputs by their nearbymost
vertical (or horizontal) edge: this allows us to more reasonably end up
with ties, where the ambiguity that is natural to the human user also
becomes effective in the code.

We curate a stack of the most recently used monitors and use it to
resolve the ties against the candidates that share the closest edge to
the currently active output.

If none of the candidates were ever visited, we fall back to the
previous heuristic, which would find the closest candidate, according
to the distance between their geometric centre and that of the active
output.