### PR TITLE
Add SwitchWorkspace action to change workspace without focusing…

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -223,6 +223,7 @@ pub enum Action {
     #[knuffel(skip)]
     FocusWorkspaceUpUnderMouse,
     FocusWorkspace(#[knuffel(argument)] WorkspaceReference),
+    SwitchWorkspace(#[knuffel(argument)] WorkspaceReference),
     FocusWorkspacePrevious,
     MoveWindowToWorkspaceDown(#[knuffel(property(name = "focus"), default = true)] bool),
     MoveWindowToWorkspaceUp(#[knuffel(property(name = "focus"), default = true)] bool),
@@ -511,6 +512,9 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::FocusWorkspaceUp {} => Self::FocusWorkspaceUp,
             niri_ipc::Action::FocusWorkspace { reference } => {
                 Self::FocusWorkspace(WorkspaceReference::from(reference))
+            }
+            niri_ipc::Action::SwitchWorkspace { reference } => {
+                Self::SwitchWorkspace(WorkspaceReference::from(reference))
             }
             niri_ipc::Action::FocusWorkspacePrevious {} => Self::FocusWorkspacePrevious,
             niri_ipc::Action::MoveWindowToWorkspaceDown { focus } => {

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -480,6 +480,12 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg())]
         reference: WorkspaceReferenceArg,
     },
+    /// Switch to a workspace on its monitor without changing the focused monitor.
+    SwitchWorkspace {
+        /// Reference (index or name) of the workspace to switch to.
+        #[cfg_attr(feature = "clap", arg())]
+        reference: WorkspaceReferenceArg,
+    },
     /// Focus the previous workspace.
     FocusWorkspacePrevious {},
     /// Move the focused window to the workspace below.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1513,6 +1513,16 @@ impl State {
                     self.niri.queue_redraw_all();
                 }
             }
+            Action::SwitchWorkspace(reference) => {
+                if let Some((Some(output), index)) =
+                    self.niri.find_output_and_workspace_index(reference)
+                {
+                    self.niri.layout.switch_workspace_on_output(&output, index);
+                    self.maybe_warp_cursor_to_focus();
+                    self.niri.layer_shell_on_demand_focus = None;
+                    self.niri.queue_redraw(&output);
+                }
+            }
             Action::FocusWorkspacePrevious => {
                 self.niri.layout.switch_workspace_previous();
                 self.maybe_warp_cursor_to_focus();

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2204,6 +2204,13 @@ impl<W: LayoutElement> Layout<W> {
         monitor.switch_workspace_previous();
     }
 
+    pub fn switch_workspace_on_output(&mut self, output: &Output, idx: usize) {
+        let Some(monitor) = self.monitor_for_output_mut(output) else {
+            return;
+        };
+        monitor.switch_workspace(idx);
+    }
+
     pub fn consume_into_column(&mut self) {
         let Some(workspace) = self.active_workspace_mut() else {
             return;


### PR DESCRIPTION
## Summary

This PR introduces a new `SwitchWorkspace` action that switches to a workspace on its monitor **without** changing the currently focused monitor. This differs from the existing `FocusWorkspace` action, which moves keyboard focus to the target workspace's monitor.

## Motivation

The current `FocusWorkspace` action is useful when you want to immediately start working on another workspace. However, there are valid workflows where you want to change a workspace on another monitor while keeping your current focus position:

- **Multi-monitor workflow with parallel tasks**: On the primary work monitor, users often run multiple parallel tasks across different workspaces, each requiring auxiliary content from other workspaces on secondary displays. For example:
  - Workspace 1 (coding) + Reference documentation on Monitor 2
  - Workspace 2 (debugging) + Logs on Monitor 2
  - Workspace 3 (code review) + CI status on Monitor 2

  With `SwitchWorkspace`, the secondary monitor can automatically follow the primary monitor's workspace changes, keeping relevant auxiliary content in sync without requiring the user to manually switch and refocus.
- **Preparing a workspace on another monitor** for an upcoming window move, such as organizing windows before a presentation or screen sharing session.
- **Previewing content** on another monitor without interrupting current work, allowing quick glances at reference material or monitoring dashboards.
- **Setting up workspaces** across multiple monitors before starting a complex task that requires specific window arrangements.

## Usage

Via IPC socket:

```bash
# Connect to niri socket and send SwitchWorkspace action
socat STDIO "$NIRI_SOCKET"
{"Action":{"SwitchWorkspace":{"reference":{"Id":2}}}}
```

Via Rust:

```rust
let mut socket = Socket::connect()?;
socket.send(Request::Action(Action::SwitchWorkspace {
    reference: WorkspaceReferenceArg::Id(2),
}));
```

## Develop Details

Implementation Details

- niri-ipc: Added SwitchWorkspace variant to the Action enum with WorkspaceReferenceArg parameter
- niri-config: Added SwitchWorkspace action variant and IPC conversion logic
- src/input: Added handler in process_action that finds the output and workspace index, then delegates to the layout
- src/layout: Added switch_workspace_on_output method that switches workspace on a specific output without changing focus

Testing

- Compiled successfully with cargo build --release
- Tested locally on my machine - runs well without any issues
- Ran cargo clippy --all --all-targets - no warnings
- Follows existing code patterns and conventions
- Adds 30 lines across 4 files with focused, minimal changes

Backward Compatibility

This change is fully backward compatible. It adds a new optional action without modifying any existing behavior.

## Scenarios

I use a three-monitor setup. The allocation of tasks across the screens (from left to right) varies depending on my primary focus. Here’s how I typically organize them in different scenarios:

| Scenario / Work Mode | Left Monitor | Center Monitor | Right Monitor |
| --- | --- | --- | --- |
|Development Workflow | Terminals (Debugging, Git, build tools) | Primary Editor/IDE (Active coding) | Documentation & Reference (API docs, specs) |
|Operations & Admin | Monitoring Terminals (Logs, system dashboards) | Configuration Editor (Scripts, config files) | Procedural Documentation (Runbooks, wikis) |
|Learning & Research | Nothing | Note-taking (Ideas, summaries) | Primary Content (eBooks, papers, course videos) |

This dynamic arrangement allows me to optimize screen real estate for the specific task at hand, maintaining an efficient and focused workflow across different activities.

## Related Info

- Related to the discussion in #3351 about workspace switching behavior.
- It’s a new version of the closed #3356 PR. I’ve changed the branch used for the PR.