### PR TITLE
gestures: edge-overscroll — pan focus by pushing the pointer past a screen edge

### DIFF
--- a/docs/wiki/Configuration:-Gestures.md
+++ b/docs/wiki/Configuration:-Gestures.md
@@ -21,6 +21,10 @@ gestures {
         max-speed 1500
     }
 
+    edge-overscroll {
+        // resistance 0   // 0 disables this gesture (the default)
+    }
+
     hot-corners {
         // off
         top-left
@@ -77,6 +81,32 @@ gestures {
     dnd-edge-workspace-switch {
         trigger-height 100
         max-speed 3000
+    }
+}
+```
+
+### `edge-overscroll`
+
+<sup>Since: next release</sup>
+
+Push the mouse cursor *past* a true screen edge — a hard edge with no adjacent output, so the motion is clipped — to pan focus to the adjacent column (left/right edge) or workspace (up/down edge).
+
+Unlike `dnd-edge-*`, this works outside drag-and-drop, during normal pointer use. It requires the cursor to reach the *actual* screen boundary (not a proximity band) and keep pushing; the clipped over-travel accumulates and, once it crosses `resistance`, performs a single discrete navigation step. Because the pointer is pinned at a hard edge, incidental edge contact accumulates only a few pixels and cannot trigger it — there is no timer and no heuristic.
+
+It is suppressed while the session is locked, in the overview/screenshot/MRU UIs, during a pointer grab or constraint, and on a fullscreen window (leaving fullscreen must be explicit). It acts on the monitor the cursor is on, fires once per excursion, and re-arms when the cursor returns inside the outputs.
+
+The option is:
+
+- `resistance`: accumulated over-travel past the edge, in logical pixels, required to trigger. `0` (the default) disables the gesture. Higher values require a firmer, more deliberate shove.
+
+This is primarily useful for scrollable layouts run *without* left/right `struts` (combined with `focus-follows-mouse max-scroll-amount="0%"`), where a maximized column leaves no off-screen sliver for ordinary focus-follows-mouse to pan via. Note: with side-by-side monitors of differing height/offset, the L-shaped no-output region next to the shorter monitor is also a true screen edge.
+
+```kdl
+gestures {
+    // Shove the cursor ~200 px past a screen edge to pan focus
+    // to the adjacent column / workspace.
+    edge-overscroll {
+        resistance 200
     }
 }
 ```

--- a/docs/wiki/Configuration:-Gestures.md
+++ b/docs/wiki/Configuration:-Gestures.md
@@ -89,7 +89,9 @@ gestures {
 
 <sup>Since: next release</sup>
 
-Push the mouse cursor *past* a true screen edge — a hard edge with no adjacent output, so the motion is clipped — to pan focus to the adjacent column (left/right edge) or workspace (up/down edge).
+Push the mouse cursor *past* a true left or right screen edge — a hard edge with no adjacent output, so the motion is clipped — to pan focus to the adjacent column on the current workspace.
+
+The gesture is horizontal only. Pushing past the top or bottom edge does nothing; it never switches workspaces.
 
 Unlike `dnd-edge-*`, this works outside drag-and-drop, during normal pointer use. It requires the cursor to reach the *actual* screen boundary (not a proximity band) and keep pushing; the clipped over-travel accumulates and, once it crosses `resistance`, performs a single discrete navigation step. Because the pointer is pinned at a hard edge, incidental edge contact accumulates only a few pixels and cannot trigger it — there is no timer and no heuristic.
 
@@ -103,8 +105,8 @@ This is primarily useful for scrollable layouts run *without* left/right `struts
 
 ```kdl
 gestures {
-    // Shove the cursor ~200 px past a screen edge to pan focus
-    // to the adjacent column / workspace.
+    // Shove the cursor ~200 px past the left or right screen edge
+    // to pan focus to the adjacent column.
     edge-overscroll {
         resistance 200
     }

--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -363,6 +363,8 @@ input {
 }
 ```
 
+> To navigate to an off-screen column/workspace by pushing the pointer past a screen edge, see the [`edge-overscroll`](./Configuration:-Gestures#edge-overscroll) gesture.
+
 #### `workspace-auto-back-and-forth`
 
 Normally, switching to the same workspace by index twice will do nothing (since you're already on that workspace).

--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -363,7 +363,7 @@ input {
 }
 ```
 
-> To navigate to an off-screen column/workspace by pushing the pointer past a screen edge, see the [`edge-overscroll`](./Configuration:-Gestures#edge-overscroll) gesture.
+> To navigate to an off-screen column by pushing the pointer past the left or right screen edge, see the [`edge-overscroll`](./Configuration:-Gestures#edge-overscroll) gesture.
 
 #### `workspace-auto-back-and-forth`
 

--- a/niri-config/src/gestures.rs
+++ b/niri-config/src/gestures.rs
@@ -5,6 +5,7 @@ use crate::FloatOrInt;
 pub struct Gestures {
     pub dnd_edge_view_scroll: DndEdgeViewScroll,
     pub dnd_edge_workspace_switch: DndEdgeWorkspaceSwitch,
+    pub edge_overscroll: EdgeOverscroll,
     pub hot_corners: HotCorners,
 }
 
@@ -15,6 +16,8 @@ pub struct GesturesPart {
     #[knuffel(child)]
     pub dnd_edge_workspace_switch: Option<DndEdgeWorkspaceSwitchPart>,
     #[knuffel(child)]
+    pub edge_overscroll: Option<EdgeOverscrollPart>,
+    #[knuffel(child)]
     pub hot_corners: Option<HotCorners>,
 }
 
@@ -24,8 +27,33 @@ impl MergeWith<GesturesPart> for Gestures {
             (self, part),
             dnd_edge_view_scroll,
             dnd_edge_workspace_switch,
+            edge_overscroll,
         );
         merge_clone!((self, part), hot_corners);
+    }
+}
+
+/// Push the pointer past a true screen edge (a hard edge with no adjacent
+/// output) to pan focus to the adjacent column (left/right) or workspace
+/// (up/down). Unlike `dnd-edge-*`, this works outside drag-and-drop, requires
+/// the pointer to reach the actual screen boundary (not a proximity band),
+/// has no timer, and performs a single discrete navigation step.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct EdgeOverscroll {
+    /// Accumulated overscroll past the edge (logical px) required to trigger.
+    /// `0` (the default) disables the gesture entirely.
+    pub resistance: f64,
+}
+
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+pub struct EdgeOverscrollPart {
+    #[knuffel(child, unwrap(argument))]
+    pub resistance: Option<FloatOrInt<0, 65535>>,
+}
+
+impl MergeWith<EdgeOverscrollPart> for EdgeOverscroll {
+    fn merge_with(&mut self, part: &EdgeOverscrollPart) {
+        merge!((self, part), resistance);
     }
 }
 
@@ -109,4 +137,29 @@ pub struct HotCorners {
     pub bottom_left: bool,
     #[knuffel(child)]
     pub bottom_right: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[track_caller]
+    fn parse(text: &str) -> Gestures {
+        let part: GesturesPart = knuffel::parse("test.kdl", text)
+            .map_err(miette::Report::new)
+            .unwrap();
+        let mut gestures = Gestures::default();
+        gestures.merge_with(&part);
+        gestures
+    }
+
+    #[test]
+    fn parse_edge_overscroll() {
+        let gestures = parse("edge-overscroll {\n    resistance 80\n}\n");
+        assert_eq!(gestures.edge_overscroll.resistance, 80.0);
+
+        // Omitted → 0.0 (disabled), the default — no behavior change.
+        let gestures = parse("");
+        assert_eq!(gestures.edge_overscroll.resistance, 0.0);
+    }
 }

--- a/niri-config/src/gestures.rs
+++ b/niri-config/src/gestures.rs
@@ -33,11 +33,12 @@ impl MergeWith<GesturesPart> for Gestures {
     }
 }
 
-/// Push the pointer past a true screen edge (a hard edge with no adjacent
-/// output) to pan focus to the adjacent column (left/right) or workspace
-/// (up/down). Unlike `dnd-edge-*`, this works outside drag-and-drop, requires
-/// the pointer to reach the actual screen boundary (not a proximity band),
-/// has no timer, and performs a single discrete navigation step.
+/// Push the pointer past a true left or right screen edge (a hard edge with no
+/// adjacent output) to pan focus to the adjacent column on the same workspace.
+/// Unlike `dnd-edge-*`, this works outside drag-and-drop, requires the pointer
+/// to reach the actual screen boundary (not a proximity band), has no timer,
+/// and performs a single discrete navigation step. Vertical edges do nothing:
+/// the gesture never switches workspaces.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct EdgeOverscroll {
     /// Accumulated overscroll past the edge (logical px) required to trigger.

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1689,6 +1689,9 @@ mod tests {
                     delay_ms: 100,
                     max_speed: 1500.0,
                 },
+                edge_overscroll: EdgeOverscroll {
+                    resistance: 0.0,
+                },
                 hot_corners: HotCorners {
                     off: false,
                     top_left: false,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2630,6 +2630,31 @@ impl State {
                 .and_then(|o| self.niri.layout.monitor_for_output(o))
                 .is_some_and(|m| m.active_workspace_ref().is_active_pending_fullscreen());
 
+            // Suppress when the overscroll direction points at a reachable
+            // monitor neighbor: that's an inner edge between adjacent monitors,
+            // not a true screen edge, and the user is trying to move the cursor
+            // to that neighbor (not pan columns). Inner edges can still clip
+            // even with perfectly aligned monitors — a diagonal nibble near
+            // the top/bottom of an inner edge lands `new_pos` in the dead
+            // space above/below both monitors, so the clamp fires against
+            // the current monitor and produces an overscroll vector dominantly
+            // on the horizontal axis even though the user is heading sideways
+            // toward the neighbor.
+            let dir = edge_overscroll_dir(edge_overscroll_vec.0, edge_overscroll_vec.1);
+            let has_neighbor_in_dir = match (dir, ptr_output.as_ref()) {
+                (Some(EdgeOverscrollDir::Left), Some(o)) => {
+                    self.niri.output_left_of(o).is_some()
+                }
+                (Some(EdgeOverscrollDir::Right), Some(o)) => {
+                    self.niri.output_right_of(o).is_some()
+                }
+                (Some(EdgeOverscrollDir::Up), Some(o)) => self.niri.output_up_of(o).is_some(),
+                (Some(EdgeOverscrollDir::Down), Some(o)) => {
+                    self.niri.output_down_of(o).is_some()
+                }
+                _ => false,
+            };
+
             // Gate firing on exactly the conditions stock focus-follows-mouse
             // respects, plus pointer grabs and fullscreen: never mutate layout
             // state while locked, in the overview/screenshot/MRU UIs, mid
@@ -2644,7 +2669,8 @@ impl State {
                 && !self.niri.screenshot_ui.is_open()
                 && !self.niri.window_mru_ui.is_open()
                 && !self.niri.layout.is_overview_open()
-                && !on_fullscreen;
+                && !on_fullscreen
+                && !has_neighbor_in_dir;
 
             if active && edge_overscroll_px > 0.0 {
                 self.niri.edge_overscroll_accum += edge_overscroll_px;
@@ -2664,7 +2690,7 @@ impl State {
                         self.niri.layout.focus_output(output);
                     }
 
-                    match edge_overscroll_dir(edge_overscroll_vec.0, edge_overscroll_vec.1) {
+                    match dir {
                         Some(EdgeOverscrollDir::Right) => self.niri.layout.focus_right(),
                         Some(EdgeOverscrollDir::Left) => self.niri.layout.focus_left(),
                         Some(EdgeOverscrollDir::Down) => self.niri.layout.switch_workspace_down(),
@@ -5414,6 +5440,43 @@ mod tests {
         assert_eq!(edge_overscroll_dir(-5.0, -5.0), Some(EdgeOverscrollDir::Left));
         // Zero vector → no action.
         assert_eq!(edge_overscroll_dir(0.0, 0.0), None);
+    }
+
+    #[test]
+    fn edge_overscroll_diagonal_near_top_of_inner_edge() {
+        // Reporter's failure mode: in a perfectly aligned horizontal pair
+        //   M1: (0, 0)-(1920, 1080)
+        //   M2: (1920, 0)-(3840, 1080)
+        // a diagonal nibble near the top-right corner of M1 (cursor at y=5,
+        // delta = (+20, -10)) puts the pre-clamp position at (1935, -5) —
+        // above all outputs. output_under(new_pos) is None, so the clamp
+        // fires against M1, producing a dominantly horizontal overscroll
+        // vector — and without neighbor-aware gating the gesture would call
+        // focus_right() inside M1 instead of letting the cursor cross to M2.
+        //
+        // The fix is structural (the `has_neighbor_in_dir` check in
+        // on_pointer_motion uses Niri::output_right_of to detect M2). This
+        // test pins the math so a tie-break or sign change can't silently
+        // flip Right ↔ Up here and re-open the bug.
+        let geo = Rectangle::<i32, Logical>::new(
+            Point::from((0, 0)),
+            smithay::utils::Size::from((1920, 1080)),
+        );
+        let pre_x = 1935.0_f64;
+        let pre_y = -5.0_f64;
+        let clamped_x = pre_x.clamp(geo.loc.x as f64, (geo.loc.x + geo.size.w - 1) as f64);
+        let clamped_y = pre_y.clamp(geo.loc.y as f64, (geo.loc.y + geo.size.h - 1) as f64);
+        assert_eq!(clamped_x, 1919.0);
+        assert_eq!(clamped_y, 0.0);
+
+        let dx = pre_x - clamped_x;
+        let dy = pre_y - clamped_y;
+        assert_eq!((dx, dy), (16.0, -5.0));
+
+        // Dominant axis is horizontal (Right). On a horizontal multi-monitor
+        // setup the on_pointer_motion gate suppresses for this direction
+        // because output_right_of(M1) returns Some(M2).
+        assert_eq!(edge_overscroll_dir(dx, dy), Some(EdgeOverscrollDir::Right));
     }
 
     #[test]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -131,6 +131,37 @@ impl<D: SeatHandler + TabletSeatHandler> AnyStartData<D> {
     }
 }
 
+/// Adjacent target a true-screen-edge overscroll points at. The overscroll vector
+/// is `(pre - clamped)` in compositor coords (Y-down): `+x` past the right
+/// edge, `-x` past the left, `+y` past the bottom, `-y` past the top. The
+/// dominant axis wins; ties favour horizontal (column) over vertical
+/// (workspace). `None` only for a zero vector (never happens when the caller
+/// gates on `edge_overscroll_px > 0`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EdgeOverscrollDir {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+fn edge_overscroll_dir(dx: f64, dy: f64) -> Option<EdgeOverscrollDir> {
+    if dx == 0.0 && dy == 0.0 {
+        return None;
+    }
+    Some(if dx.abs() >= dy.abs() {
+        if dx > 0.0 {
+            EdgeOverscrollDir::Right
+        } else {
+            EdgeOverscrollDir::Left
+        }
+    } else if dy > 0.0 {
+        EdgeOverscrollDir::Down
+    } else {
+        EdgeOverscrollDir::Up
+    })
+}
+
 impl State {
     pub fn process_input_event<I: InputBackend + 'static>(&mut self, event: InputEvent<I>)
     where
@@ -2537,6 +2568,12 @@ impl State {
             }
         }
 
+        // How far the motion was clipped away by a true screen edge this
+        // event (0 when the pointer stayed on an output). This is the
+        // deliberate "pushing past the edge" signal the edge overscroll gates on.
+        let mut edge_overscroll_px = 0.0;
+        let mut edge_overscroll_vec = (0.0_f64, 0.0_f64);
+
         if self
             .niri
             .global_space
@@ -2549,18 +2586,97 @@ impl State {
                 // The pointer was previously on some output. Clip the movement against its
                 // boundaries.
                 let geom = self.niri.global_space.output_geometry(output).unwrap();
+                let pre = new_pos;
                 new_pos.x = new_pos
                     .x
                     .clamp(geom.loc.x as f64, (geom.loc.x + geom.size.w - 1) as f64);
                 new_pos.y = new_pos
                     .y
                     .clamp(geom.loc.y as f64, (geom.loc.y + geom.size.h - 1) as f64);
+                edge_overscroll_vec = (pre.x - new_pos.x, pre.y - new_pos.y);
+                edge_overscroll_px =
+                    (edge_overscroll_vec.0.powi(2) + edge_overscroll_vec.1.powi(2)).sqrt();
             } else {
                 // The pointer was not on any output in the first place. Find one for it.
                 // Let's do the simple thing and just put it on the first output.
                 let output = self.niri.global_space.outputs().next().unwrap();
                 let geom = self.niri.global_space.output_geometry(output).unwrap();
                 new_pos = center(geom).to_f64();
+            }
+        }
+
+        // True-screen-edge overscroll → pan focus to the adjacent column /
+        // workspace. Deliberate by construction: the cursor is pinned at a
+        // hard screen edge and you must keep shoving past it — that can't
+        // happen by accident, so there is no time delay and no heuristic.
+        {
+            let threshold = self
+                .niri
+                .config
+                .borrow()
+                .gestures
+                .edge_overscroll
+                .resistance;
+
+            // Monitor the pointer is overscrolling (used for the fullscreen
+            // check and to act on the right monitor below).
+            let ptr_output = self.niri.global_space.output_under(pos).next().cloned();
+
+            // Don't let an edge overscroll pan focus out of a fullscreen window:
+            // fullscreen content owns the screen, so leaving it must be
+            // explicit (keybind), never an edge shove.
+            let on_fullscreen = ptr_output
+                .as_ref()
+                .and_then(|o| self.niri.layout.monitor_for_output(o))
+                .is_some_and(|m| m.active_workspace_ref().is_active_pending_fullscreen());
+
+            // Gate firing on exactly the conditions stock focus-follows-mouse
+            // respects, plus pointer grabs and fullscreen: never mutate layout
+            // state while locked, in the overview/screenshot/MRU UIs, mid
+            // drag/resize, or on a fullscreen window. The accumulator is still
+            // reset in those states so it can't fire stale the instant the
+            // state clears.
+            let pointer = self.niri.seat.get_pointer().unwrap();
+            let active = threshold > 0.0
+                && !pointer.is_grabbed()
+                && pointer_confined.is_none()
+                && !self.niri.is_locked()
+                && !self.niri.screenshot_ui.is_open()
+                && !self.niri.window_mru_ui.is_open()
+                && !self.niri.layout.is_overview_open()
+                && !on_fullscreen;
+
+            if active && edge_overscroll_px > 0.0 {
+                self.niri.edge_overscroll_accum += edge_overscroll_px;
+                if !self.niri.edge_overscroll_latched && self.niri.edge_overscroll_accum >= threshold {
+                    self.niri.edge_overscroll_latched = true;
+
+                    // Act on the monitor the pointer is overscrolling, not
+                    // whichever monitor happens to be active (FFM has not yet
+                    // re-synced the active output at this point). `ptr_output`
+                    // is always Some here: overscroll only accumulates when the
+                    // pre-clamp pointer was on an output.
+                    debug_assert!(
+                        ptr_output.is_some(),
+                        "edge overscroll fired with no pointer output"
+                    );
+                    if let Some(output) = &ptr_output {
+                        self.niri.layout.focus_output(output);
+                    }
+
+                    match edge_overscroll_dir(edge_overscroll_vec.0, edge_overscroll_vec.1) {
+                        Some(EdgeOverscrollDir::Right) => self.niri.layout.focus_right(),
+                        Some(EdgeOverscrollDir::Left) => self.niri.layout.focus_left(),
+                        Some(EdgeOverscrollDir::Down) => self.niri.layout.switch_workspace_down(),
+                        Some(EdgeOverscrollDir::Up) => self.niri.layout.switch_workspace_up(),
+                        None => {}
+                    }
+                    self.niri.layer_shell_on_demand_focus = None;
+                }
+            } else {
+                // Suppressed or pointer back inside: reset for the next push.
+                self.niri.edge_overscroll_accum = 0.0;
+                self.niri.edge_overscroll_latched = false;
             }
         }
 
@@ -2617,7 +2733,8 @@ impl State {
             }
         }
 
-        self.niri.handle_focus_follows_mouse(&under);
+        self.niri
+            .handle_focus_follows_mouse(&under);
 
         self.niri.pointer_contents.clone_from(&under);
 
@@ -2717,6 +2834,12 @@ impl State {
         }
 
         let under = self.niri.contents_under(pos);
+
+        // Absolute positioning can't overscroll a screen edge; clear any
+        // in-progress edge overscroll so a device switch mid-push can't carry stale
+        // accumulation into the next relative-motion event.
+        self.niri.edge_overscroll_accum = 0.0;
+        self.niri.edge_overscroll_latched = false;
 
         self.niri.handle_focus_follows_mouse(&under);
 
@@ -5275,6 +5398,23 @@ mod tests {
 
     use super::*;
     use crate::animation::Clock;
+
+    #[test]
+    fn edge_overscroll_dir_dominant_axis_and_signs() {
+        // Y-down: +x right, -x left, +y down (workspace), -y up.
+        assert_eq!(edge_overscroll_dir(10.0, 0.0), Some(EdgeOverscrollDir::Right));
+        assert_eq!(edge_overscroll_dir(-10.0, 0.0), Some(EdgeOverscrollDir::Left));
+        assert_eq!(edge_overscroll_dir(0.0, 10.0), Some(EdgeOverscrollDir::Down));
+        assert_eq!(edge_overscroll_dir(0.0, -10.0), Some(EdgeOverscrollDir::Up));
+        // Dominant axis wins.
+        assert_eq!(edge_overscroll_dir(9.0, -3.0), Some(EdgeOverscrollDir::Right));
+        assert_eq!(edge_overscroll_dir(-2.0, 8.0), Some(EdgeOverscrollDir::Down));
+        // Ties favour horizontal (column) over vertical (workspace).
+        assert_eq!(edge_overscroll_dir(5.0, 5.0), Some(EdgeOverscrollDir::Right));
+        assert_eq!(edge_overscroll_dir(-5.0, -5.0), Some(EdgeOverscrollDir::Left));
+        // Zero vector → no action.
+        assert_eq!(edge_overscroll_dir(0.0, 0.0), None);
+    }
 
     #[test]
     fn bindings_suppress_keys() {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -131,34 +131,26 @@ impl<D: SeatHandler + TabletSeatHandler> AnyStartData<D> {
     }
 }
 
-/// Adjacent target a true-screen-edge overscroll points at. The overscroll vector
-/// is `(pre - clamped)` in compositor coords (Y-down): `+x` past the right
-/// edge, `-x` past the left, `+y` past the bottom, `-y` past the top. The
-/// dominant axis wins; ties favour horizontal (column) over vertical
-/// (workspace). `None` only for a zero vector (never happens when the caller
-/// gates on `edge_overscroll_px > 0`).
+/// Adjacent column a true-screen-edge overscroll points at. The overscroll
+/// vector is `(pre - clamped)` in compositor coords (Y-down): `+x` past the
+/// right edge, `-x` past the left. The gesture is horizontal only — it pans
+/// between columns on the current workspace and never switches workspaces —
+/// so a push whose vertical component dominates yields `None`, as does a zero
+/// vector. Ties (`|dx| == |dy|`) count as horizontal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EdgeOverscrollDir {
     Left,
     Right,
-    Up,
-    Down,
 }
 
 fn edge_overscroll_dir(dx: f64, dy: f64) -> Option<EdgeOverscrollDir> {
-    if dx == 0.0 && dy == 0.0 {
+    if dx == 0.0 || dx.abs() < dy.abs() {
         return None;
     }
-    Some(if dx.abs() >= dy.abs() {
-        if dx > 0.0 {
-            EdgeOverscrollDir::Right
-        } else {
-            EdgeOverscrollDir::Left
-        }
-    } else if dy > 0.0 {
-        EdgeOverscrollDir::Down
+    Some(if dx > 0.0 {
+        EdgeOverscrollDir::Right
     } else {
-        EdgeOverscrollDir::Up
+        EdgeOverscrollDir::Left
     })
 }
 
@@ -2569,9 +2561,8 @@ impl State {
         }
 
         // How far the motion was clipped away by a true screen edge this
-        // event (0 when the pointer stayed on an output). This is the
+        // event ((0, 0) when the pointer stayed on an output). This is the
         // deliberate "pushing past the edge" signal the edge overscroll gates on.
-        let mut edge_overscroll_px = 0.0;
         let mut edge_overscroll_vec = (0.0_f64, 0.0_f64);
 
         if self
@@ -2594,8 +2585,6 @@ impl State {
                     .y
                     .clamp(geom.loc.y as f64, (geom.loc.y + geom.size.h - 1) as f64);
                 edge_overscroll_vec = (pre.x - new_pos.x, pre.y - new_pos.y);
-                edge_overscroll_px =
-                    (edge_overscroll_vec.0.powi(2) + edge_overscroll_vec.1.powi(2)).sqrt();
             } else {
                 // The pointer was not on any output in the first place. Find one for it.
                 // Let's do the simple thing and just put it on the first output.
@@ -2605,10 +2594,11 @@ impl State {
             }
         }
 
-        // True-screen-edge overscroll → pan focus to the adjacent column /
-        // workspace. Deliberate by construction: the cursor is pinned at a
-        // hard screen edge and you must keep shoving past it — that can't
-        // happen by accident, so there is no time delay and no heuristic.
+        // True-screen-edge overscroll → pan focus to the adjacent column on
+        // the current workspace. Deliberate by construction: the cursor is
+        // pinned at a hard screen edge and you must keep shoving past it —
+        // that can't happen by accident, so there is no time delay and no
+        // heuristic.
         {
             let threshold = self
                 .niri
@@ -2630,6 +2620,9 @@ impl State {
                 .and_then(|o| self.niri.layout.monitor_for_output(o))
                 .is_some_and(|m| m.active_workspace_ref().is_active_pending_fullscreen());
 
+            // Horizontal only: `dir` is None for a vertical-dominant push, so
+            // shoving past the top/bottom edge does nothing.
+            //
             // Suppress when the overscroll direction points at a reachable
             // monitor neighbor: that's an inner edge between adjacent monitors,
             // not a true screen edge, and the user is trying to move the cursor
@@ -2642,16 +2635,8 @@ impl State {
             // toward the neighbor.
             let dir = edge_overscroll_dir(edge_overscroll_vec.0, edge_overscroll_vec.1);
             let has_neighbor_in_dir = match (dir, ptr_output.as_ref()) {
-                (Some(EdgeOverscrollDir::Left), Some(o)) => {
-                    self.niri.output_left_of(o).is_some()
-                }
-                (Some(EdgeOverscrollDir::Right), Some(o)) => {
-                    self.niri.output_right_of(o).is_some()
-                }
-                (Some(EdgeOverscrollDir::Up), Some(o)) => self.niri.output_up_of(o).is_some(),
-                (Some(EdgeOverscrollDir::Down), Some(o)) => {
-                    self.niri.output_down_of(o).is_some()
-                }
+                (Some(EdgeOverscrollDir::Left), Some(o)) => self.niri.output_left_of(o).is_some(),
+                (Some(EdgeOverscrollDir::Right), Some(o)) => self.niri.output_right_of(o).is_some(),
                 _ => false,
             };
 
@@ -2662,7 +2647,8 @@ impl State {
             // reset in those states so it can't fire stale the instant the
             // state clears.
             let pointer = self.niri.seat.get_pointer().unwrap();
-            let active = threshold > 0.0
+            let active = dir.is_some()
+                && threshold > 0.0
                 && !pointer.is_grabbed()
                 && pointer_confined.is_none()
                 && !self.niri.is_locked()
@@ -2672,9 +2658,11 @@ impl State {
                 && !on_fullscreen
                 && !has_neighbor_in_dir;
 
-            if active && edge_overscroll_px > 0.0 {
-                self.niri.edge_overscroll_accum += edge_overscroll_px;
-                if !self.niri.edge_overscroll_latched && self.niri.edge_overscroll_accum >= threshold {
+            if active {
+                self.niri.edge_overscroll_accum += edge_overscroll_vec.0.abs();
+                if !self.niri.edge_overscroll_latched
+                    && self.niri.edge_overscroll_accum >= threshold
+                {
                     self.niri.edge_overscroll_latched = true;
 
                     // Act on the monitor the pointer is overscrolling, not
@@ -2693,8 +2681,6 @@ impl State {
                     match dir {
                         Some(EdgeOverscrollDir::Right) => self.niri.layout.focus_right(),
                         Some(EdgeOverscrollDir::Left) => self.niri.layout.focus_left(),
-                        Some(EdgeOverscrollDir::Down) => self.niri.layout.switch_workspace_down(),
-                        Some(EdgeOverscrollDir::Up) => self.niri.layout.switch_workspace_up(),
                         None => {}
                     }
                     self.niri.layer_shell_on_demand_focus = None;
@@ -5426,18 +5412,39 @@ mod tests {
     use crate::animation::Clock;
 
     #[test]
-    fn edge_overscroll_dir_dominant_axis_and_signs() {
-        // Y-down: +x right, -x left, +y down (workspace), -y up.
-        assert_eq!(edge_overscroll_dir(10.0, 0.0), Some(EdgeOverscrollDir::Right));
-        assert_eq!(edge_overscroll_dir(-10.0, 0.0), Some(EdgeOverscrollDir::Left));
-        assert_eq!(edge_overscroll_dir(0.0, 10.0), Some(EdgeOverscrollDir::Down));
-        assert_eq!(edge_overscroll_dir(0.0, -10.0), Some(EdgeOverscrollDir::Up));
-        // Dominant axis wins.
-        assert_eq!(edge_overscroll_dir(9.0, -3.0), Some(EdgeOverscrollDir::Right));
-        assert_eq!(edge_overscroll_dir(-2.0, 8.0), Some(EdgeOverscrollDir::Down));
-        // Ties favour horizontal (column) over vertical (workspace).
-        assert_eq!(edge_overscroll_dir(5.0, 5.0), Some(EdgeOverscrollDir::Right));
-        assert_eq!(edge_overscroll_dir(-5.0, -5.0), Some(EdgeOverscrollDir::Left));
+    fn edge_overscroll_dir_horizontal_only() {
+        // Y-down: +x right, -x left.
+        assert_eq!(
+            edge_overscroll_dir(10.0, 0.0),
+            Some(EdgeOverscrollDir::Right)
+        );
+        assert_eq!(
+            edge_overscroll_dir(-10.0, 0.0),
+            Some(EdgeOverscrollDir::Left)
+        );
+        // Horizontal-dominant diagonals still pan columns.
+        assert_eq!(
+            edge_overscroll_dir(9.0, -3.0),
+            Some(EdgeOverscrollDir::Right)
+        );
+        assert_eq!(
+            edge_overscroll_dir(-9.0, 3.0),
+            Some(EdgeOverscrollDir::Left)
+        );
+        // Ties count as horizontal.
+        assert_eq!(
+            edge_overscroll_dir(5.0, 5.0),
+            Some(EdgeOverscrollDir::Right)
+        );
+        assert_eq!(
+            edge_overscroll_dir(-5.0, -5.0),
+            Some(EdgeOverscrollDir::Left)
+        );
+        // Vertical pushes never act: workspace panning is gone.
+        assert_eq!(edge_overscroll_dir(0.0, 10.0), None);
+        assert_eq!(edge_overscroll_dir(0.0, -10.0), None);
+        assert_eq!(edge_overscroll_dir(-2.0, 8.0), None);
+        assert_eq!(edge_overscroll_dir(3.0, -9.0), None);
         // Zero vector → no action.
         assert_eq!(edge_overscroll_dir(0.0, 0.0), None);
     }
@@ -5456,8 +5463,8 @@ mod tests {
         //
         // The fix is structural (the `has_neighbor_in_dir` check in
         // on_pointer_motion uses Niri::output_right_of to detect M2). This
-        // test pins the math so a tie-break or sign change can't silently
-        // flip Right ↔ Up here and re-open the bug.
+        // test pins the math so an axis or sign change can't silently stop
+        // reporting Right here and re-open the bug.
         let geo = Rectangle::<i32, Logical>::new(
             Point::from((0, 0)),
             smithay::utils::Size::from((1920, 1080)),
@@ -5474,7 +5481,7 @@ mod tests {
         assert_eq!((dx, dy), (16.0, -5.0));
 
         // Dominant axis is horizontal (Right). On a horizontal multi-monitor
-        // setup the on_pointer_motion gate suppresses for this direction
+        // setup the on_pointer_motion gate suppresses this direction
         // because output_right_of(M1) returns Some(M2).
         assert_eq!(edge_overscroll_dir(dx, dy), Some(EdgeOverscrollDir::Right));
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -651,6 +651,17 @@ impl HitType {
             .map(|hit| (tile.window(), hit.offset_win_pos(tile_pos)))
     }
 
+    /// Like `hit_tile()`, but clipped to the tile's activation region.
+    pub fn hit_tile_within_activation_region<W: LayoutElement>(
+        tile: &Tile<W>,
+        tile_pos: Point<f64, Logical>,
+        point: Point<f64, Logical>,
+    ) -> Option<(&W, Self)> {
+        let pos_within_tile = point - tile_pos;
+        tile.hit_within_activation_region(pos_within_tile)
+            .map(|hit| (tile.window(), hit.offset_win_pos(tile_pos)))
+    }
+
     pub fn to_activate(self) -> Self {
         match self {
             HitType::Input { .. } => HitType::Activate {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -3042,6 +3042,27 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 // Round to physical pixels.
                 let tile_pos = tile_pos.to_physical_precise_round(scale).to_logical(scale);
 
+                // Prefer hits within the activation region so CSD shadows can't steal
+                // hits from adjacent tiles (e.g. peeking columns in strut zones).
+                if let Some(rv) =
+                    HitType::hit_tile_within_activation_region(tile, tile_pos, pos)
+                {
+                    return Some(rv);
+                }
+            }
+        }
+
+        // Fall back to CSD input regions extending beyond tile bounds (shadows, resize
+        // handles, GTK 3 subsurface popups) so normal pointer input still reaches them.
+        for (col, col_pos) in self.columns_with_render_positions() {
+            for (tile, tile_off, visible) in col.tiles_in_render_order() {
+                if !visible {
+                    continue;
+                }
+
+                let tile_pos = col_pos + tile_off + tile.render_offset();
+                let tile_pos = tile_pos.to_physical_precise_round(scale).to_logical(scale);
+
                 if let Some(rv) = HitType::hit_tile(tile, tile_pos, pos) {
                     return Some(rv);
                 }

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4082,6 +4082,16 @@ impl<W: LayoutElement> Column<W> {
     ) {
         let mut update_sizes = false;
 
+        // Animate the tile resize only when the available area changed on its own
+        // (e.g. a layer-shell exclusive zone like a bar toggling, or struts
+        // changing) while the output geometry stayed put. parent_area is the
+        // layer-zone-aware area handed down from the workspace, so it moves on a
+        // bar toggle too. Output resolution or scale changes still snap, since
+        // animating those looks wrong.
+        let area_changed =
+            self.working_area != working_area || self.parent_area != parent_area;
+        let size_or_scale_changed = self.view_size != view_size || self.scale != scale;
+
         if self.view_size != view_size
             || self.working_area != working_area
             || self.parent_area != parent_area
@@ -4128,7 +4138,7 @@ impl<W: LayoutElement> Column<W> {
         self.options = options;
 
         if update_sizes {
-            self.update_tile_sizes(false);
+            self.update_tile_sizes(area_changed && !size_or_scale_changed);
         }
     }
 

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -919,6 +919,27 @@ impl<W: LayoutElement> Tile<W> {
         activation_region.contains(point)
     }
 
+    /// Like `hit()`, but only returns a result if the point is within the tile's activation
+    /// region (i.e. within tile bounds). This prevents CSD input regions (shadows, resize handles)
+    /// from claiming hits outside the tile.
+    pub fn hit_within_activation_region(&self, point: Point<f64, Logical>) -> Option<HitType> {
+        let offset = self.bob_offset();
+        let point = point - offset;
+
+        if self.is_in_activation_region(point) {
+            if self.is_in_input_region(point) {
+                let win_pos = self.buf_loc() + offset;
+                Some(HitType::Input { win_pos })
+            } else {
+                Some(HitType::Activate {
+                    is_tab_indicator: false,
+                })
+            }
+        } else {
+            None
+        }
+    }
+
     pub fn hit(&self, point: Point<f64, Logical>) -> Option<HitType> {
         let offset = self.bob_offset();
         let point = point - offset;

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1787,7 +1787,7 @@ impl<W: LayoutElement> Workspace<W> {
 
                 let pos_within_tile = pos - tile_pos;
 
-                if tile.hit(pos_within_tile).is_some() {
+                if tile.hit_within_activation_region(pos_within_tile).is_some() {
                     let size = tile.tile_size().to_f64();
 
                     let mut edges = ResizeEdge::empty();

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -359,6 +359,14 @@ pub struct Niri {
     pub pointer_contents: PointContents,
     pub pointer_visibility: PointerVisibility,
     pub pointer_inactivity_timer: Option<RegistrationToken>,
+    /// True-screen-edge overscroll accumulator (px): grows while the pointer is
+    /// pushing past a hard screen edge with no adjacent output, resets to 0
+    /// once the pointer is back inside. Crossing the configured threshold
+    /// pans focus to the adjacent column/workspace.
+    pub edge_overscroll_accum: f64,
+    /// Latched after an edge overscroll fired; blocks repeat fires until the pointer
+    /// leaves the edge (accumulator resets).
+    pub edge_overscroll_latched: bool,
     /// Whether the pointer inactivity timer got reset this event loop iteration.
     ///
     /// Used for limiting the reset to once per iteration, so that it's not spammed with high
@@ -1453,6 +1461,11 @@ impl State {
         };
 
         self.niri.config_error_notification.hide();
+
+        // Reset any in-progress edge overscroll so it can't fire with stale intent
+        // across a config reload.
+        self.niri.edge_overscroll_accum = 0.0;
+        self.niri.edge_overscroll_latched = false;
 
         // Find & orphan removed named workspaces.
         let mut removed_workspaces: Vec<String> = vec![];
@@ -2608,6 +2621,8 @@ impl Niri {
             pointer_contents: PointContents::default(),
             pointer_visibility: PointerVisibility::Visible,
             pointer_inactivity_timer: None,
+            edge_overscroll_accum: 0.0,
+            edge_overscroll_latched: false,
             pointer_inactivity_timer_got_reset: false,
             notified_activity_this_iteration: false,
             pointer_inside_hot_corner: false,
@@ -6252,12 +6267,20 @@ impl Niri {
                     return;
                 }
 
+                let scroll_amount = self.layout.scroll_amount_to_activate(window);
+
                 if let Some(threshold) = ffm.max_scroll_amount {
-                    if self.layout.scroll_amount_to_activate(window) > threshold.0 {
+                    if scroll_amount > threshold.0 {
                         return;
                     }
                 }
 
+                // Stock behavior: activate immediately. With left/right struts
+                // removed there is no off-screen sliver under the pointer, so
+                // this only ever fires for windows already on screen — no
+                // accidental edge focus changes. Deliberate panning to an
+                // off-screen column is handled by true-screen-edge overscroll
+                // (see `edge_overscroll_*` in on_pointer_motion).
                 self.layout.activate_window_without_raising(window);
                 self.layer_shell_on_demand_focus = None;
             }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -360,9 +360,9 @@ pub struct Niri {
     pub pointer_visibility: PointerVisibility,
     pub pointer_inactivity_timer: Option<RegistrationToken>,
     /// True-screen-edge overscroll accumulator (px): grows while the pointer is
-    /// pushing past a hard screen edge with no adjacent output, resets to 0
-    /// once the pointer is back inside. Crossing the configured threshold
-    /// pans focus to the adjacent column/workspace.
+    /// pushing past a hard left/right screen edge with no adjacent output,
+    /// resets to 0 once the pointer is back inside. Crossing the configured
+    /// threshold pans focus to the adjacent column on the same workspace.
     pub edge_overscroll_accum: f64,
     /// Latched after an edge overscroll fired; blocks repeat fires until the pointer
     /// leaves the edge (accumulator resets).


### PR DESCRIPTION
## What & why

Scrollable-tiling mouse users currently pan between off-screen columns via `focus-follows-mouse` with `max-scroll-amount="100%"` plus left/right `struts` that leave a sliver of the neighbour visible. That has two problems:

1. **It can't work without struts.** A maximized column hides adjacent windows entirely, so there's no sliver for FFM to land on — you simply can't mouse-pan.
2. **It's accident-prone and toolkit-dependent.** At `100%`, FFM activates a neighbour the instant *anything* of it is under the cursor — a strut sliver, or a CSD client's shadow/overflow region (Spotify/Firefox/Electron draw them, SSD apps like Alacritty don't). Brushing the edge swaps columns; behaviour varies per toolkit.

This PR adds an explicit, opt-in gesture: **`gestures { edge-overscroll { resistance N } }`**. Push the pointer *past* a true screen edge (a hard edge with no adjacent output, so motion is clipped); the clipped over-travel accumulates and, once it crosses `resistance` logical px, performs **one discrete** focus step — adjacent column (L/R) or workspace (U/D).

Because the pointer is pinned at a hard edge, incidental contact accumulates only a few px and can't trigger it — no timer, no heuristic. Combined with `focus-follows-mouse max-scroll-amount="0%"` and **no** left/right struts, this gives reliable, deliberate, toolkit-independent edge panning that reclaims the strut screen estate. Tuned with `resistance` to taste against accidental swaps; `0`/absent disables it (default — zero behaviour change for existing configs).

This is intentionally **not** `dnd-edge-*`: those are DnD-only, proximity-band, continuous auto-scroll. This is non-drag, true-edge, single-step, FFM-independent — disjoint from existing gestures, hence a new sibling under `gestures {}`.

## Two commits (stacked, please take both)

1. **`fix: prioritize activation region hits over CSD overflow in scrolling hit testing`** — prerequisite. Under heavy CSD app usage the gesture (and click/activation generally) misbehaves because a CSD client's shadow/overflow steals the hit before the real activation region. This makes scrolling hit-testing prefer the activation region before falling back to CSD overflow. It's an independent correctness fix but is required for the feature to behave consistently across toolkits.
2. **`gestures: edge-overscroll …`** — the feature: config (`niri-config` knuffel + merge + snapshot), the `on_pointer_motion` true-edge clip → accumulate → latch logic, direction resolver, state reset paths, and wiki docs.

## Suppression / safety

Never fires while: session locked, overview/screenshot/MRU UIs open, pointer grab or pointer constraint active, or on a fullscreen window (leaving fullscreen must be explicit). Acts on the monitor the cursor is actually on; fires once per excursion and re-arms when the cursor returns inside the outputs. State resets on config reload and absolute-motion path.

## Testing

- `cargo test -p niri-config` green incl. new `parse_edge_overscroll` (knuffel parse + merge) and updated parse snapshot.
- `edge_overscroll_dir` unit test (dominant-axis + sign resolution) green.
- `cargo run -- validate` clean.
- Daily-driven for weeks on a 2-monitor setup (ultrawide + 1080p, mixed scale) across CSD-heavy apps (Spotify/Firefox/Electron OWAs) and SSD (Alacritty) — consistent behaviour, no accidental swaps at `resistance ~200`.

Docs added to the Gestures wiki page; the Input wiki cross-links to it. `Since:` placeholder is `next release` — happy to set a concrete version on request.
