### PR TITLE
Update deprecated systemd import-environment call

### DIFF
--- a/resources/niri-session
+++ b/resources/niri-session
@@ -33,7 +33,7 @@ if hash systemctl >/dev/null 2>&1; then
     systemctl --user reset-failed
 
     # Import the login manager environment.
-    systemctl --user import-environment
+    systemctl --user import-environment WAYLAND_DISPLAY DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP NIRI_SOCKET
 
     # DBus activation environment is independent from systemd. While most of
     # dbus-activated services are already using `SystemdService` directive, some


### PR DESCRIPTION
Fixes the deprecated `systemctl --user import-environment` call in `niri-session` to include specific env vars to import.