### PR TITLE
feat: add focus-on-activate window rule

### DIFF
--- a/docs/wiki/Configuration:-Debug-Options.md
+++ b/docs/wiki/Configuration:-Debug-Options.md
@@ -283,6 +283,8 @@ Most of the time, these fresh tokens will have invalid serials, because the app 
 By default, niri ignores xdg-activation tokens with invalid serials, to prevent windows from randomly stealing focus.
 This debug flag makes niri honor such tokens, making the aforementioned widely-used apps get focus when clicking on their tray icon or notification.
 
+Use the [`focus-on-xdg-activate` window rule](./Configuration:-Window-Rules.md#focus-on-xdg-activate) to control whether individual windows receive focus for accepted xdg-activation requests.
+
 Amusingly, clicking on a notification sends the app a perfectly valid activation token from the notification daemon, but these apps seem to simply ignore it.
 Maybe in the future these apps/toolkits (Electron, Qt) are fixed, making this debug flag unnecessary.
 

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -58,6 +58,7 @@ window-rule {
     default-column-display "tabbed"
     default-floating-position x=100 y=200 relative-to="bottom-left"
     scroll-factor 0.75
+    focus-on-activate true
 
     focus-ring {
         // off
@@ -593,6 +594,25 @@ window-rule {
 >
 > This is because window title (and app ID) are not double-buffered in the Wayland protocol, so they are not tied to specific window contents.
 > There's no robust way for Firefox to synchronize visibly showing a different tab and changing the window title.
+
+#### `focus-on-activate`
+
+<sup>Since: next release</sup>
+
+Set this to `false` to prevent the window from receiving focus when it requests activation.
+This is useful for apps that steal focus on incoming messages or when opening popup windows like Picture-in-Picture.
+
+When set to `false`, the window will instead be marked as urgent.
+
+```kdl
+// Don't let Firefox PiP steal focus.
+window-rule {
+    match title="^Picture-in-Picture$"
+
+    open-floating true
+    focus-on-activate false
+}
+```
 
 #### `opacity`
 

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -58,6 +58,7 @@ window-rule {
     default-column-display "tabbed"
     default-floating-position x=100 y=200 relative-to="bottom-left"
     scroll-factor 0.75
+    focus-on-xdg-activate true
 
     focus-ring {
         // off
@@ -593,6 +594,25 @@ window-rule {
 >
 > This is because window title (and app ID) are not double-buffered in the Wayland protocol, so they are not tied to specific window contents.
 > There's no robust way for Firefox to synchronize visibly showing a different tab and changing the window title.
+
+#### `focus-on-xdg-activate`
+
+<sup>Since: next release</sup>
+
+Set this to `false` to prevent the window from receiving focus when it requests activation.
+This is useful for apps that steal focus on incoming messages or when opening popup windows like Picture-in-Picture.
+
+When set to `false`, the window will instead be marked as urgent.
+
+```kdl
+// Don't let Firefox PiP steal focus.
+window-rule {
+    match title="^Picture-in-Picture$"
+
+    open-floating true
+    focus-on-xdg-activate false
+}
+```
 
 #### `opacity`
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1792,6 +1792,7 @@ mod tests {
                     open_focused: Some(
                         true,
                     ),
+                    focus_on_activate: None,
                     min_width: None,
                     min_height: None,
                     max_width: None,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1792,6 +1792,7 @@ mod tests {
                     open_focused: Some(
                         true,
                     ),
+                    focus_on_xdg_activate: None,
                     min_width: None,
                     min_height: None,
                     max_width: None,

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -34,6 +34,8 @@ pub struct WindowRule {
     pub open_floating: Option<bool>,
     #[knuffel(child, unwrap(argument))]
     pub open_focused: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub focus_on_activate: Option<bool>,
 
     // Rules applied dynamically.
     #[knuffel(child, unwrap(argument))]

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -34,6 +34,8 @@ pub struct WindowRule {
     pub open_floating: Option<bool>,
     #[knuffel(child, unwrap(argument))]
     pub open_focused: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub focus_on_xdg_activate: Option<bool>,
 
     // Rules applied dynamically.
     #[knuffel(child, unwrap(argument))]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -75,6 +75,7 @@ use smithay::{
 pub use crate::handlers::xdg_shell::KdeDecorationsModeState;
 use crate::layout::workspace::WorkspaceId;
 use crate::layout::ActivateWindow;
+use crate::layout::LayoutElement;
 use crate::niri::{DndIcon, NewClient, State};
 use crate::protocols::ext_workspace::{self, ExtWorkspaceHandler, ExtWorkspaceManagerState};
 use crate::protocols::foreign_toplevel::{
@@ -824,7 +825,9 @@ impl XdgActivationHandler for State {
         if token_data.timestamp.elapsed() < XDG_ACTIVATION_TOKEN_TIMEOUT {
             if let Some((mapped, _)) = self.niri.layout.find_window_and_output_mut(&surface) {
                 let window = mapped.window.clone();
-                if token_data.user_data.get::<UrgentOnlyMarker>().is_some() {
+                if token_data.user_data.get::<UrgentOnlyMarker>().is_some()
+                    || mapped.rules().focus_on_activate == Some(false)
+                {
                     mapped.set_urgent(true);
                     self.niri.queue_redraw_all();
                 } else {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -74,7 +74,7 @@ use smithay::{
 
 pub use crate::handlers::xdg_shell::KdeDecorationsModeState;
 use crate::layout::workspace::WorkspaceId;
-use crate::layout::ActivateWindow;
+use crate::layout::{ActivateWindow, LayoutElement};
 use crate::niri::{DndIcon, NewClient, State};
 use crate::protocols::ext_workspace::{self, ExtWorkspaceHandler, ExtWorkspaceManagerState};
 use crate::protocols::foreign_toplevel::{
@@ -824,7 +824,9 @@ impl XdgActivationHandler for State {
         if token_data.timestamp.elapsed() < XDG_ACTIVATION_TOKEN_TIMEOUT {
             if let Some((mapped, _)) = self.niri.layout.find_window_and_output_mut(&surface) {
                 let window = mapped.window.clone();
-                if token_data.user_data.get::<UrgentOnlyMarker>().is_some() {
+                if token_data.user_data.get::<UrgentOnlyMarker>().is_some()
+                    || mapped.rules().focus_on_xdg_activate == Some(false)
+                {
                     mapped.set_urgent(true);
                     self.niri.queue_redraw_all();
                 } else {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -73,6 +73,9 @@ pub struct ResolvedWindowRules {
     /// Whether the window should open focused.
     pub open_focused: Option<bool>,
 
+    /// Whether the window should receive focus on xdg-activation requests.
+    pub focus_on_activate: Option<bool>,
+
     /// Extra bound on the minimum window width.
     pub min_width: Option<u16>,
     /// Extra bound on the minimum window height.
@@ -255,6 +258,10 @@ impl ResolvedWindowRules {
 
                 if let Some(x) = rule.open_focused {
                     resolved.open_focused = Some(x);
+                }
+
+                if let Some(x) = rule.focus_on_activate {
+                    resolved.focus_on_activate = Some(x);
                 }
 
                 if let Some(x) = rule.min_width {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -73,6 +73,9 @@ pub struct ResolvedWindowRules {
     /// Whether the window should open focused.
     pub open_focused: Option<bool>,
 
+    /// Whether the window should receive focus on xdg-activation requests.
+    pub focus_on_xdg_activate: Option<bool>,
+
     /// Extra bound on the minimum window width.
     pub min_width: Option<u16>,
     /// Extra bound on the minimum window height.
@@ -255,6 +258,10 @@ impl ResolvedWindowRules {
 
                 if let Some(x) = rule.open_focused {
                     resolved.open_focused = Some(x);
+                }
+
+                if let Some(x) = rule.focus_on_xdg_activate {
+                    resolved.focus_on_xdg_activate = Some(x);
                 }
 
                 if let Some(x) = rule.min_width {


### PR DESCRIPTION
Add focus-on-activate dynamic window rule that controls whether
a window receives focus when it requests activation via xdg-activation.

When set to false, activation requests downgrade to urgent-only:
the window is marked urgent instead of stealing focus.

Useful for Firefox PiP, Telegram, and other apps that steal focus
on incoming messages or popup windows.

Closes: #2937
Refs: #2120