### PR TITLE
Add disable-pointer-movement option for touchpads

### DIFF
--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -252,6 +252,7 @@ Settings specific to `touchpad`s:
 - `tap-button-map`: can be `left-right-middle` or `left-middle-right`, controls which button corresponds to a two-finger tap and a three-finger tap.
 - `click-method`: can be `button-areas` or `clickfinger`, changes the [click method](https://wayland.freedesktop.org/libinput/doc/latest/clickpad-softbuttons.html).
 - `disabled-on-external-mouse`: do not send events while external pointer device is plugged in.
+- `disable-pointer-movement`: <sup>Since: next release</sup> when enabled, the touchpad will not move the pointer. Scrolling and gestures still work.
 
 Settings specific to `touchpad` and `mouse`:
 

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -221,6 +221,8 @@ pub struct Touchpad {
     pub middle_emulation: bool,
     #[knuffel(child)]
     pub scroll_factor: Option<ScrollFactor>,
+    #[knuffel(child)]
+    pub disable_pointer_movement: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Default, Clone, PartialEq)]

--- a/src/input/backend_ext.rs
+++ b/src/input/backend_ext.rs
@@ -21,12 +21,18 @@ pub trait NiriInputDevice: input::Device {
     // but it's not clear that this matters in practice?
     // it might be more obvious once we implement it for libinput
     fn output(&self, state: &State) -> Option<Output>;
+    fn is_touchpad(&self) -> bool {
+        false
+    }
 }
 
 impl NiriInputDevice for libinput::Device {
     fn output(&self, _state: &State) -> Option<Output> {
         // FIXME: Allow specifying the output per-device?
         None
+    }
+    fn is_touchpad(&self) -> bool {
+        self.config_tap_finger_count() > 0
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2434,6 +2434,13 @@ impl State {
         self.niri.pointer_visibility = PointerVisibility::Visible;
         self.niri.tablet_cursor_location = None;
 
+        if event.device().is_touchpad()
+            && self.niri.config.borrow().input.touchpad.disable_pointer_movement
+        {
+            pointer.frame(self);
+            return;
+        }
+
         // Check if we have an active pointer constraint.
         //
         // FIXME: ideally this should use the pointer focus with up-to-date global location.


### PR DESCRIPTION
When enabled, the touchpad will not move the pointer, but scrolling and gestures still work.

Can be used by people with trackpoint + touchpad configurations where they want to use the touchpad just for gestures/multitouch/scrolling but not for actual mouse movements.

Feel free to edit or discard this PR completely if you don't think it makes sense for niri to support such a niche scenario!

Disclosure: this PR was implemented with the help of LLMs, I gave it a thorough review to the best of my Rust abilities, on top of testing it on my laptop.