### PR TITLE
Add XF86AudioPause media key mapping

### DIFF
--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -383,6 +383,7 @@ binds {
     // Example media keys mapping using playerctl.
     // This will work with any MPRIS-enabled media player.
     XF86AudioPlay        allow-when-locked=true { spawn-sh "playerctl play-pause"; }
+    XF86AudioPause       allow-when-locked=true { spawn-sh "playerctl play-pause"; }
     XF86AudioStop        allow-when-locked=true { spawn-sh "playerctl stop"; }
     XF86AudioPrev        allow-when-locked=true { spawn-sh "playerctl previous"; }
     XF86AudioNext        allow-when-locked=true { spawn-sh "playerctl next"; }


### PR DESCRIPTION
Some Bluetooth earbuds send alternating XF86AudioPlay/XF86AudioPause keycodes on the same physical press. Without a binding for XF86AudioPause, every other press is dropped, making playback toggle unreliable.