### PR TITLE
Add window-rule `float-above-fullscreen`

### DIFF
--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -99,6 +99,7 @@ window-rule {
     clip-to-geometry true
     tiled-state true
     baba-is-float true
+    float-above-fullscreen true
 
     background-effect {
         xray true
@@ -927,6 +928,18 @@ window-rule {
 https://github.com/user-attachments/assets/3f4cb1a4-40b2-4766-98b7-eec014c19509
 
 </video>
+
+#### `float-above-fullscreen`
+
+<sup>Since: next release</sup>
+
+Make a floating window always visible when the current workspace is occupied by a fullscreen window.
+
+```kdl
+window-rule {
+    float-above-fullscreen false
+}
+```
 
 #### `background-effect`
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -905,6 +905,8 @@ mod tests {
                 tab-indicator {
                     active-color "#f00"
                 }
+
+                float-above-fullscreen true
             }
 
             layer-rule {
@@ -1864,6 +1866,9 @@ mod tests {
                     geometry_corner_radius: None,
                     clip_to_geometry: None,
                     baba_is_float: None,
+                    float_above_fullscreen: Some(
+                        true,
+                    ),
                     block_out_from: None,
                     variable_refresh_rate: None,
                     default_column_display: Some(

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -64,6 +64,8 @@ pub struct WindowRule {
     #[knuffel(child, unwrap(argument))]
     pub baba_is_float: Option<bool>,
     #[knuffel(child, unwrap(argument))]
+    pub float_above_fullscreen: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
     pub block_out_from: Option<BlockOutFrom>,
     #[knuffel(child, unwrap(argument))]
     pub variable_refresh_rate: Option<bool>,

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1062,6 +1062,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
         xray_pos: XrayPos,
         view_rect: Rectangle<f64, Logical>,
         focus_ring: bool,
+        base_visible: bool,
         push: &mut dyn FnMut(FloatingSpaceRenderElement<R>),
     ) {
         let scale = Scale::from(self.scale);
@@ -1076,6 +1077,10 @@ impl<W: LayoutElement> FloatingSpace<W> {
 
         let active = self.active_window_id.clone();
         for (tile, tile_pos) in self.tiles_with_render_positions() {
+            if !base_visible && tile.window().rules().float_above_fullscreen != Some(true) {
+                continue;
+            }
+
             // For the active tile, draw the focus ring.
             let focus_ring = focus_ring && Some(tile.window().id()) == active.as_ref();
 

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1588,8 +1588,14 @@ impl<W: LayoutElement> Workspace<W> {
         let scrolling = self.scrolling.tiles_with_render_positions();
 
         let floating = self.floating.tiles_with_render_positions();
-        let visible = self.is_floating_visible();
-        let floating = floating.map(move |(tile, pos)| (tile, pos, visible));
+        let base_visible = self.is_floating_visible();
+        let floating = floating.map(move |(tile, pos)| {
+            if tile.window().rules().float_above_fullscreen == Some(true) {
+                (tile, pos, true)
+            } else {
+                (tile, pos, base_visible)
+            }
+        });
 
         floating.chain(scrolling)
     }
@@ -1646,16 +1652,18 @@ impl<W: LayoutElement> Workspace<W> {
         focus_ring: bool,
         push: &mut dyn FnMut(WorkspaceRenderElement<R>),
     ) {
-        if !self.is_floating_visible() {
-            return;
-        }
+        let base_visible = self.is_floating_visible();
 
         let view_rect = Rectangle::from_size(self.view_size);
         let floating_focus_ring = focus_ring && self.floating_is_active();
-        self.floating
-            .render(ctx, xray_pos, view_rect, floating_focus_ring, &mut |elem| {
-                push(elem.into())
-            });
+        self.floating.render(
+            ctx,
+            xray_pos,
+            view_rect,
+            floating_focus_ring,
+            base_visible,
+            &mut |elem| push(elem.into()),
+        );
     }
 
     pub fn render_shadow<R: NiriRenderer>(
@@ -1755,14 +1763,19 @@ impl<W: LayoutElement> Workspace<W> {
 
     pub fn window_under(&self, pos: Point<f64, Logical>) -> Option<(&W, HitType)> {
         // This logic is consistent with tiles_with_render_positions().
-        if self.is_floating_visible() {
-            if let Some(rv) = self
-                .floating
+        let base_visible = self.is_floating_visible();
+        if let Some(rv) =
+            self.floating
                 .tiles_with_render_positions()
-                .find_map(|(tile, tile_pos)| HitType::hit_tile(tile, tile_pos, pos))
-            {
-                return Some(rv);
-            }
+                .find_map(|(tile, tile_pos)| {
+                    if base_visible || tile.window().rules().float_above_fullscreen == Some(true) {
+                        HitType::hit_tile(tile, tile_pos, pos)
+                    } else {
+                        None
+                    }
+                })
+        {
+            return Some(rv);
         }
 
         self.scrolling.window_under(pos)

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -108,6 +108,9 @@ pub struct ResolvedWindowRules {
     /// Whether to bob this window up and down.
     pub baba_is_float: Option<bool>,
 
+    /// Whether this floating window should render above fullscreen windows.
+    pub float_above_fullscreen: Option<bool>,
+
     /// Whether to block out this window from certain render targets.
     pub block_out_from: Option<BlockOutFrom>,
 
@@ -289,6 +292,9 @@ impl ResolvedWindowRules {
                 }
                 if let Some(x) = rule.baba_is_float {
                     resolved.baba_is_float = Some(x);
+                }
+                if let Some(x) = rule.float_above_fullscreen {
+                    resolved.float_above_fullscreen = Some(x);
                 }
                 if let Some(x) = rule.block_out_from {
                     resolved.block_out_from = Some(x);


### PR DESCRIPTION
This PR adds a window-rule `float-above-fullscreen` (or whatever, like `always-float`, `always-on-top` etc, if there's a better name for it) which prevents a floating window from being hidden when another window is fullscreened.

The configuration:

```kdl
window-rule {
    match title="^Picture-in-Picture$"

    float-above-fullscreen true
}
```

This is useful say if one is playing a fullscreen video game and meanwhile is watching a video as a floating window in the corner (e.g. firefox's picture-in-picture). And I searched for it and found there's a discussion about this: https://github.com/niri-wm/niri/discussions/2798#discussioncomment-16933617, knowing I'm not the only one who likes doing such things sometimes :).

The current solution to this is kill the bar (like DankMaterialShell bar or waybar or similar) and to make the game go 'maximize-window-to-edges' state. When no bar is present, 'maximize-window-to-edges' looks identical to the real 'fullscreen'. But most people I believe won't want to bother doing this workaround. There are also differences between 'maximize-window-to-edges' and 'fullscreen' I guess, for example, the `direct-scanout`. If `direct-scanout` is enabled (yes in niri it is by default), I just tested, Minecraft (26.2-snapshot-7) will sync its framerate with the monitor if it's 'fullscreen', but it won't if it's 'maximize-window-to-edges', though without a bar these two look identical. Anyway to achieve this (playing games + watching videos :) ), a window-rule for it is more preferable I suppose.