### PR TITLE
Add wp_pointer_warp_v1 protocol support

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -21,6 +21,7 @@ use smithay::output::Output;
 use smithay::reexports::rustix::fs::{fcntl_setfl, OFlags};
 use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1;
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
+use smithay::reexports::wayland_server::protocol::wl_pointer::WlPointer;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::Resource;
 use smithay::utils::{Logical, Point, Rectangle, Serial};
@@ -37,7 +38,10 @@ use smithay::wayland::keyboard_shortcuts_inhibit::{
     KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
 };
 use smithay::wayland::output::OutputHandler;
-use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraintsHandler};
+use smithay::wayland::pointer_constraints::{
+    with_pointer_constraint, PointerConstraint, PointerConstraintsHandler,
+};
+use smithay::wayland::pointer_warp::PointerWarpHandler;
 use smithay::wayland::security_context::{
     SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
 };
@@ -89,7 +93,9 @@ use crate::protocols::virtual_pointer::{
     VirtualPointerInputBackend, VirtualPointerManagerState, VirtualPointerMotionAbsoluteEvent,
     VirtualPointerMotionEvent,
 };
-use crate::utils::{output_size, send_scale_transform};
+use crate::utils::{
+    get_surface_size, get_surface_toplevel_coords, output_size, send_scale_transform,
+};
 use crate::{
     delegate_ext_workspace, delegate_foreign_toplevel, delegate_gamma_control,
     delegate_mutter_x11_interop, delegate_output_management, delegate_screencopy,
@@ -218,6 +224,101 @@ impl PointerConstraintsHandler for State {
     }
 }
 delegate_pointer_constraints!(State);
+
+impl PointerWarpHandler for State {
+    fn warp_pointer(
+        &mut self,
+        surface: WlSurface,
+        _pointer: WlPointer,
+        pos: Point<f64, Logical>,
+        serial: Serial,
+    ) {
+        let Some(seat_pointer) = &self.niri.seat.get_pointer() else {
+            return;
+        };
+
+        let Some(last_serial) = seat_pointer.last_enter() else {
+            return;
+        };
+
+        if serial != last_serial {
+            return;
+        }
+
+        let surface_size = get_surface_size(&surface).to_f64();
+        if pos.x < 0. || pos.y < 0. || pos.x > surface_size.w || pos.y > surface_size.h {
+            return;
+        }
+
+        // Check the warp against an active pointer constraint. Constraints live on the
+        // pointer's focus surface, which may legitimately differ from the warp target
+        // (the enter serial is valid for any surface of the client).
+        let mut allow = true;
+        if let Some((focus_surface, origin)) = self.niri.pointer_contents.surface.clone() {
+            let pos_within_focus = seat_pointer.current_location() - origin;
+            with_pointer_constraint(&focus_surface, seat_pointer, |constraint| {
+                let Some(constraint) = constraint else { return };
+                if !constraint.is_active() {
+                    return;
+                }
+
+                // Constraint does not apply if the pointer is not within region.
+                if let Some(region) = constraint.region() {
+                    if !region.contains(pos_within_focus.to_i32_round()) {
+                        return;
+                    }
+                }
+
+                match &*constraint {
+                    // Deliberately honor warps while locked. The spec leaves this
+                    // implementation-defined, and the client holding the lock is the one
+                    // requesting the warp.
+                    PointerConstraint::Locked(_) => (),
+                    // A confined pointer must stay within the confine region.
+                    PointerConstraint::Confined(confine) => {
+                        if focus_surface != surface {
+                            allow = false;
+                        } else if let Some(region) = confine.region() {
+                            allow = region.contains(pos.to_i32_round());
+                        }
+                    }
+                }
+            });
+        }
+        if !allow {
+            return;
+        }
+
+        let Some((mapped, output)) = self.niri.layout.find_window_and_output(&surface) else {
+            return;
+        };
+
+        let Some(output) = output else {
+            return;
+        };
+
+        let Some(output_geo) = self.niri.global_space.output_geometry(output) else {
+            return;
+        };
+
+        let Some(monitor) = self.niri.layout.monitor_for_output(output) else {
+            return;
+        };
+
+        let Some(rect) = monitor.window_visual_rectangle(&mapped.window) else {
+            return;
+        };
+
+        let mut coords = pos;
+        coords += rect.loc;
+        coords += get_surface_toplevel_coords(&surface).to_f64();
+        coords += output_geo.loc.to_f64();
+
+        self.move_cursor(coords);
+    }
+}
+
+smithay::delegate_pointer_warp!(State);
 
 impl InputMethodHandler for State {
     fn new_popup(&mut self, surface: PopupSurface) {

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -358,6 +358,22 @@ impl<W: LayoutElement> FloatingSpace<W> {
         self.working_area.intersection(window_rect)
     }
 
+    /// Returns the geometry of the window matching id relative to and clamped to the working area.
+    ///
+    /// During animations, assumes the final tile position.
+    pub fn window_visual_rectangle(&self, id: &W::Id) -> Option<Rectangle<f64, Logical>> {
+        for (tile, pos) in self.tiles_with_offsets() {
+            if tile.window().id() == id {
+                let window_pos = pos + tile.window_loc();
+                let window_size = tile.window_size();
+                let window_rect = Rectangle::new(window_pos, window_size);
+                return self.working_area.intersection(window_rect);
+            }
+        }
+
+        None
+    }
+
     pub fn popup_target_rect(&self, id: &W::Id) -> Option<Rectangle<f64, Logical>> {
         for (tile, pos) in self.tiles_with_offsets() {
             if tile.window().id() == id {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -1353,6 +1353,19 @@ impl<W: LayoutElement> Monitor<W> {
         self.active_workspace_ref().active_window_visual_rectangle()
     }
 
+    /// Returns the geometry of the window matching id relative to and clamped to the view.
+    ///
+    /// During animations, assumes the final view position.
+    pub fn window_visual_rectangle(&self, id: &W::Id) -> Option<Rectangle<f64, Logical>> {
+        if self.overview_open {
+            return None;
+        }
+
+        self.workspaces
+            .iter()
+            .find_map(|ws| ws.window_visual_rectangle(id))
+    }
+
     fn workspace_size(&self, zoom: f64) -> Size<f64, Logical> {
         let ws_size = self.view_size.upscale(zoom);
         let scale = self.scale.fractional_scale();

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2559,6 +2559,29 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         view.intersection(window_rect)
     }
 
+    /// Returns the geometry of the window matching id relative to and clamped to the view.
+    ///
+    /// During animations, assumes the final view position.
+    pub fn window_visual_rectangle(&self, id: &W::Id) -> Option<Rectangle<f64, Logical>> {
+        let final_view_offset = self.view_offset.target();
+        let view_off = Point::from((-final_view_offset, 0.));
+
+        for col in &self.columns {
+            for (tile, pos) in col.tiles() {
+                if tile.window().id() == id {
+                    let window_pos = view_off + pos + tile.window_loc();
+                    let window_size = tile.window_size();
+                    let window_rect = Rectangle::new(window_pos, window_size);
+
+                    let view = Rectangle::from_size(self.view_size);
+                    return view.intersection(window_rect);
+                }
+            }
+        }
+
+        None
+    }
+
     pub fn popup_target_rect(&self, id: &W::Id) -> Option<Rectangle<f64, Logical>> {
         for col in &self.columns {
             for (tile, pos) in col.tiles() {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1617,6 +1617,14 @@ impl<W: LayoutElement> Workspace<W> {
         }
     }
 
+    pub fn window_visual_rectangle(&self, window: &W::Id) -> Option<Rectangle<f64, Logical>> {
+        if self.floating.has_window(window) {
+            self.floating.window_visual_rectangle(window)
+        } else {
+            self.scrolling.window_visual_rectangle(window)
+        }
+    }
+
     pub fn popup_target_rect(&self, window: &W::Id) -> Option<Rectangle<f64, Logical>> {
         if self.floating.has_window(window) {
             self.floating.popup_target_rect(window)

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -89,6 +89,7 @@ use smithay::wayland::keyboard_shortcuts_inhibit::{
 use smithay::wayland::output::OutputManagerState;
 use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraintsState};
 use smithay::wayland::pointer_gestures::PointerGesturesState;
+use smithay::wayland::pointer_warp::PointerWarpManager;
 use smithay::wayland::presentation::PresentationState;
 use smithay::wayland::relative_pointer::RelativePointerManagerState;
 use smithay::wayland::security_context::SecurityContextState;
@@ -299,6 +300,7 @@ pub struct Niri {
     pub pointer_gestures_state: PointerGesturesState,
     pub relative_pointer_state: RelativePointerManagerState,
     pub pointer_constraints_state: PointerConstraintsState,
+    pub pointer_warp_manager: PointerWarpManager,
     pub idle_notifier_state: IdleNotifierState<State>,
     pub idle_inhibit_manager_state: IdleInhibitManagerState,
     pub data_device_state: DataDeviceState,
@@ -2309,6 +2311,7 @@ impl Niri {
         let pointer_gestures_state = PointerGesturesState::new::<State>(&display_handle);
         let relative_pointer_state = RelativePointerManagerState::new::<State>(&display_handle);
         let pointer_constraints_state = PointerConstraintsState::new::<State>(&display_handle);
+        let pointer_warp_manager = PointerWarpManager::new::<State>(&display_handle);
         let idle_notifier_state = IdleNotifierState::new(&display_handle, event_loop.clone());
         let idle_inhibit_manager_state = IdleInhibitManagerState::new::<State>(&display_handle);
         let data_device_state = DataDeviceState::new::<State>(&display_handle);
@@ -2554,6 +2557,7 @@ impl Niri {
             pointer_gestures_state,
             relative_pointer_state,
             pointer_constraints_state,
+            pointer_warp_manager,
             idle_notifier_state,
             idle_inhibit_manager_state,
             data_device_state,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -25,7 +25,9 @@ use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::{Client, DisplayHandle, Resource as _};
 use smithay::utils::{Coordinate, Logical, Point, Rectangle, Size, Transform};
-use smithay::wayland::compositor::{send_surface_state, with_states, SurfaceData};
+use smithay::wayland::compositor::{
+    get_parent, send_surface_state, with_states, SubsurfaceCachedState, SurfaceData,
+};
 use smithay::wayland::fractional_scale::with_fractional_scale;
 use smithay::wayland::shell::xdg::{
     ToplevelCachedState, ToplevelConfigure, ToplevelState, ToplevelSurface, XdgToplevelSurfaceData,
@@ -590,6 +592,37 @@ pub fn show_screenshot_notification(image_path: Option<&Path>) -> anyhow::Result
     )?;
 
     Ok(())
+}
+
+/// Computes this surface's location relative to its toplevel wl_surface's geometry.
+///
+/// This function will go up the parent stack and add up the relative locations. Useful for
+/// transitive subsurfaces.
+pub fn get_surface_toplevel_coords(surface: &WlSurface) -> Point<i32, Logical> {
+    let mut offset = (0, 0).into();
+    let mut current = surface.clone();
+    while let Some(parent) = get_parent(&current) {
+        offset += with_states(&current, |states| {
+            states
+                .cached_state
+                .get::<SubsurfaceCachedState>()
+                .current()
+                .location
+        });
+        current = parent;
+    }
+
+    offset
+}
+
+pub fn get_surface_size(surface: &WlSurface) -> Size<i32, Logical> {
+    with_states(surface, |states| {
+        states
+            .data_map
+            .get::<RendererSurfaceStateUserData>()
+            .and_then(|d| d.lock().unwrap().surface_size())
+            .unwrap_or_default()
+    })
 }
 
 #[inline(never)]


### PR DESCRIPTION
Closes #3988.

Adds support for the `wp_pointer_warp_v1` staging protocol (wayland-protocols 1.45).
Niri's pinned Smithay already includes the server-side handler from
[Smithay#1757](https://github.com/Smithay/smithay/pull/1757); this PR is the compositor
wiring + validation policy + the niri-side helpers.

## Validation policy

Implements the protocol's three "should" rules with **lenient (KWin-style)** semantics:
focus + bounds, no `button_count > 0` requirement. The protocol says "honor it if the
surface has pointer focus, *including* when it has an implicit pointer grab" — "including"
reads as "focus is sufficient; implicit grab is one valid case", not as a requirement.
Most legitimate `SetCursorPos`-class callers (Wine apps, mouselook recentering,
drag-completion, menu navigation) happen outside a button-down, so the strict reading
rejects most of them.

## Reference implementations

(Per @YaLTeR's request in #3988.)

- **KWin** ([commit](https://invent.kde.org/plasma/kwin/-/commit/c8e3f6ca32), Sept 2024).
  Validation in [`src/pointer_input.cpp:152-164`](https://invent.kde.org/plasma/kwin/-/blob/master/src/pointer_input.cpp#L152) — focus + bounds, no grab requirement. Lenient.
- **Mutter** ([commit](https://gitlab.gnome.org/GNOME/mutter/-/commit/96d4e7c3ce), July 2025).
  Validation in [`meta_wayland_pointer_can_warp`](https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/wayland/meta-wayland-pointer.c) — adds `button_count > 0`. Strict.

## Implementation overview

- Two free helpers in `src/utils/mod.rs`:
  - `get_surface_toplevel_coords` — walks the subsurface chain accumulating offsets via
    `SubsurfaceCachedState.location`. Parallel to Smithay's existing `get_popup_toplevel_coords`
    (which handles xdg_popup chains).
  - `get_surface_size` — reads `RendererSurfaceState::surface_size()`.
- `impl PointerWarpHandler for State` in `src/handlers/mod.rs`: serial check via
  `pointer.last_enter()`, surface-local bounds check, `find_window_and_output` →
  window-rect → output-global four-term composition, `self.move_cursor(target)`.
- New per-window `window_visual_rectangle(id) -> Option<Rectangle<f64, Logical>>` at all
  four layout layers (floating/scrolling/workspace/monitor), parallel to the existing
  `active_window_visual_rectangle`. Dispatches monitor → workspace → (floating | scrolling).
- Field + init + delegate macro for `PointerWarpManager` in `src/niri.rs` and
  `src/handlers/mod.rs`.

## Testing

Verified end-to-end with [Wine MR !10830](https://gitlab.winehq.org/wine/wine/-/merge_requests/10830)
— the matching client-side `winewayland.drv` patch.

- `SetCursorPos` called 12 times by a test program (3 laps × 4 corners of a square).
- Niri side: registry binds the global; every warp validated and honored; cursor lands on
  each target.
- Wine side: every `GetCursorPos` returns the requested position — full roundtrip works.

Tested both nested (winit backend) and as a real session.