### PR TITLE
Assign issue with type instead of label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug or a crash
 title: ''
-labels: bug
+type: bug
 assignees: ''
 
 ---


### PR DESCRIPTION
Seems like Niri (or Semper) is preferring the issue type over label, so let's make it the default.