### PR TITLE
Prevent leaving an orphaned shell process when using niri-session

### DIFF
--- a/resources/niri-session
+++ b/resources/niri-session
@@ -15,7 +15,7 @@ if [ -n "$SHELL" ] &&
    ! (echo "$SHELL" | grep -q "false") &&
    ! (echo "$SHELL" | grep -q "nologin"); then
   if [ "$1" != '-l' ]; then
-    exec bash -c "exec -l '$SHELL' -c '$0 -l $*'"
+    exec bash -c "exec -l '$SHELL' -c 'exec $0 -l $*'"
   else
     shift
   fi


### PR DESCRIPTION
I noticed that when running niri-session, in the last step of the execution process, an `exec` was omitted and as a result niri runs as a child process of a shell, without there being any reason for it as far as I'm aware. This PR helps save about 8 MB of RAM on my system, which I'm sure is very useful for everyone! (/s)