### PR TITLE
fix: warp mouse when switching between recent windows

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -992,6 +992,7 @@ impl State {
 
     pub fn confirm_mru(&mut self) {
         if let Some(window) = self.niri.close_mru(MruCloseRequest::Confirm) {
+            self.update_keyboard_focus();
             self.focus_window(&window);
         }
     }


### PR DESCRIPTION
This is a super simple fix.

Currently, if you were to use the recent windows to switch between windows, while also having `warp-mouse-to-focus`, your mouse doesn't actually move to that window, it stays as is. This one line fix solves it.

before:

https://github.com/user-attachments/assets/b0bc0a96-9a71-4475-884e-a57677c86c81

after:


https://github.com/user-attachments/assets/09a5b2fa-1ec8-4710-b2b5-e104e95ac8f7

<sub>i'm pressing alt+tab here, it just gets debounced because of how fast i was pressing it</sub>

pretty new to rust, hopefully this is fine