### PR TITLE
window-rule: add `disable-mod-mouse-actions` for Mod+Mouse move/resize

### DIFF
--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -928,6 +928,22 @@ https://github.com/user-attachments/assets/3f4cb1a4-40b2-4766-98b7-eec014c19509
 
 </video>
 
+#### `disable-mod-mouse-actions`
+
+<sup>Since: next release</sup>
+
+Disables the niri-side <kbd>Mod</kbd>+<kbd>Left Mouse</kbd> interactive move and <kbd>Mod</kbd>+<kbd>Right Mouse</kbd> interactive resize for matching windows.
+Also disables the corresponding <kbd>Mod</kbd>+touch move grab.
+
+Useful for windows that want to handle <kbd>Mod</kbd>+click themselves, such as games or remote desktop clients.
+
+```kdl
+window-rule {
+    match app-id="^remote-desktop$"
+    disable-mod-mouse-actions true
+}
+```
+
 #### `background-effect`
 
 <sup>Since: 26.04</sup>

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -958,6 +958,22 @@ https://github.com/user-attachments/assets/3f4cb1a4-40b2-4766-98b7-eec014c19509
 
 </video>
 
+#### `disable-mod-mouse-actions`
+
+<sup>Since: next release</sup>
+
+Disables the niri-side <kbd>Mod</kbd>+<kbd>Left Mouse</kbd> interactive move and <kbd>Mod</kbd>+<kbd>Right Mouse</kbd> interactive resize for matching windows.
+Also disables the corresponding <kbd>Mod</kbd>+touch move grab.
+
+Useful for windows that want to handle <kbd>Mod</kbd>+click themselves, such as games or remote desktop clients.
+
+```kdl
+window-rule {
+    match app-id="^remote-desktop$"
+    disable-mod-mouse-actions true
+}
+```
+
 #### `background-effect`
 
 <sup>Since: 26.04</sup>

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -887,6 +887,7 @@ mod tests {
                 open-fullscreen false
                 open-floating false
                 open-focused true
+                disable-mod-mouse-actions true
                 default-window-height { fixed 500; }
                 default-column-display "tabbed"
                 default-floating-position x=100 y=-200 relative-to="bottom-left"
@@ -1874,6 +1875,9 @@ mod tests {
                     ),
                     scroll_factor: None,
                     tiled_state: None,
+                    disable_mod_mouse_actions: Some(
+                        true,
+                    ),
                     background_effect: BackgroundEffectRule {
                         xray: None,
                         blur: None,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -912,6 +912,7 @@ mod tests {
                 open-fullscreen false
                 open-floating false
                 open-focused true
+                disable-mod-mouse-actions true
                 default-window-height { fixed 500; }
                 default-column-display "tabbed"
                 default-floating-position x=100 y=-200 relative-to="bottom-left"
@@ -1910,6 +1911,9 @@ mod tests {
                     ),
                     scroll_factor: None,
                     tiled_state: None,
+                    disable_mod_mouse_actions: Some(
+                        true,
+                    ),
                     background_effect: BackgroundEffectRule {
                         xray: None,
                         blur: None,

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -75,6 +75,8 @@ pub struct WindowRule {
     pub scroll_factor: Option<FloatOrInt<0, 100>>,
     #[knuffel(child, unwrap(argument))]
     pub tiled_state: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub disable_mod_mouse_actions: Option<bool>,
     #[knuffel(child, default)]
     pub background_effect: BackgroundEffectRule,
     #[knuffel(child, default)]

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -77,6 +77,8 @@ pub struct WindowRule {
     pub scroll_factor: Option<FloatOrInt<0, 100>>,
     #[knuffel(child, unwrap(argument))]
     pub tiled_state: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub disable_mod_mouse_actions: Option<bool>,
     #[knuffel(child, default)]
     pub background_effect: BackgroundEffectRule,
     #[knuffel(child, default)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2890,10 +2890,11 @@ impl State {
 
             if let Some(mapped) = self.niri.window_under_cursor() {
                 let window = mapped.window.clone();
+                let mod_actions_disabled = mapped.rules().disable_mod_mouse_actions == Some(true);
 
                 // Check if we need to start an interactive move.
                 if button == Some(MouseButton::Left) && !pointer.is_grabbed() {
-                    if is_overview_open || mod_down {
+                    if is_overview_open || (mod_down && !mod_actions_disabled) {
                         let location = pointer.current_location();
 
                         if !is_overview_open {
@@ -2926,7 +2927,11 @@ impl State {
                     }
                 }
                 // Check if we need to start an interactive resize.
-                else if button == Some(MouseButton::Right) && !pointer.is_grabbed() && mod_down {
+                else if button == Some(MouseButton::Right)
+                    && !pointer.is_grabbed()
+                    && mod_down
+                    && !mod_actions_disabled
+                {
                     let location = pointer.current_location();
                     let (output, pos_within_output) = self.niri.output_under(location).unwrap();
                     let edges = self
@@ -4200,8 +4205,13 @@ impl State {
             } else if let Some((window, _)) = under.window {
                 self.niri.layout.activate_window(&window);
 
+                let mod_actions_disabled = self
+                    .niri
+                    .window_under(pos)
+                    .is_some_and(|m| m.rules().disable_mod_mouse_actions == Some(true));
+
                 // Check if we need to start a touch move grab.
-                if mod_down {
+                if mod_down && !mod_actions_disabled {
                     let start_data = TouchGrabStartData {
                         focus: None,
                         slot,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2918,10 +2918,11 @@ impl State {
 
             if let Some(mapped) = self.niri.window_under_cursor() {
                 let window = mapped.window.clone();
+                let mod_actions_disabled = mapped.rules().disable_mod_mouse_actions == Some(true);
 
                 // Check if we need to start an interactive move.
                 if button == Some(MouseButton::Left) && !pointer.is_grabbed() {
-                    if is_overview_open || mod_down {
+                    if is_overview_open || (mod_down && !mod_actions_disabled) {
                         let location = pointer.current_location();
 
                         if !is_overview_open {
@@ -2954,7 +2955,11 @@ impl State {
                     }
                 }
                 // Check if we need to start an interactive resize.
-                else if button == Some(MouseButton::Right) && !pointer.is_grabbed() && mod_down {
+                else if button == Some(MouseButton::Right)
+                    && !pointer.is_grabbed()
+                    && mod_down
+                    && !mod_actions_disabled
+                {
                     let location = pointer.current_location();
                     let (output, pos_within_output) = self.niri.output_under(location).unwrap();
                     let edges = self
@@ -4340,8 +4345,13 @@ impl State {
             } else if let Some((window, _)) = under.window {
                 self.niri.layout.activate_window(&window);
 
+                let mod_actions_disabled = self
+                    .niri
+                    .window_under(pos)
+                    .is_some_and(|m| m.rules().disable_mod_mouse_actions == Some(true));
+
                 // Check if we need to start a touch move grab.
-                if mod_down {
+                if mod_down && !mod_actions_disabled {
                     let start_data = TouchGrabStartData {
                         focus: None,
                         slot,

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -120,6 +120,10 @@ pub struct ResolvedWindowRules {
     /// Override whether to set the Tiled xdg-toplevel state on the window.
     pub tiled_state: Option<bool>,
 
+    /// Whether to disable Mod+Left Click drag for move
+    /// and Mod+Right Click Drag for resize for this window.
+    pub disable_mod_mouse_actions: Option<bool>,
+
     /// Background effect configuration.
     pub background_effect: BackgroundEffect,
 
@@ -301,6 +305,9 @@ impl ResolvedWindowRules {
                 }
                 if let Some(x) = rule.tiled_state {
                     resolved.tiled_state = Some(x);
+                }
+                if let Some(x) = rule.disable_mod_mouse_actions {
+                    resolved.disable_mod_mouse_actions = Some(x);
                 }
 
                 resolved

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -123,6 +123,10 @@ pub struct ResolvedWindowRules {
     /// Override whether to set the Tiled xdg-toplevel state on the window.
     pub tiled_state: Option<bool>,
 
+    /// Whether to disable Mod+Left Click drag for move
+    /// and Mod+Right Click Drag for resize for this window.
+    pub disable_mod_mouse_actions: Option<bool>,
+
     /// Background effect configuration.
     pub background_effect: BackgroundEffect,
 
@@ -308,6 +312,9 @@ impl ResolvedWindowRules {
                 }
                 if let Some(x) = rule.tiled_state {
                     resolved.tiled_state = Some(x);
+                }
+                if let Some(x) = rule.disable_mod_mouse_actions {
+                    resolved.disable_mod_mouse_actions = Some(x);
                 }
 
                 resolved


### PR DESCRIPTION
Mod-Click can sometimes interfere with applications that want to handle it themselves, like games (factorio) or remote desktop software (https://github.com/niri-wm/niri/discussions/3825).

The PR adds a window-rule opt-out for the Mod+LMB interactive move and Mod+RMB interactive resize.
It also disables Mod+touch move, but I didn't test that one.

```kdl
window-rule {
    match app-id="^factorio$"
    disable-mod-mouse-actions true
}
```
