### PR TITLE
add only-focus-on-click option

### DIFF
--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -20,6 +20,7 @@ pub struct Input {
     pub disable_power_key_handling: bool,
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
+    pub only_focus_on_click: bool,
     pub workspace_auto_back_and_forth: bool,
     pub mod_key: Option<ModKey>,
     pub mod_key_nested: Option<ModKey>,
@@ -48,6 +49,8 @@ pub struct InputPart {
     #[knuffel(child)]
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
     #[knuffel(child)]
+    pub only_focus_on_click: Option<Flag>,
+    #[knuffel(child)]
     pub workspace_auto_back_and_forth: Option<Flag>,
     #[knuffel(child, unwrap(argument, str))]
     pub mod_key: Option<ModKey>,
@@ -61,6 +64,7 @@ impl MergeWith<InputPart> for Input {
             (self, part),
             keyboard,
             disable_power_key_handling,
+            only_focus_on_click,
             workspace_auto_back_and_forth,
         );
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -733,6 +733,7 @@ mod tests {
 
                 warp-mouse-to-focus
                 focus-follows-mouse
+                only-focus-on-click
                 workspace-auto-back-and-forth
 
                 mod-key "Mod5"
@@ -857,7 +858,7 @@ mod tests {
                 window-open { off; }
 
                 window-close {
-                    curve "cubic-bezier" 0.05 0.7 0.1 1  
+                    curve "cubic-bezier" 0.05 0.7 0.1 1
                 }
 
                 recent-windows-close {
@@ -1135,6 +1136,7 @@ mod tests {
                         max_scroll_amount: None,
                     },
                 ),
+                only_focus_on_click: true,
                 workspace_auto_back_and_forth: true,
                 mod_key: Some(
                     IsoLevel3Shift,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2993,8 +2993,8 @@ impl State {
                     }
                 }
 
-                if !is_overview_open {
-                    self.niri.layout.activate_window(&window);
+                if !is_overview_open && self.niri.layout.activate_window(&window) {
+                    return;
                 }
 
                 // FIXME: granular.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2994,7 +2994,10 @@ impl State {
                 }
 
                 if !is_overview_open && self.niri.layout.activate_window(&window) {
-                    return;
+                    let config = self.niri.config.borrow();
+                    if config.input.only_focus_on_click {
+                        return;
+                    }
                 }
 
                 // FIXME: granular.

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1511,10 +1511,10 @@ impl<W: LayoutElement> Layout<W> {
         ws_idx == mon.active_workspace_idx
     }
 
-    pub fn activate_window(&mut self, window: &W::Id) {
+    pub fn activate_window(&mut self, window: &W::Id) -> bool {
         if let Some(InteractiveMoveState::Moving(move_)) = &self.interactive_move {
             if move_.tile.window().id() == window {
-                return;
+                return false;
             }
         }
 
@@ -1524,11 +1524,12 @@ impl<W: LayoutElement> Layout<W> {
             ..
         } = &mut self.monitor_set
         else {
-            return;
+            return false;
         };
 
         for (monitor_idx, mon) in monitors.iter_mut().enumerate() {
             for (workspace_idx, ws) in mon.workspaces.iter_mut().enumerate() {
+                let ret = !ws.active_window().is_some_and(|w| w.id() == window);
                 if ws.activate_window(window) {
                     *active_monitor_idx = monitor_idx;
 
@@ -1541,10 +1542,11 @@ impl<W: LayoutElement> Layout<W> {
                         _ => mon.switch_workspace(workspace_idx),
                     }
 
-                    return;
+                    return ret;
                 }
             }
         }
+        false
     }
 
     pub fn activate_window_without_raising(&mut self, window: &W::Id) {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -1129,7 +1129,9 @@ impl Op {
             Op::FocusWindowUpOrColumnRight => layout.focus_up_or_right(),
             Op::FocusWindowOrWorkspaceDown => layout.focus_window_or_workspace_down(),
             Op::FocusWindowOrWorkspaceUp => layout.focus_window_or_workspace_up(),
-            Op::FocusWindow(id) => layout.activate_window(&id),
+            Op::FocusWindow(id) => {
+                layout.activate_window(&id);
+            }
             Op::FocusWindowInColumn(index) => layout.focus_window_in_column(index),
             Op::FocusWindowTop => layout.focus_window_top(),
             Op::FocusWindowBottom => layout.focus_window_bottom(),


### PR DESCRIPTION
Inhibits click events on unfocused windows, instead just raises them (I think this is how macOS works). Name could probably be improved, or perhaps it could be added as a property to warp-mouse-to-focus since it's intended for use with that.