### PR TITLE
Fix typo in issue type name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug or a crash
 title: ''
-type: bug
+type: Bug
 assignees: ''
 
 ---


### PR DESCRIPTION
I thought the type name was case-insensitive (because of some examples in GH docs) so I didnt capitalize it properly in #4015. As a result, the auto type tagging seems to stop working.

Sorry for any inconvenience caused.