### PR TITLE
feat: virtual headless outputs

### DIFF
--- a/docs/Virtual-Outputs.md
+++ b/docs/Virtual-Outputs.md
@@ -1,0 +1,161 @@
+# Virtual Outputs (Headless Displays)
+
+Niri supports creating virtual headless outputs that can be used for VNC, screen sharing, or testing purposes. Virtual outputs work similarly to Sway's `create_output` command.
+
+## Use Cases
+
+- Remote desktop access via VNC (e.g., with wayvnc)
+- Screen recording/streaming of a separate output
+- Testing and development
+- Running niri without physical displays (CI, servers)
+
+## Creating Virtual Outputs
+
+### On a Regular Session (TTY with Physical Display)
+
+When running niri on a TTY with your physical monitor, you can create additional virtual outputs:
+
+```bash
+# Create a 1920x1080 virtual output
+niri msg create-virtual-output --width 1920 --height 1080
+# Output: Created virtual output: HEADLESS-1
+
+# Create another output with different resolution
+niri msg create-virtual-output --width 1280 --height 720
+# Output: Created virtual output: HEADLESS-2
+
+# Create a 120Hz output
+niri msg create-virtual-output --width 1920 --height 1080 --refresh-rate 120
+# Output: Created virtual output: HEADLESS-3
+
+# List all outputs (physical + virtual)
+niri msg outputs
+```
+
+### Pure Headless Mode (No Physical Display)
+
+For servers, VMs, or remote-only access:
+
+```bash
+# Start niri in headless mode
+NIRI_BACKEND=headless niri
+
+# A default 1920x1080 HEADLESS-1 output is created automatically
+# Create additional outputs if needed
+niri msg create-virtual-output --width 1280 --height 720
+```
+
+## Removing Virtual Outputs
+
+```bash
+niri msg remove-virtual-output HEADLESS-1
+# Output: Removed virtual output: HEADLESS-1
+```
+
+## Configuring Virtual Outputs
+
+Virtual outputs can be configured like regular outputs:
+
+```bash
+# Set scale
+niri msg output HEADLESS-1 scale 1.5
+
+# Set transform (rotation)
+niri msg output HEADLESS-1 transform 90
+
+# Turn off
+niri msg output HEADLESS-1 off
+
+# Turn on
+niri msg output HEADLESS-1 on
+```
+
+You can also configure them in your `config.kdl`:
+
+```kdl
+output "HEADLESS-1" {
+    scale 1.0
+    position x=1920 y=0
+}
+```
+
+## Using with VNC (wayvnc)
+
+[wayvnc](https://github.com/any1/wayvnc) is a VNC server for wlroots-based Wayland compositors.
+
+### Setup with Physical Display + VNC
+
+```bash
+# 1. Start niri normally on your TTY
+niri
+
+# 2. Create a virtual output for VNC
+niri msg create-virtual-output --width 1920 --height 1080
+
+# 3. Start wayvnc on the virtual output
+wayvnc --output HEADLESS-1
+
+# 4. Connect from a VNC client to your machine's IP
+```
+
+### Setup for Pure Headless (Remote Only)
+
+```bash
+# 1. Start niri in headless mode (e.g., over SSH)
+NIRI_BACKEND=headless niri &
+
+# 2. Start wayvnc
+WAYLAND_DISPLAY=wayland-1 wayvnc
+
+# 3. Connect from a VNC client
+```
+
+### Headless with systemd
+
+For a persistent headless niri session:
+
+```ini
+# ~/.config/systemd/user/niri-headless.service
+[Unit]
+Description=Niri Headless Session
+
+[Service]
+Type=simple
+Environment=NIRI_BACKEND=headless
+ExecStart=/usr/bin/niri
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user enable --now niri-headless
+```
+
+## CLI Reference
+
+### create-virtual-output
+
+```
+niri msg create-virtual-output [OPTIONS]
+
+Options:
+  --width <WIDTH>              Width in pixels [default: 1920]
+  --height <HEIGHT>            Height in pixels [default: 1080]
+  --refresh-rate <REFRESH_RATE>  Refresh rate in Hz [default: 60]
+```
+
+### remove-virtual-output
+
+```
+niri msg remove-virtual-output <NAME>
+
+Arguments:
+  <NAME>  Name of the output to remove (e.g., "HEADLESS-1")
+```
+
+## Limitations
+
+- Virtual outputs are not supported when running niri nested in another Wayland compositor (Winit backend)
+- Virtual outputs are not persisted across niri restarts - you need to recreate them

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -98,6 +98,25 @@ pub enum Request {
         /// Configuration to apply.
         action: OutputAction,
     },
+    /// Create a new virtual headless output.
+    ///
+    /// This only works when niri is running with the headless backend (e.g. with
+    /// `NIRI_BACKEND=headless`).
+    CreateVirtualOutput {
+        /// Width in pixels. Defaults to 1920 if not specified.
+        width: Option<u16>,
+        /// Height in pixels. Defaults to 1080 if not specified.
+        height: Option<u16>,
+        /// Refresh rate in Hz. Defaults to 60 if not specified.
+        refresh_rate: Option<u32>,
+    },
+    /// Remove a virtual headless output by name.
+    ///
+    /// This only works when niri is running with the headless backend.
+    RemoveVirtualOutput {
+        /// Name of the output to remove (e.g. "HEADLESS-1").
+        name: String,
+    },
     /// Start continuously receiving events from the compositor.
     ///
     /// The compositor should reply with `Reply::Ok(Response::Handled)`, then continuously send
@@ -165,6 +184,8 @@ pub enum Response {
     OverviewState(Overview),
     /// Information about screencasts.
     Casts(Vec<Cast>),
+    /// A virtual output was created successfully.
+    VirtualOutputCreated(String),
 }
 
 /// Overview information.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -100,8 +100,7 @@ pub enum Request {
     },
     /// Create a new virtual headless output.
     ///
-    /// This only works when niri is running with the headless backend (e.g. with
-    /// `NIRI_BACKEND=headless`).
+    /// This works with both the headless and the TTY backend.
     CreateVirtualOutput {
         /// Width in pixels. Defaults to 1920 if not specified.
         width: Option<u16>,
@@ -112,7 +111,7 @@ pub enum Request {
     },
     /// Remove a virtual headless output by name.
     ///
-    /// This only works when niri is running with the headless backend.
+    /// This works with both the headless and the TTY backend.
     RemoveVirtualOutput {
         /// Name of the output to remove (e.g. "HEADLESS-1").
         name: String,

--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -133,7 +133,7 @@ impl Headless {
         width: u16,
         height: u16,
         refresh_rate: u32,
-    ) -> String {
+    ) -> Result<String, String> {
         self.virtual_outputs
             .create(niri, &self.ipc_outputs, width, height, refresh_rate)
     }

--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -4,9 +4,8 @@
 //! - Running niri without physical displays (for VNC, screensharing, etc.)
 //! - Testing purposes
 //!
-//! Note: This is missing some parts like dmabufs.
+//! Note: This is missing some parts like direct rendering to dmabufs.
 
-use std::collections::HashMap;
 use std::mem;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -19,6 +18,7 @@ use smithay::backend::egl::native::EGLSurfacelessDisplay;
 use smithay::backend::egl::{EGLContext, EGLDisplay};
 use smithay::backend::renderer::element::RenderElementStates;
 use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::backend::renderer::ImportDma;
 use smithay::output::{Mode, Output, PhysicalProperties, Subpixel};
 use smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback;
 use smithay::utils::Size;
@@ -32,10 +32,7 @@ use crate::utils::{get_monotonic_time, logical_output};
 pub struct Headless {
     renderer: Option<GlesRenderer>,
     ipc_outputs: Arc<Mutex<IpcOutputMap>>,
-    /// Counter for auto-naming headless outputs (HEADLESS-1, HEADLESS-2, etc.)
-    output_counter: u32,
-    /// Track outputs by name for removal, storing (Output, OutputId)
-    outputs: HashMap<String, (Output, OutputId)>,
+    virtual_outputs: super::VirtualOutputs,
 }
 
 impl Headless {
@@ -43,8 +40,7 @@ impl Headless {
         Self {
             renderer: None,
             ipc_outputs: Default::default(),
-            output_counter: 0,
-            outputs: HashMap::new(),
+            virtual_outputs: super::VirtualOutputs::new(),
         }
     }
 
@@ -138,90 +134,13 @@ impl Headless {
         height: u16,
         refresh_rate: u32,
     ) -> String {
-        self.output_counter += 1;
-        let n = self.output_counter;
-
-        let connector = format!("HEADLESS-{n}");
-        let make = "niri".to_string();
-        let model = "virtual".to_string();
-        let serial = n.to_string();
-
-        let refresh = i32::try_from(refresh_rate * 1000).unwrap_or(60_000);
-
-        let output = Output::new(
-            connector.clone(),
-            PhysicalProperties {
-                size: (0, 0).into(),
-                subpixel: Subpixel::Unknown,
-                make: make.clone(),
-                model: model.clone(),
-                serial_number: serial.clone(),
-            },
-        );
-
-        let mode = Mode {
-            size: Size::from((i32::from(width), i32::from(height))),
-            refresh,
-        };
-        output.change_current_state(Some(mode), None, None, None);
-        output.set_preferred(mode);
-
-        output.user_data().insert_if_missing(|| OutputName {
-            connector: connector.clone(),
-            make: Some(make),
-            model: Some(model),
-            serial: Some(serial),
-        });
-
-        let output_id = OutputId::next();
-        let physical_properties = output.physical_properties();
-        self.ipc_outputs.lock().unwrap().insert(
-            output_id,
-            niri_ipc::Output {
-                name: output.name(),
-                make: physical_properties.make,
-                model: physical_properties.model,
-                serial: None,
-                physical_size: None,
-                modes: vec![niri_ipc::Mode {
-                    width,
-                    height,
-                    refresh_rate: refresh_rate * 1000,
-                    is_preferred: true,
-                }],
-                current_mode: Some(0),
-                is_custom_mode: true,
-                vrr_supported: false,
-                vrr_enabled: false,
-                logical: Some(logical_output(&output)),
-            },
-        );
-
-        // Track the output for potential removal
-        self.outputs
-            .insert(connector.clone(), (output.clone(), output_id));
-
-        let refresh_interval = Duration::from_nanos(1_000_000_000 / u64::from(refresh_rate));
-        niri.add_output(output, Some(refresh_interval), false);
-
-        connector
+        self.virtual_outputs
+            .create(niri, &self.ipc_outputs, width, height, refresh_rate)
     }
 
-    /// Remove a virtual headless output by name.
-    /// Returns Ok(()) if successful, Err with message if not found or failed.
     pub fn remove_virtual_output(&mut self, niri: &mut Niri, name: &str) -> Result<(), String> {
-        let (output, output_id) = self
-            .outputs
-            .remove(name)
-            .ok_or_else(|| format!("output '{}' not found", name))?;
-
-        // Remove from IPC outputs
-        self.ipc_outputs.lock().unwrap().remove(&output_id);
-
-        // Remove from niri
-        niri.remove_output(&output);
-
-        Ok(())
+        self.virtual_outputs
+            .remove(niri, &self.ipc_outputs, name)
     }
 
     pub fn seat_name(&self) -> String {
@@ -299,8 +218,17 @@ impl Headless {
         RenderResult::Submitted
     }
 
-    pub fn import_dmabuf(&mut self, _dmabuf: &Dmabuf) -> bool {
-        unimplemented!()
+    pub fn import_dmabuf(&mut self, dmabuf: &Dmabuf) -> bool {
+        let Some(renderer) = self.renderer.as_mut() else {
+            return false;
+        };
+        match renderer.import_dmabuf(dmabuf, None) {
+            Ok(_texture) => true,
+            Err(err) => {
+                debug!("error importing dmabuf: {err:?}");
+                false
+            }
+        }
     }
 
     pub fn ipc_outputs(&self) -> Arc<Mutex<IpcOutputMap>> {

--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -48,10 +48,7 @@ impl Headless {
         }
     }
 
-    pub fn init(&mut self, niri: &mut Niri) {
-        // Create a default output on startup
-        self.create_virtual_output(niri, 1920, 1080, 60);
-    }
+    pub fn init(&mut self, _niri: &mut Niri) {}
 
     pub fn add_renderer(&mut self) -> anyhow::Result<()> {
         if self.renderer.is_some() {

--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -1,14 +1,20 @@
-//! Headless backend for tests.
+//! Headless backend for virtual outputs and testing.
 //!
-//! This can eventually grow into a more complete backend if needed, but for now it's missing some
-//! crucial parts like dmabufs.
+//! This backend can be used for:
+//! - Running niri without physical displays (for VNC, screensharing, etc.)
+//! - Testing purposes
+//!
+//! Note: This is missing some parts like dmabufs.
 
+use std::collections::HashMap;
 use std::mem;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::Context as _;
 use niri_config::OutputName;
 use smithay::backend::allocator::dmabuf::Dmabuf;
+use smithay::reexports::calloop::timer::{TimeoutAction, Timer};
 use smithay::backend::egl::native::EGLSurfacelessDisplay;
 use smithay::backend::egl::{EGLContext, EGLDisplay};
 use smithay::backend::renderer::element::RenderElementStates;
@@ -26,6 +32,10 @@ use crate::utils::{get_monotonic_time, logical_output};
 pub struct Headless {
     renderer: Option<GlesRenderer>,
     ipc_outputs: Arc<Mutex<IpcOutputMap>>,
+    /// Counter for auto-naming headless outputs (HEADLESS-1, HEADLESS-2, etc.)
+    output_counter: u32,
+    /// Track outputs by name for removal, storing (Output, OutputId)
+    outputs: HashMap<String, (Output, OutputId)>,
 }
 
 impl Headless {
@@ -33,10 +43,15 @@ impl Headless {
         Self {
             renderer: None,
             ipc_outputs: Default::default(),
+            output_counter: 0,
+            outputs: HashMap::new(),
         }
     }
 
-    pub fn init(&mut self, _niri: &mut Niri) {}
+    pub fn init(&mut self, niri: &mut Niri) {
+        // Create a default output on startup
+        self.create_virtual_output(niri, 1920, 1080, 60);
+    }
 
     pub fn add_renderer(&mut self) -> anyhow::Result<()> {
         if self.renderer.is_some() {
@@ -58,6 +73,8 @@ impl Headless {
         Ok(())
     }
 
+    /// Add an output for testing (uses lowercase naming like `headless-1`).
+    /// This is kept for backwards compatibility with tests.
     pub fn add_output(&mut self, niri: &mut Niri, n: u8, size: (u16, u16)) {
         let connector = format!("headless-{n}");
         let make = "niri".to_string();
@@ -115,6 +132,101 @@ impl Headless {
         niri.add_output(output, None, false);
     }
 
+    /// Create a virtual headless output with the given dimensions.
+    /// Returns the name of the created output (e.g., "HEADLESS-1").
+    pub fn create_virtual_output(
+        &mut self,
+        niri: &mut Niri,
+        width: u16,
+        height: u16,
+        refresh_rate: u32,
+    ) -> String {
+        self.output_counter += 1;
+        let n = self.output_counter;
+
+        let connector = format!("HEADLESS-{n}");
+        let make = "niri".to_string();
+        let model = "virtual".to_string();
+        let serial = n.to_string();
+
+        let refresh = i32::try_from(refresh_rate * 1000).unwrap_or(60_000);
+
+        let output = Output::new(
+            connector.clone(),
+            PhysicalProperties {
+                size: (0, 0).into(),
+                subpixel: Subpixel::Unknown,
+                make: make.clone(),
+                model: model.clone(),
+                serial_number: serial.clone(),
+            },
+        );
+
+        let mode = Mode {
+            size: Size::from((i32::from(width), i32::from(height))),
+            refresh,
+        };
+        output.change_current_state(Some(mode), None, None, None);
+        output.set_preferred(mode);
+
+        output.user_data().insert_if_missing(|| OutputName {
+            connector: connector.clone(),
+            make: Some(make),
+            model: Some(model),
+            serial: Some(serial),
+        });
+
+        let output_id = OutputId::next();
+        let physical_properties = output.physical_properties();
+        self.ipc_outputs.lock().unwrap().insert(
+            output_id,
+            niri_ipc::Output {
+                name: output.name(),
+                make: physical_properties.make,
+                model: physical_properties.model,
+                serial: None,
+                physical_size: None,
+                modes: vec![niri_ipc::Mode {
+                    width,
+                    height,
+                    refresh_rate: refresh_rate * 1000,
+                    is_preferred: true,
+                }],
+                current_mode: Some(0),
+                is_custom_mode: true,
+                vrr_supported: false,
+                vrr_enabled: false,
+                logical: Some(logical_output(&output)),
+            },
+        );
+
+        // Track the output for potential removal
+        self.outputs
+            .insert(connector.clone(), (output.clone(), output_id));
+
+        let refresh_interval = Duration::from_nanos(1_000_000_000 / u64::from(refresh_rate));
+        niri.add_output(output, Some(refresh_interval), false);
+
+        connector
+    }
+
+    /// Remove a virtual headless output by name.
+    /// Returns Ok(()) if successful, Err with message if not found or failed.
+    pub fn remove_virtual_output(&mut self, niri: &mut Niri, name: &str) -> Result<(), String> {
+        let (output, output_id) = self
+            .outputs
+            .remove(name)
+            .ok_or_else(|| format!("output '{}' not found", name))?;
+
+        // Remove from IPC outputs
+        self.ipc_outputs.lock().unwrap().remove(&output_id);
+
+        // Remove from niri
+        niri.remove_output(&output);
+
+        Ok(())
+    }
+
     pub fn seat_name(&self) -> String {
         "headless".to_owned()
     }
@@ -127,10 +239,12 @@ impl Headless {
     }
 
     pub fn render(&mut self, niri: &mut Niri, output: &Output) -> RenderResult {
+        let now = get_monotonic_time();
+
         let states = RenderElementStates::default();
         let mut presentation_feedbacks = niri.take_presentation_feedbacks(output, &states);
         presentation_feedbacks.presented::<_, smithay::utils::Monotonic>(
-            get_monotonic_time(),
+            now,
             Refresh::Unknown,
             0,
             wp_presentation_feedback::Kind::empty(),
@@ -141,13 +255,49 @@ impl Headless {
             RedrawState::Idle => unreachable!(),
             RedrawState::Queued => (),
             RedrawState::WaitingForVBlank { .. } => unreachable!(),
-            RedrawState::WaitingForEstimatedVBlank(_) => unreachable!(),
-            RedrawState::WaitingForEstimatedVBlankAndQueued(_) => unreachable!(),
+            RedrawState::WaitingForEstimatedVBlank(token)
+            | RedrawState::WaitingForEstimatedVBlankAndQueued(token) => {
+                niri.event_loop.remove(token);
+            }
         }
 
+        // Update the frame clock so animation timing works correctly.
+        output_state.frame_clock.presented(now);
         output_state.frame_callback_sequence = output_state.frame_callback_sequence.wrapping_add(1);
 
-        // FIXME: request redraw on unfinished animations remain
+        // Use a timer to pace redraws, simulating vblank for headless outputs.
+        let refresh_interval = output_state
+            .frame_clock
+            .refresh_interval()
+            .unwrap_or(Duration::from_micros(16_667));
+
+        let output_clone = output.clone();
+        let timer = Timer::from_duration(refresh_interval);
+        let token = niri
+            .event_loop
+            .insert_source(timer, move |_, _, data| {
+                let output_state = data.niri.output_state.get_mut(&output_clone).unwrap();
+                output_state.frame_callback_sequence =
+                    output_state.frame_callback_sequence.wrapping_add(1);
+
+                match mem::replace(&mut output_state.redraw_state, RedrawState::Idle) {
+                    RedrawState::WaitingForEstimatedVBlank(_) => (),
+                    RedrawState::WaitingForEstimatedVBlankAndQueued(_) => {
+                        output_state.redraw_state = RedrawState::Queued;
+                        return TimeoutAction::Drop;
+                    }
+                    _ => unreachable!(),
+                }
+
+                if output_state.unfinished_animations_remain {
+                    data.niri.queue_redraw(&output_clone);
+                } else {
+                    data.niri.send_frame_callbacks_for_virtual_output(&output_clone);
+                }
+                TimeoutAction::Drop
+            })
+            .unwrap();
+        output_state.redraw_state = RedrawState::WaitingForEstimatedVBlank(token);
 
         RenderResult::Submitted
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -232,4 +232,39 @@ impl Backend {
             panic!("backend is not Headless")
         }
     }
+
+    /// Create a virtual headless output.
+    ///
+    /// This works with both the headless backend and the TTY backend.
+    /// Returns the name of the created output (e.g., "HEADLESS-1").
+    pub fn create_virtual_output(
+        &mut self,
+        niri: &mut Niri,
+        width: u16,
+        height: u16,
+        refresh_rate: u32,
+    ) -> Result<String, String> {
+        match self {
+            Backend::Headless(headless) => {
+                Ok(headless.create_virtual_output(niri, width, height, refresh_rate))
+            }
+            Backend::Tty(tty) => Ok(tty.create_virtual_output(niri, width, height, refresh_rate)),
+            Backend::Winit(_) => {
+                Err("virtual outputs are not supported with the Winit backend".into())
+            }
+        }
+    }
+
+    /// Remove a virtual headless output by name.
+    ///
+    /// This works with both the headless backend and the TTY backend.
+    pub fn remove_virtual_output(&mut self, niri: &mut Niri, name: &str) -> Result<(), String> {
+        match self {
+            Backend::Headless(headless) => headless.remove_virtual_output(niri, name),
+            Backend::Tty(tty) => tty.remove_virtual_output(niri, name),
+            Backend::Winit(_) => {
+                Err("virtual outputs are not supported with the Winit backend".into())
+            }
+        }
+    }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -81,7 +81,11 @@ impl VirtualOutputs {
         width: u16,
         height: u16,
         refresh_rate: u32,
-    ) -> String {
+    ) -> Result<String, String> {
+        if refresh_rate == 0 {
+            return Err("refresh rate must be greater than 0".into());
+        }
+
         self.counter += 1;
         let n = self.counter;
 
@@ -118,6 +122,14 @@ impl VirtualOutputs {
         });
 
         let output_id = OutputId::next();
+        self.outputs
+            .insert(connector.clone(), (output.clone(), output_id));
+
+        let refresh_interval = Duration::from_nanos(1_000_000_000 / u64::from(refresh_rate));
+        niri.add_output(output.clone(), Some(refresh_interval), false);
+
+        // Build IPC output after add_output so logical geometry reflects
+        // applied config (scale, transform, position).
         let physical_properties = output.physical_properties();
         ipc_outputs.lock().unwrap().insert(
             output_id,
@@ -141,13 +153,7 @@ impl VirtualOutputs {
             },
         );
 
-        self.outputs
-            .insert(connector.clone(), (output.clone(), output_id));
-
-        let refresh_interval = Duration::from_nanos(1_000_000_000 / u64::from(refresh_rate));
-        niri.add_output(output, Some(refresh_interval), false);
-
-        connector
+        Ok(connector)
     }
 
     /// Remove a virtual headless output by name.
@@ -368,9 +374,9 @@ impl Backend {
     ) -> Result<String, String> {
         match self {
             Backend::Headless(headless) => {
-                Ok(headless.create_virtual_output(niri, width, height, refresh_rate))
+                headless.create_virtual_output(niri, width, height, refresh_rate)
             }
-            Backend::Tty(tty) => Ok(tty.create_virtual_output(niri, width, height, refresh_rate)),
+            Backend::Tty(tty) => tty.create_virtual_output(niri, width, height, refresh_rate),
             Backend::Winit(_) => {
                 Err("virtual outputs are not supported with the Winit backend".into())
             }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,14 +2,16 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use niri_config::{Config, ModKey};
+use niri_config::{Config, ModKey, OutputName};
 use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::renderer::gles::GlesRenderer;
-use smithay::output::Output;
+use smithay::output::{Mode, Output, PhysicalProperties, Subpixel};
+use smithay::utils::Size;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 
 use crate::niri::Niri;
 use crate::utils::id::IdCounter;
+use crate::utils::logical_output;
 
 pub mod tty;
 pub use tty::Tty;
@@ -51,6 +53,126 @@ impl OutputId {
 
     pub fn get(self) -> u64 {
         self.0
+    }
+}
+
+/// Manages virtual headless outputs.
+pub struct VirtualOutputs {
+    /// Counter for auto-naming outputs (HEADLESS-1, HEADLESS-2, etc.)
+    counter: u32,
+    /// Track outputs by name for removal, storing (Output, OutputId)
+    outputs: HashMap<String, (Output, OutputId)>,
+}
+
+impl VirtualOutputs {
+    pub fn new() -> Self {
+        Self {
+            counter: 0,
+            outputs: HashMap::new(),
+        }
+    }
+
+    /// Create a virtual headless output with the given dimensions.
+    /// Returns the name of the created output (e.g., "HEADLESS-1").
+    pub fn create(
+        &mut self,
+        niri: &mut Niri,
+        ipc_outputs: &Arc<Mutex<IpcOutputMap>>,
+        width: u16,
+        height: u16,
+        refresh_rate: u32,
+    ) -> String {
+        self.counter += 1;
+        let n = self.counter;
+
+        let connector = format!("HEADLESS-{n}");
+        let make = "niri".to_string();
+        let model = "virtual".to_string();
+        let serial = n.to_string();
+
+        let refresh = i32::try_from(refresh_rate * 1000).unwrap_or(60_000);
+
+        let output = Output::new(
+            connector.clone(),
+            PhysicalProperties {
+                size: (0, 0).into(),
+                subpixel: Subpixel::Unknown,
+                make: make.clone(),
+                model: model.clone(),
+                serial_number: serial.clone(),
+            },
+        );
+
+        let mode = Mode {
+            size: Size::from((i32::from(width), i32::from(height))),
+            refresh,
+        };
+        output.change_current_state(Some(mode), None, None, None);
+        output.set_preferred(mode);
+
+        output.user_data().insert_if_missing(|| OutputName {
+            connector: connector.clone(),
+            make: Some(make),
+            model: Some(model),
+            serial: Some(serial),
+        });
+
+        let output_id = OutputId::next();
+        let physical_properties = output.physical_properties();
+        ipc_outputs.lock().unwrap().insert(
+            output_id,
+            niri_ipc::Output {
+                name: output.name(),
+                make: physical_properties.make,
+                model: physical_properties.model,
+                serial: None,
+                physical_size: None,
+                modes: vec![niri_ipc::Mode {
+                    width,
+                    height,
+                    refresh_rate: refresh_rate * 1000,
+                    is_preferred: true,
+                }],
+                current_mode: Some(0),
+                is_custom_mode: true,
+                vrr_supported: false,
+                vrr_enabled: false,
+                logical: Some(logical_output(&output)),
+            },
+        );
+
+        self.outputs
+            .insert(connector.clone(), (output.clone(), output_id));
+
+        let refresh_interval = Duration::from_nanos(1_000_000_000 / u64::from(refresh_rate));
+        niri.add_output(output, Some(refresh_interval), false);
+
+        connector
+    }
+
+    /// Remove a virtual headless output by name.
+    /// Returns Ok(()) if successful, Err with message if not found.
+    pub fn remove(
+        &mut self,
+        niri: &mut Niri,
+        ipc_outputs: &Arc<Mutex<IpcOutputMap>>,
+        name: &str,
+    ) -> Result<(), String> {
+        let (output, output_id) = self
+            .outputs
+            .remove(name)
+            .ok_or_else(|| format!("virtual output '{}' not found", name))?;
+
+        ipc_outputs.lock().unwrap().remove(&output_id);
+        niri.remove_output(&output);
+
+        Ok(())
+    }
+}
+
+impl Default for VirtualOutputs {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -85,6 +85,9 @@ impl VirtualOutputs {
         if refresh_rate == 0 {
             return Err("refresh rate must be greater than 0".into());
         }
+        if refresh_rate > 1000 {
+            return Err("refresh rate must be 1000 Hz or less".into());
+        }
 
         self.counter += 1;
         let n = self.counter;
@@ -94,7 +97,8 @@ impl VirtualOutputs {
         let model = "virtual".to_string();
         let serial = n.to_string();
 
-        let refresh = i32::try_from(refresh_rate * 1000).unwrap_or(60_000);
+        let refresh =
+            i32::try_from(u64::from(refresh_rate).saturating_mul(1000)).unwrap_or(60_000);
 
         let output = Output::new(
             connector.clone(),
@@ -142,7 +146,10 @@ impl VirtualOutputs {
                 modes: vec![niri_ipc::Mode {
                     width,
                     height,
-                    refresh_rate: refresh_rate * 1000,
+                    refresh_rate: u64::from(refresh_rate)
+                        .saturating_mul(1000)
+                        .try_into()
+                        .unwrap_or(60_000),
                     is_preferred: true,
                 }],
                 current_mode: Some(0),

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -1606,8 +1606,9 @@ impl Tty {
             .global_space
             .outputs()
             .find(|output| {
-                let tty_state: &TtyOutputState = output.user_data().get().unwrap();
-                tty_state.node == node && tty_state.crtc == crtc
+                output.user_data()
+                    .get::<TtyOutputState>()
+                    .is_some_and(|tty_state| tty_state.node == node && tty_state.crtc == crtc)
             })
             .cloned();
         if let Some(output) = output {
@@ -1686,8 +1687,9 @@ impl Tty {
             .global_space
             .outputs()
             .find(|output| {
-                let tty_state: &TtyOutputState = output.user_data().get().unwrap();
-                tty_state.node == node && tty_state.crtc == crtc
+                output.user_data()
+                    .get::<TtyOutputState>()
+                    .is_some_and(|tty_state| tty_state.node == node && tty_state.crtc == crtc)
             })
             .cloned()
         else {
@@ -2209,8 +2211,9 @@ impl Tty {
                     .global_space
                     .outputs()
                     .find(|output| {
-                        let tty_state: &TtyOutputState = output.user_data().get().unwrap();
-                        tty_state.node == *node && tty_state.crtc == crtc
+                        output.user_data()
+                            .get::<TtyOutputState>()
+                            .is_some_and(|tty_state| tty_state.node == *node && tty_state.crtc == crtc)
                     })
                     .map(logical_output);
 
@@ -2410,6 +2413,11 @@ impl Tty {
     pub fn set_output_on_demand_vrr(&mut self, niri: &mut Niri, output: &Output, enable_vrr: bool) {
         let _span = tracy_client::span!("Tty::set_output_on_demand_vrr");
 
+        let Some(tty_state) = output.user_data().get::<TtyOutputState>() else {
+            // Virtual outputs don't support VRR.
+            return;
+        };
+
         let output_state = niri.output_state.get_mut(output).unwrap();
         output_state.on_demand_vrr_enabled = enable_vrr;
         if output_state.frame_clock.vrr() == enable_vrr {
@@ -2417,7 +2425,6 @@ impl Tty {
         }
         for (&node, device) in self.devices.iter_mut() {
             for (&crtc, surface) in device.surfaces.iter_mut() {
-                let tty_state: &TtyOutputState = output.user_data().get().unwrap();
                 if tty_state.node == node && tty_state.crtc == crtc {
                     let word = if enable_vrr { "enabling" } else { "disabling" };
                     if let Err(err) = surface.compositor.use_vrr(enable_vrr) {
@@ -2590,8 +2597,9 @@ impl Tty {
                     .global_space
                     .outputs()
                     .find(|output| {
-                        let tty_state: &TtyOutputState = output.user_data().get().unwrap();
-                        tty_state.node == node && tty_state.crtc == crtc
+                        output.user_data()
+                            .get::<TtyOutputState>()
+                            .is_some_and(|tty_state| tty_state.node == node && tty_state.crtc == crtc)
                     })
                     .cloned();
                 let Some(output) = output else {

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -61,8 +61,7 @@ use smithay_drm_extras::drm_scanner::{DrmScanEvent, DrmScanner};
 use wayland_protocols::wp::linux_dmabuf::zv1::server::zwp_linux_dmabuf_feedback_v1::TrancheFlags;
 use wayland_protocols::wp::presentation_time::server::wp_presentation_feedback;
 
-use super::{IpcOutputMap, RenderResult};
-use crate::backend::OutputId;
+use super::{IpcOutputMap, OutputId, RenderResult};
 use crate::frame_clock::FrameClock;
 use crate::niri::{Niri, RedrawState, State};
 use crate::render_helpers::debug::draw_damage;
@@ -100,6 +99,16 @@ pub struct Tty {
     // Whether the debug tinting is enabled.
     debug_tint: bool,
     ipc_outputs: Arc<Mutex<IpcOutputMap>>,
+    // Secondary headless backend for virtual outputs.
+    virtual_outputs: VirtualOutputs,
+}
+
+/// Manages virtual headless outputs alongside the TTY backend.
+struct VirtualOutputs {
+    /// Counter for auto-naming outputs (HEADLESS-1, HEADLESS-2, etc.)
+    counter: u32,
+    /// Track outputs by name for removal, storing (Output, OutputId)
+    outputs: HashMap<String, (Output, OutputId)>,
 }
 
 pub type TtyRenderer<'render> = MultiRenderer<
@@ -506,6 +515,10 @@ impl Tty {
             update_output_config_on_resume: false,
             debug_tint: false,
             ipc_outputs: Arc::new(Mutex::new(HashMap::new())),
+            virtual_outputs: VirtualOutputs {
+                counter: 0,
+                outputs: HashMap::new(),
+            },
         })
     }
 
@@ -1821,7 +1834,15 @@ impl Tty {
         if output_state.unfinished_animations_remain {
             niri.queue_redraw(&output);
         } else {
-            niri.send_frame_callbacks(&output);
+            // Virtual outputs don't have TtyOutputState and need a different
+            // frame callback path since they don't go through GPU rendering
+            // that sets surface_primary_scanout_output.
+            let is_virtual = output.user_data().get::<TtyOutputState>().is_none();
+            if is_virtual {
+                niri.send_frame_callbacks_for_virtual_output(&output);
+            } else {
+                niri.send_frame_callbacks(&output);
+            }
         }
     }
 
@@ -1850,7 +1871,12 @@ impl Tty {
 
         let mut rv = RenderResult::Skipped;
 
-        let tty_state: &TtyOutputState = output.user_data().get().unwrap();
+        // Check if this is a virtual output (no TtyOutputState)
+        let Some(tty_state) = output.user_data().get::<TtyOutputState>() else {
+            // This is a virtual output - handle it like headless
+            return self.render_virtual_output(niri, output, target_presentation_time);
+        };
+        let tty_state: &TtyOutputState = tty_state;
         let Some(device) = self.devices.get_mut(&tty_state.node) else {
             error!("missing output device");
             return rv;
@@ -2219,6 +2245,134 @@ impl Tty {
 
     pub fn ipc_outputs(&self) -> Arc<Mutex<IpcOutputMap>> {
         self.ipc_outputs.clone()
+    }
+
+    /// Render a virtual output (no actual rendering, just presentation feedback).
+    fn render_virtual_output(
+        &mut self,
+        niri: &mut Niri,
+        output: &Output,
+        target_presentation_time: Duration,
+    ) -> RenderResult {
+        use smithay::backend::renderer::element::RenderElementStates;
+        use smithay::wayland::presentation::Refresh;
+
+        let now = get_monotonic_time();
+
+        let states = RenderElementStates::default();
+        let mut presentation_feedbacks = niri.take_presentation_feedbacks(output, &states);
+        presentation_feedbacks.presented::<_, smithay::utils::Monotonic>(
+            now,
+            Refresh::Unknown,
+            0,
+            wp_presentation_feedback::Kind::empty(),
+        );
+
+        // Update the frame clock so animation timing works correctly.
+        let output_state = niri.output_state.get_mut(output).unwrap();
+        output_state.frame_clock.presented(now);
+
+        // Use the estimated vblank timer to pace redraws, just like physical outputs.
+        queue_estimated_vblank_timer(niri, output.clone(), target_presentation_time);
+
+        RenderResult::Submitted
+    }
+
+    /// Create a virtual headless output with the given dimensions.
+    /// Returns the name of the created output (e.g., "HEADLESS-1").
+    pub fn create_virtual_output(
+        &mut self,
+        niri: &mut Niri,
+        width: u16,
+        height: u16,
+        refresh_rate: u32,
+    ) -> String {
+        self.virtual_outputs.counter += 1;
+        let n = self.virtual_outputs.counter;
+
+        let connector = format!("HEADLESS-{n}");
+        let make = "niri".to_string();
+        let model = "virtual".to_string();
+        let serial = n.to_string();
+
+        let refresh = i32::try_from(refresh_rate * 1000).unwrap_or(60_000);
+
+        let output = Output::new(
+            connector.clone(),
+            PhysicalProperties {
+                size: (0, 0).into(),
+                subpixel: smithay::output::Subpixel::Unknown,
+                make: make.clone(),
+                model: model.clone(),
+                serial_number: serial.clone(),
+            },
+        );
+
+        let mode = Mode {
+            size: smithay::utils::Size::from((i32::from(width), i32::from(height))),
+            refresh,
+        };
+        output.change_current_state(Some(mode), None, None, None);
+        output.set_preferred(mode);
+
+        output.user_data().insert_if_missing(|| OutputName {
+            connector: connector.clone(),
+            make: Some(make),
+            model: Some(model),
+            serial: Some(serial),
+        });
+
+        let output_id = OutputId::next();
+        let physical_properties = output.physical_properties();
+        self.ipc_outputs.lock().unwrap().insert(
+            output_id,
+            niri_ipc::Output {
+                name: output.name(),
+                make: physical_properties.make,
+                model: physical_properties.model,
+                serial: None,
+                physical_size: None,
+                modes: vec![niri_ipc::Mode {
+                    width,
+                    height,
+                    refresh_rate: refresh_rate * 1000,
+                    is_preferred: true,
+                }],
+                current_mode: Some(0),
+                is_custom_mode: true,
+                vrr_supported: false,
+                vrr_enabled: false,
+                logical: Some(logical_output(&output)),
+            },
+        );
+
+        // Track the output for potential removal
+        self.virtual_outputs
+            .outputs
+            .insert(connector.clone(), (output.clone(), output_id));
+
+        let refresh_interval = Duration::from_nanos(1_000_000_000 / u64::from(refresh_rate));
+        niri.add_output(output, Some(refresh_interval), false);
+
+        connector
+    }
+
+    /// Remove a virtual headless output by name.
+    /// Returns Ok(()) if successful, Err with message if not found.
+    pub fn remove_virtual_output(&mut self, niri: &mut Niri, name: &str) -> Result<(), String> {
+        let (output, output_id) = self
+            .virtual_outputs
+            .outputs
+            .remove(name)
+            .ok_or_else(|| format!("virtual output '{}' not found", name))?;
+
+        // Remove from IPC outputs
+        self.ipc_outputs.lock().unwrap().remove(&output_id);
+
+        // Remove from niri
+        niri.remove_output(&output);
+
+        Ok(())
     }
 
     #[cfg(feature = "xdp-gnome-screencast")]

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -2229,6 +2229,33 @@ impl Tty {
             }
         }
 
+        // Re-add virtual outputs so they don't disappear on IPC refresh.
+        for (_, (output, output_id)) in &self.virtual_outputs.outputs {
+            let mode = output.current_mode().unwrap();
+            let physical_properties = output.physical_properties();
+            ipc_outputs.insert(
+                *output_id,
+                niri_ipc::Output {
+                    name: output.name(),
+                    make: physical_properties.make,
+                    model: physical_properties.model,
+                    serial: None,
+                    physical_size: None,
+                    modes: vec![niri_ipc::Mode {
+                        width: mode.size.w as u16,
+                        height: mode.size.h as u16,
+                        refresh_rate: mode.refresh as u32,
+                        is_preferred: true,
+                    }],
+                    current_mode: Some(0),
+                    is_custom_mode: true,
+                    vrr_supported: false,
+                    vrr_enabled: false,
+                    logical: Some(logical_output(output)),
+                },
+            );
+        }
+
         let mut guard = self.ipc_outputs.lock().unwrap();
         *guard = ipc_outputs;
         niri.ipc_outputs_changed = true;

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -2275,7 +2275,7 @@ impl Tty {
         width: u16,
         height: u16,
         refresh_rate: u32,
-    ) -> String {
+    ) -> Result<String, String> {
         self.virtual_outputs
             .create(niri, &self.ipc_outputs, width, height, refresh_rate)
     }

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -99,16 +99,7 @@ pub struct Tty {
     // Whether the debug tinting is enabled.
     debug_tint: bool,
     ipc_outputs: Arc<Mutex<IpcOutputMap>>,
-    // Secondary headless backend for virtual outputs.
-    virtual_outputs: VirtualOutputs,
-}
-
-/// Manages virtual headless outputs alongside the TTY backend.
-struct VirtualOutputs {
-    /// Counter for auto-naming outputs (HEADLESS-1, HEADLESS-2, etc.)
-    counter: u32,
-    /// Track outputs by name for removal, storing (Output, OutputId)
-    outputs: HashMap<String, (Output, OutputId)>,
+    virtual_outputs: super::VirtualOutputs,
 }
 
 pub type TtyRenderer<'render> = MultiRenderer<
@@ -515,10 +506,7 @@ impl Tty {
             update_output_config_on_resume: false,
             debug_tint: false,
             ipc_outputs: Arc::new(Mutex::new(HashMap::new())),
-            virtual_outputs: VirtualOutputs {
-                counter: 0,
-                outputs: HashMap::new(),
-            },
+            virtual_outputs: super::VirtualOutputs::new(),
         })
     }
 
@@ -2281,8 +2269,6 @@ impl Tty {
         RenderResult::Submitted
     }
 
-    /// Create a virtual headless output with the given dimensions.
-    /// Returns the name of the created output (e.g., "HEADLESS-1").
     pub fn create_virtual_output(
         &mut self,
         niri: &mut Niri,
@@ -2290,92 +2276,13 @@ impl Tty {
         height: u16,
         refresh_rate: u32,
     ) -> String {
-        self.virtual_outputs.counter += 1;
-        let n = self.virtual_outputs.counter;
-
-        let connector = format!("HEADLESS-{n}");
-        let make = "niri".to_string();
-        let model = "virtual".to_string();
-        let serial = n.to_string();
-
-        let refresh = i32::try_from(refresh_rate * 1000).unwrap_or(60_000);
-
-        let output = Output::new(
-            connector.clone(),
-            PhysicalProperties {
-                size: (0, 0).into(),
-                subpixel: smithay::output::Subpixel::Unknown,
-                make: make.clone(),
-                model: model.clone(),
-                serial_number: serial.clone(),
-            },
-        );
-
-        let mode = Mode {
-            size: smithay::utils::Size::from((i32::from(width), i32::from(height))),
-            refresh,
-        };
-        output.change_current_state(Some(mode), None, None, None);
-        output.set_preferred(mode);
-
-        output.user_data().insert_if_missing(|| OutputName {
-            connector: connector.clone(),
-            make: Some(make),
-            model: Some(model),
-            serial: Some(serial),
-        });
-
-        let output_id = OutputId::next();
-        let physical_properties = output.physical_properties();
-        self.ipc_outputs.lock().unwrap().insert(
-            output_id,
-            niri_ipc::Output {
-                name: output.name(),
-                make: physical_properties.make,
-                model: physical_properties.model,
-                serial: None,
-                physical_size: None,
-                modes: vec![niri_ipc::Mode {
-                    width,
-                    height,
-                    refresh_rate: refresh_rate * 1000,
-                    is_preferred: true,
-                }],
-                current_mode: Some(0),
-                is_custom_mode: true,
-                vrr_supported: false,
-                vrr_enabled: false,
-                logical: Some(logical_output(&output)),
-            },
-        );
-
-        // Track the output for potential removal
         self.virtual_outputs
-            .outputs
-            .insert(connector.clone(), (output.clone(), output_id));
-
-        let refresh_interval = Duration::from_nanos(1_000_000_000 / u64::from(refresh_rate));
-        niri.add_output(output, Some(refresh_interval), false);
-
-        connector
+            .create(niri, &self.ipc_outputs, width, height, refresh_rate)
     }
 
-    /// Remove a virtual headless output by name.
-    /// Returns Ok(()) if successful, Err with message if not found.
     pub fn remove_virtual_output(&mut self, niri: &mut Niri, name: &str) -> Result<(), String> {
-        let (output, output_id) = self
-            .virtual_outputs
-            .outputs
-            .remove(name)
-            .ok_or_else(|| format!("virtual output '{}' not found", name))?;
-
-        // Remove from IPC outputs
-        self.ipc_outputs.lock().unwrap().remove(&output_id);
-
-        // Remove from niri
-        niri.remove_output(&output);
-
-        Ok(())
+        self.virtual_outputs
+            .remove(niri, &self.ipc_outputs, name)
     }
 
     #[cfg(feature = "xdp-gnome-screencast")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,8 +101,7 @@ pub enum Msg {
     },
     /// Create a virtual headless output.
     ///
-    /// This only works when niri is running with the headless backend
-    /// (e.g. with `NIRI_BACKEND=headless`).
+    /// This works with both the headless and the TTY backend.
     CreateVirtualOutput {
         /// Width in pixels.
         #[arg(long, default_value = "1920")]
@@ -116,7 +115,7 @@ pub enum Msg {
     },
     /// Remove a virtual headless output.
     ///
-    /// This only works when niri is running with the headless backend.
+    /// This works with both the headless and the TTY backend.
     RemoveVirtualOutput {
         /// Name of the output to remove (e.g. "HEADLESS-1").
         #[arg()]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,6 +99,29 @@ pub enum Msg {
         #[command(subcommand)]
         action: OutputAction,
     },
+    /// Create a virtual headless output.
+    ///
+    /// This only works when niri is running with the headless backend
+    /// (e.g. with `NIRI_BACKEND=headless`).
+    CreateVirtualOutput {
+        /// Width in pixels.
+        #[arg(long, default_value = "1920")]
+        width: u16,
+        /// Height in pixels.
+        #[arg(long, default_value = "1080")]
+        height: u16,
+        /// Refresh rate in Hz.
+        #[arg(long, default_value = "60")]
+        refresh_rate: u32,
+    },
+    /// Remove a virtual headless output.
+    ///
+    /// This only works when niri is running with the headless backend.
+    RemoveVirtualOutput {
+        /// Name of the output to remove (e.g. "HEADLESS-1").
+        #[arg()]
+        name: String,
+    },
     /// Start continuously receiving events from the compositor.
     EventStream,
     /// Print the version of the running niri instance.

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -41,6 +41,16 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
             output: output.clone(),
             action: action.clone(),
         },
+        Msg::CreateVirtualOutput {
+            width,
+            height,
+            refresh_rate,
+        } => Request::CreateVirtualOutput {
+            width: Some(*width),
+            height: Some(*height),
+            refresh_rate: Some(*refresh_rate),
+        },
+        Msg::RemoveVirtualOutput { name } => Request::RemoveVirtualOutput { name: name.clone() },
         Msg::Workspaces => Request::Workspaces,
         Msg::Windows => Request::Windows,
         Msg::Layers => Request::Layers,
@@ -549,6 +559,31 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                 print_cast(&cast);
                 println!();
             }
+        }
+        Msg::CreateVirtualOutput { .. } => {
+            let Response::VirtualOutputCreated(name) = response else {
+                bail!("unexpected response: expected VirtualOutputCreated, got {response:?}");
+            };
+
+            if json {
+                let response = json!({ "name": name });
+                println!("{response}");
+                return Ok(());
+            }
+
+            println!("Created virtual output: {name}");
+        }
+        Msg::RemoveVirtualOutput { name } => {
+            let Response::Handled = response else {
+                bail!("unexpected response: expected Handled, got {response:?}");
+            };
+
+            if json {
+                println!("{{}}");
+                return Ok(());
+            }
+
+            println!("Removed virtual output: {name}");
         }
     }
 

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -455,6 +455,50 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let casts = state.casts.casts.values().cloned().collect();
             Response::Casts(casts)
         }
+        Request::CreateVirtualOutput {
+            width,
+            height,
+            refresh_rate,
+        } => {
+            let width = width.unwrap_or(1920);
+            let height = height.unwrap_or(1080);
+            let refresh_rate = refresh_rate.unwrap_or(60);
+            let (tx, rx) = async_channel::bounded(1);
+
+            ctx.event_loop.insert_idle(move |state| {
+                let result = state.backend.create_virtual_output(
+                    &mut state.niri,
+                    width,
+                    height,
+                    refresh_rate,
+                );
+                let _ = tx.send_blocking(result);
+            });
+
+            let result = rx
+                .recv()
+                .await
+                .map_err(|_| String::from("error creating virtual output"))?;
+            match result {
+                Ok(name) => Response::VirtualOutputCreated(name),
+                Err(e) => return Err(e),
+            }
+        }
+        Request::RemoveVirtualOutput { name } => {
+            let (tx, rx) = async_channel::bounded(1);
+
+            ctx.event_loop.insert_idle(move |state| {
+                let result = state.backend.remove_virtual_output(&mut state.niri, &name);
+                let _ = tx.send_blocking(result);
+            });
+
+            let result = rx
+                .recv()
+                .await
+                .map_err(|_| String::from("error removing virtual output"))?;
+            result?;
+            Response::Handled
+        }
     };
 
     Ok(response)

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Handle Ctrl+C and other signals.
     niri::utils::signals::listen(&event_loop.handle());
 
+    // Check if we should use the headless backend.
+    let headless = env::var("NIRI_BACKEND")
+        .map(|v| v.eq_ignore_ascii_case("headless"))
+        .unwrap_or(false);
+
+    if headless {
+        info!("starting in headless mode (NIRI_BACKEND=headless)");
+    }
+
     // Create the compositor.
     let display = Display::new().unwrap();
 
@@ -179,7 +188,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         event_loop.handle(),
         event_loop.get_signal(),
         display,
-        false,
+        headless,
         true,
         cli.session,
     )

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -743,7 +743,9 @@ impl State {
 
         if headless && create_wayland_socket {
             if let Backend::Headless(headless) = &mut state.backend {
-                headless.create_virtual_output(&mut state.niri, 1920, 1080, 60);
+                headless
+                    .create_virtual_output(&mut state.niri, 1920, 1080, 60)
+                    .unwrap();
             }
         }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -5102,6 +5102,44 @@ impl Niri {
         }
     }
 
+    /// Send frame callbacks for a virtual output.
+    ///
+    /// Unlike `send_frame_callbacks`, this does not check `surface_primary_scanout_output`
+    /// because virtual outputs don't go through the GPU rendering pipeline that sets it.
+    pub fn send_frame_callbacks_for_virtual_output(&mut self, output: &Output) {
+        let _span = tracy_client::span!("Niri::send_frame_callbacks_for_virtual_output");
+
+        let frame_callback_time = get_monotonic_time();
+
+        for mapped in self.layout.windows_for_output_mut(output) {
+            mapped.send_frame(
+                output,
+                frame_callback_time,
+                FRAME_CALLBACK_THROTTLE,
+                |_, _| Some(output.clone()),
+            );
+        }
+
+        for surface in layer_map_for_output(output).layers() {
+            surface.send_frame(
+                output,
+                frame_callback_time,
+                FRAME_CALLBACK_THROTTLE,
+                |_, _| Some(output.clone()),
+            );
+        }
+
+        if let Some(surface) = &self.output_state[output].lock_surface {
+            send_frames_surface_tree(
+                surface.wl_surface(),
+                output,
+                frame_callback_time,
+                FRAME_CALLBACK_THROTTLE,
+                |_, _| Some(output.clone()),
+            );
+        }
+    }
+
     pub fn send_frame_callbacks_on_fallback_timer(&mut self) {
         let _span = tracy_client::span!("Niri::send_frame_callbacks_on_fallback_timer");
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -743,6 +743,9 @@ impl State {
 
         if headless && create_wayland_socket {
             if let Backend::Headless(headless) = &mut state.backend {
+                if let Err(err) = headless.add_renderer() {
+                    warn!("failed to initialize headless renderer: {err:?}");
+                }
                 headless
                     .create_virtual_output(&mut state.niri, 1920, 1080, 60)
                     .unwrap();

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -741,6 +741,12 @@ impl State {
 
         let mut state = Self { backend, niri };
 
+        if headless && create_wayland_socket {
+            if let Backend::Headless(headless) = &mut state.backend {
+                headless.create_virtual_output(&mut state.niri, 1920, 1080, 60);
+            }
+        }
+
         // Load the xkb_file config option if set by the user.
         state.load_xkb_file();
         // Initialize some IPC server state.
@@ -5132,6 +5138,26 @@ impl Niri {
         if let Some(surface) = &self.output_state[output].lock_surface {
             send_frames_surface_tree(
                 surface.wl_surface(),
+                output,
+                frame_callback_time,
+                FRAME_CALLBACK_THROTTLE,
+                |_, _| Some(output.clone()),
+            );
+        }
+
+        if let Some(surface) = self.dnd_icon.as_ref().map(|icon| &icon.surface) {
+            send_frames_surface_tree(
+                surface,
+                output,
+                frame_callback_time,
+                FRAME_CALLBACK_THROTTLE,
+                |_, _| Some(output.clone()),
+            );
+        }
+
+        if let CursorImageStatus::Surface(surface) = self.cursor_manager.cursor_image() {
+            send_frames_surface_tree(
+                surface,
                 output,
                 frame_callback_time,
                 FRAME_CALLBACK_THROTTLE,


### PR DESCRIPTION
Closes #714

Based on [QaidVoid's `feat/virtual` branch](https://github.com/QaidVoid/niri/tree/feat/virtual), with fixes and cleanups applied on top.

### What this does

Adds dynamic virtual headless outputs to niri, usable for VNC (wayvnc), Sunshine/Moonlight, and remote desktop without physical displays.

Two modes:
- **Pure headless**: `NIRI_BACKEND=headless niri` — auto-creates a default `HEADLESS-1`
- **TTY hybrid**: `niri msg create-virtual-output --width 1920 --height 1080` while running normally

New IPC commands: `CreateVirtualOutput`, `RemoveVirtualOutput`.

### Changes on top of QaidVoid's branch

1. **Fix TTY backend panics** — virtual outputs don't have `TtyOutputState`; every `find()` over outputs that unwrapped it would panic. Fixed 5 locations (connector disconnect, vblank, IPC refresh, VRR toggle, resume).
2. **Fix test breakage** — `Headless::init()` auto-created `HEADLESS-1`, breaking tests that expected `headless-1` at index 0. Moved auto-creation to `State::new()` only for real sessions.
3. **Add missing frame callbacks** — DND icon and cursor surfaces now get frame callbacks on virtual outputs.
4. **Fix CLI docs** — corrected help text that falsely claimed headless-only support (TTY backend works too).
5. **Deduplicate virtual output code** — extracted shared `VirtualOutputs` struct into `backend/mod.rs`, removing ~90 lines of duplication between `Headless` and `Tty`.
6. **Implement headless dmabuf import** — `Headless::import_dmabuf()` was `unimplemented!()`; now uses the existing `GlesRenderer`, enabling PipeWire/screencast in pure headless mode.

### Testing

- `cargo check` passes
- All relevant tests pass (remove_output, window_opening, floating, layer_shell, transactions)
