### PR TITLE
window-rule: add block-pointer-constraints to suppress pointer-lock activation

### DIFF
--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -596,7 +596,7 @@ window-rule {
 
 #### `block-pointer-constraints`
 
-<sup>Since: next</sup>
+<sup>Since: next release</sup>
 
 Suppress activation of [`zwp_pointer_constraints_v1`](https://wayland.app/protocols/pointer-constraints-unstable-v1) requests originating from this window.
 Affects both `locked` and `confined` constraint variants.
@@ -607,9 +607,11 @@ Well-behaved clients gate relative-motion mode and similar features on the const
 
 Useful for opting out of apps that request a pointer-lock as part of a tooltip, annotation, or overlay UI that the user doesn't want to engage when the cursor merely crosses the surface.
 
+For example, Zoom's `annotate_toolbar` overlay window requests a pointer-lock the user typically doesn't want to engage:
+
 ```kdl
 window-rule {
-    match app-id="some-app"
+    match app-id="^Zoom$" title="^annotate_toolbar$"
     block-pointer-constraints true
 }
 ```

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -594,6 +594,30 @@ window-rule {
 > This is because window title (and app ID) are not double-buffered in the Wayland protocol, so they are not tied to specific window contents.
 > There's no robust way for Firefox to synchronize visibly showing a different tab and changing the window title.
 
+#### `block-pointer-constraints`
+
+<sup>Since: next</sup>
+
+Suppress activation of [`zwp_pointer_constraints_v1`](https://wayland.app/protocols/pointer-constraints-unstable-v1) requests originating from this window.
+Affects both `locked` and `confined` constraint variants.
+
+The constraint can still be requested and bound to the window's surfaces by the client.
+niri simply never activates it, so the client observes a constraint that remains inactive for its entire lifetime.
+Well-behaved clients gate relative-motion mode and similar features on the constraint being active, so they degrade gracefully to normal absolute-motion input.
+
+Useful for opting out of apps that request a pointer-lock as part of a tooltip, annotation, or overlay UI that the user doesn't want to engage when the cursor merely crosses the surface.
+
+```kdl
+window-rule {
+    match app-id="some-app"
+    block-pointer-constraints true
+}
+```
+
+> [!NOTE]
+> This is unrelated to keyboard focus or pointer focus.
+> Cursor entry into the window's surface still updates pointer focus normally (and triggers [`focus-follows-mouse`](./Configuration:-Input.md#focus-follows-mouse) if configured) — only the pointer-lock/confine activation is gated.
+
 #### `opacity`
 
 Set the opacity of the window.

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -890,6 +890,7 @@ mod tests {
                 default-window-height { fixed 500; }
                 default-column-display "tabbed"
                 default-floating-position x=100 y=-200 relative-to="bottom-left"
+                block-pointer-constraints true
 
                 focus-ring {
                     off
@@ -1857,6 +1858,9 @@ mod tests {
                     clip_to_geometry: None,
                     baba_is_float: None,
                     block_out_from: None,
+                    block_pointer_constraints: Some(
+                        true,
+                    ),
                     variable_refresh_rate: None,
                     default_column_display: Some(
                         Tabbed,

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -66,6 +66,8 @@ pub struct WindowRule {
     #[knuffel(child, unwrap(argument))]
     pub block_out_from: Option<BlockOutFrom>,
     #[knuffel(child, unwrap(argument))]
+    pub block_pointer_constraints: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
     pub variable_refresh_rate: Option<bool>,
     #[knuffel(child, unwrap(argument, str))]
     pub default_column_display: Option<ColumnDisplay>,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -73,7 +73,7 @@ use smithay::utils::{
 };
 use smithay::wayland::background_effect::BackgroundEffectState;
 use smithay::wayland::compositor::{
-    get_parent, with_states, with_surface_tree_downward, CompositorClientState, CompositorHandler,
+    with_states, with_surface_tree_downward, CompositorClientState, CompositorHandler,
     CompositorState, HookId, SurfaceData, TraversalAction,
 };
 use smithay::wayland::cursor_shape::CursorShapeManagerState;
@@ -6077,13 +6077,11 @@ impl Niri {
         // `block-pointer-constraints true` short-circuits activation here.
         // The constraint can still be requested by the client and bound to
         // the surface — we just never activate it, so the protocol behaves
-        // like a silent no-op for the lifetime of the request. Walk to the
-        // root surface first because pointer-constraints can be requested
-        // on subsurfaces too, and rules resolve on the toplevel.
-        let mut root = surface.clone();
-        while let Some(parent) = get_parent(&root) {
-            root = parent;
-        }
+        // like a silent no-op for the lifetime of the request. Resolve to
+        // the root toplevel first because pointer-constraints can be
+        // requested on subsurfaces / popups too, while rules resolve on
+        // the toplevel.
+        let root = self.find_root_shell_surface(surface);
         if let Some((mapped, _)) = self.layout.find_window_and_output(&root) {
             if mapped.rules().block_pointer_constraints == Some(true) {
                 return;

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -6073,26 +6073,27 @@ impl Niri {
             return;
         }
 
-        // Window-rule opt-out: a window matched by a rule with
-        // `block-pointer-constraints true` short-circuits activation here.
-        // The constraint can still be requested by the client and bound to
-        // the surface — we just never activate it, so the protocol behaves
-        // like a silent no-op for the lifetime of the request. Resolve to
-        // the root toplevel first because pointer-constraints can be
-        // requested on subsurfaces / popups too, while rules resolve on
-        // the toplevel.
-        let root = self.find_root_shell_surface(surface);
-        if let Some((mapped, _)) = self.layout.find_window_and_output(&root) {
-            if mapped.rules().block_pointer_constraints == Some(true) {
-                return;
-            }
-        }
-
         with_pointer_constraint(surface, &pointer, |constraint| {
             let Some(constraint) = constraint else { return };
 
             if constraint.is_active() {
                 return;
+            }
+
+            // Window-rule opt-out: a window matched by a rule with
+            // `block-pointer-constraints true` short-circuits before
+            // activation. The constraint stays bound but inactive for its
+            // lifetime, so the protocol behaves like a silent no-op.
+            // Resolving root + looking up the window rules is deferred
+            // until here so the no-constraint fast path (every pointer
+            // motion over a surface without a constraint) doesn't pay
+            // for it. Pointer-constraints can be requested on subsurfaces
+            // / popups, but rules resolve on the toplevel.
+            let root = self.find_root_shell_surface(surface);
+            if let Some((mapped, _)) = self.layout.find_window_and_output(&root) {
+                if mapped.rules().block_pointer_constraints == Some(true) {
+                    return;
+                }
             }
 
             // Constraint does not apply if not within region.

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -73,7 +73,7 @@ use smithay::utils::{
 };
 use smithay::wayland::background_effect::BackgroundEffectState;
 use smithay::wayland::compositor::{
-    with_states, with_surface_tree_downward, CompositorClientState, CompositorHandler,
+    get_parent, with_states, with_surface_tree_downward, CompositorClientState, CompositorHandler,
     CompositorState, HookId, SurfaceData, TraversalAction,
 };
 use smithay::wayland::cursor_shape::CursorShapeManagerState;
@@ -6071,6 +6071,23 @@ impl Niri {
         let pointer = self.seat.get_pointer().unwrap();
         if Some(surface) != pointer.current_focus().as_ref() {
             return;
+        }
+
+        // Window-rule opt-out: a window matched by a rule with
+        // `block-pointer-constraints true` short-circuits activation here.
+        // The constraint can still be requested by the client and bound to
+        // the surface — we just never activate it, so the protocol behaves
+        // like a silent no-op for the lifetime of the request. Walk to the
+        // root surface first because pointer-constraints can be requested
+        // on subsurfaces too, and rules resolve on the toplevel.
+        let mut root = surface.clone();
+        while let Some(parent) = get_parent(&root) {
+            root = parent;
+        }
+        if let Some((mapped, _)) = self.layout.find_window_and_output(&root) {
+            if mapped.rules().block_pointer_constraints == Some(true) {
+                return;
+            }
         }
 
         with_pointer_constraint(surface, &pointer, |constraint| {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -112,12 +112,6 @@ pub struct ResolvedWindowRules {
     pub block_out_from: Option<BlockOutFrom>,
 
     /// Whether to block pointer-constraints (locked + confined) for this window.
-    ///
-    /// When `Some(true)`, niri suppresses activation of any pointer-constraint
-    /// (`zwp_pointer_constraints_v1`) request originating from this window. Useful
-    /// for apps that request a pointer-lock as part of an annotation/overlay UI
-    /// that the user doesn't want to engage every time the cursor crosses the
-    /// surface. Both `Locked` and `Confined` variants are suppressed.
     pub block_pointer_constraints: Option<bool>,
 
     /// Whether to enable VRR on this window's primary output if it is on-demand.

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -111,6 +111,15 @@ pub struct ResolvedWindowRules {
     /// Whether to block out this window from certain render targets.
     pub block_out_from: Option<BlockOutFrom>,
 
+    /// Whether to block pointer-constraints (locked + confined) for this window.
+    ///
+    /// When `Some(true)`, niri suppresses activation of any pointer-constraint
+    /// (`zwp_pointer_constraints_v1`) request originating from this window. Useful
+    /// for apps that request a pointer-lock as part of an annotation/overlay UI
+    /// that the user doesn't want to engage every time the cursor crosses the
+    /// surface. Both `Locked` and `Confined` variants are suppressed.
+    pub block_pointer_constraints: Option<bool>,
+
     /// Whether to enable VRR on this window's primary output if it is on-demand.
     pub variable_refresh_rate: Option<bool>,
 
@@ -292,6 +301,9 @@ impl ResolvedWindowRules {
                 }
                 if let Some(x) = rule.block_out_from {
                     resolved.block_out_from = Some(x);
+                }
+                if let Some(x) = rule.block_pointer_constraints {
+                    resolved.block_pointer_constraints = Some(x);
                 }
                 if let Some(x) = rule.variable_refresh_rate {
                     resolved.variable_refresh_rate = Some(x);


### PR DESCRIPTION
## Summary

Adds a `block-pointer-constraints` window-rule (`Option<bool>`) that
suppresses activation of `zwp_pointer_constraints_v1` constraints for
matching windows. Both `Locked` and `Confined` variants are suppressed
unconditionally — the rule is opt-in per window, so apps that
legitimately need pointer-constraints (games, drawing tablets, 3D
modelers) are unaffected unless explicitly matched.

## Motivation

Some clients request a pointer-lock as part of a tooltip / annotation /
overlay UI surface that users don't actually want to engage when the
cursor merely crosses it — the constraint locks the cursor in place
until pointer focus moves away (which from a user's perspective looks
like "the cursor is stuck"). A per-window opt-out preserves the
protocol for its intended uses while letting users disable it for
specific surfaces.

Concrete motivating case: Zoom's `annotate_toolbar` overlay (a small
floating toolbar that appears during screen-sharing-with-annotation)
requests a pointer-lock on hover. Users only want to interact with the
toolbar deliberately, but on niri the lock activates whenever the
cursor crosses the overlay's region.

## Implementation

- **Schema** (`niri-config/src/window_rule.rs`): new
  `block_pointer_constraints: Option<bool>` field on `WindowRule`
  adjacent to `block_out_from`, with the standard
  `#[knuffel(child, unwrap(argument))]` annotation.
- **Resolution** (`src/window/mod.rs`): same field on
  `ResolvedWindowRules`, last-`Some`-wins resolution in `compute()`.
- **Gate** (`src/niri.rs`): `Niri::maybe_activate_pointer_constraint()`
  short-circuits when the constrained surface's root toplevel matches a
  rule with this flag set. The check is placed **inside** the
  `with_pointer_constraint` callback after the constraint-present
  early-return, so the no-constraint fast path that runs on every
  pointer motion is unchanged. Root-surface resolution uses the existing
  `Niri::find_root_shell_surface` helper (popups + subsurfaces are
  handled correctly).
- **Test**: parser test in `niri-config/src/lib.rs` extends the existing
  window-rule fixture to cover the new property round-tripping.
- **Wiki**: new `#### block-pointer-constraints` section in
  `docs/wiki/Configuration:-Window-Rules.md` between `block-out-from`
  and `opacity`, with the motivating Zoom example.

## Design notes

- **Activation-time gate, not bind-time refusal.** The protocol still
  binds and the client's request still arrives at smithay; niri just
  never calls `constraint.activate()`. Well-behaved clients gate
  relative-motion mode and similar features on the constraint being
  active, so they degrade gracefully to normal absolute-motion input.
- **Both variants, unconditionally.** A `Confined` constraint with a
  sufficiently large region produces the same user-visible "cursor
  stuck" pattern as `Locked`; suppressing both keeps the rule's
  semantics predictable. A future enhancement could split this into an
  enum if a real use case demands variant-specific control.
- **Per-window, opt-in.** Global pointer-constraint suppression would
  break games, drawing tablets, and Blender-style middle-drag
  interactions; per-window keeps the rule narrowly scoped.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p niri-config` passes (parser test exercises the new field, wiki-parses test confirms the KDL example parses)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check --all` clean
- [x] Deployed live on Linux/Wayland; config parses, rule resolves on the motivating window
- [ ] End-to-end cursor-suppression on the motivating app (Zoom `annotate_toolbar`) — verification in progress on next session