### PR TITLE
ipc: expose workspace scrolling view position

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1437,7 +1437,7 @@ pub enum OutputConfigChanged {
 }
 
 /// A workspace.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Workspace {
     /// Unique id of this workspace.
@@ -1475,6 +1475,23 @@ pub struct Workspace {
     pub is_focused: bool,
     /// Id of the active window on this workspace, if any.
     pub active_window_id: Option<u64>,
+    /// Horizontal scroll position of the workspace's scrolling layout, in logical pixels.
+    ///
+    /// This is the x coordinate, within the scrolling layout's coordinate space, of the left edge
+    /// of the workspace view. The leftmost edge of column 1 is at x = 0; gaps between columns
+    /// count toward the offset. The value reflects the resting (target) view position, so it
+    /// updates on logical navigation steps (focus changes, gestures) rather than per animation
+    /// frame.
+    ///
+    /// In practice the value is usually negative: niri leaves a `gaps`-sized space to the left of
+    /// column 1, plus additional offset when the active column is centered
+    /// (`center-focused-column`).
+    ///
+    /// Clients can use this together with the column widths and tile heights from
+    /// [`WindowLayout::tile_size`] (and [`WindowLayout::pos_in_scrolling_layout`]) to compute a
+    /// scrolling tile's position within the workspace view: subtract `scrolling_view_pos` from the
+    /// tile's x in the scrolling layout.
+    pub scrolling_view_pos: f64,
 }
 
 /// Configured keyboard layouts.
@@ -1637,6 +1654,17 @@ pub enum Event {
         workspace_id: u64,
         /// Id of the new active window, if any.
         active_window_id: Option<u64>,
+    },
+    /// The horizontal scroll position of a workspace's scrolling layout changed.
+    ///
+    /// This is emitted when the resting (target) view position changes — e.g. on focus moves
+    /// between columns, after a touchpad swipe settles, or while a gesture is being driven.
+    /// Per-animation-frame interpolation is not reported, to avoid IPC spam.
+    WorkspaceViewPosChanged {
+        /// Id of the workspace whose view position changed.
+        workspace_id: u64,
+        /// The new horizontal scroll position; see [`Workspace::scrolling_view_pos`].
+        view_pos: f64,
     },
     /// The window configuration has changed.
     WindowsChanged {

--- a/niri-ipc/src/state.rs
+++ b/niri-ipc/src/state.rs
@@ -158,6 +158,14 @@ impl EventStreamStatePart for WorkspacesState {
                 let ws = ws.expect("changed workspace was missing from the map");
                 ws.active_window_id = active_window_id;
             }
+            Event::WorkspaceViewPosChanged {
+                workspace_id,
+                view_pos,
+            } => {
+                let ws = self.workspaces.get_mut(&workspace_id);
+                let ws = ws.expect("changed workspace was missing from the map");
+                ws.scrolling_view_pos = view_pos;
+            }
             event => return Some(event),
         }
         None
@@ -319,5 +327,40 @@ impl EventStreamStatePart for CastsState {
             event => return Some(event),
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ws(id: u64, view_pos: f64) -> Workspace {
+        Workspace {
+            id,
+            idx: 1,
+            name: None,
+            output: None,
+            is_urgent: false,
+            is_active: true,
+            is_focused: true,
+            active_window_id: None,
+            scrolling_view_pos: view_pos,
+        }
+    }
+
+    #[test]
+    fn view_pos_changed_updates_only_the_named_workspace() {
+        let mut state = WorkspacesState::default();
+        state.apply(Event::WorkspacesChanged {
+            workspaces: vec![ws(1, 0.0), ws(2, 100.0)],
+        });
+
+        state.apply(Event::WorkspaceViewPosChanged {
+            workspace_id: 1,
+            view_pos: 250.5,
+        });
+
+        assert_eq!(state.workspaces[&1].scrolling_view_pos, 250.5);
+        assert_eq!(state.workspaces[&2].scrolling_view_pos, 100.0);
     }
 }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -447,6 +447,16 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                              active window changed to {active_window_id:?}"
                         );
                     }
+                    Event::WorkspaceViewPosChanged {
+                        workspace_id,
+                        view_pos,
+                    } => {
+                        println!(
+                            "Workspace {workspace_id}: \
+                             scrolling view position changed to {}",
+                            fmt_rounded(view_pos)
+                        );
+                    }
                     Event::WindowsChanged { windows } => {
                         println!("Windows changed: {windows:?}");
                     }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -631,6 +631,17 @@ impl State {
                 });
             }
 
+            // Check if this workspace's resting horizontal scroll position changed. This is
+            // intentionally a per-workspace event so a viewport move emits a single event for the
+            // workspace, instead of fanning out to one WindowLayout update per tile.
+            let scrolling_view_pos = ws.scrolling_view_pos();
+            if ipc_ws.scrolling_view_pos != scrolling_view_pos {
+                events.push(Event::WorkspaceViewPosChanged {
+                    workspace_id: id,
+                    view_pos: scrolling_view_pos,
+                });
+            }
+
             // Check if this workspace urgent state changed.
             let urgent = ws.is_urgent();
             if urgent != ipc_ws.is_urgent {
@@ -672,6 +683,7 @@ impl State {
                         is_active: mon.is_some_and(|mon| mon.active_workspace_idx() == ws_idx),
                         is_focused: Some(id) == focused_ws_id,
                         active_window_id: ws.active_window().map(|win| win.id().get()),
+                        scrolling_view_pos: ws.scrolling_view_pos(),
                     }
                 })
                 .collect();

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1977,6 +1977,10 @@ impl<W: LayoutElement> Workspace<W> {
         self.layout_config.as_ref()
     }
 
+    pub fn scrolling_view_pos(&self) -> f64 {
+        self.scrolling.target_view_pos()
+    }
+
     #[cfg(test)]
     pub fn scrolling(&self) -> &ScrollingSpace<W> {
         &self.scrolling

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1985,6 +1985,10 @@ impl<W: LayoutElement> Workspace<W> {
         self.layout_config.as_ref()
     }
 
+    pub fn scrolling_view_pos(&self) -> f64 {
+        self.scrolling.target_view_pos()
+    }
+
     pub fn scrolling(&self) -> &ScrollingSpace<W> {
         &self.scrolling
     }


### PR DESCRIPTION
Closes #2381.

Posted the design in [#2381](https://github.com/niri-wm/niri/issues/2381#issuecomment-3079060) a week ago for early feedback; opening this PR to make it easier to review concretely. Happy to back out if the shape is wrong.

## Summary

Adds a per-workspace viewport offset to niri-ipc so clients can compute on-screen tile positions themselves, without niri fanning out per-tile geometry on every viewport move:

- `Workspace::scrolling_view_pos: f64` — x coordinate of the workspace view's left edge in scrolling-layout coordinate space. Uses `target_view_pos()`, so animation interpolation doesn't churn the value.
- `Event::WorkspaceViewPosChanged { workspace_id, view_pos }` — emitted from `ipc_refresh_workspaces` only when the resting value changes. One event per workspace per logical navigation step, regardless of tile count.

## Why this shape

#2381 asked for `tile_pos_in_workspace_view` on `WindowLayout` to be filled for scrolling tiles. @YaLTeR explained why per-tile fill is the wrong design:

> tile_pos_in_workspace_view in particular is likely not happening for tiled windows because resizing 1 window has to update this for all (potentially very many) windows to the right of it.

@jbms proposed the alternative in #3305:

> add a field to Workspace that specifies what the current viewport is and how it maps to the output coordinate space. That would also provide a natural way to integrate with the event stream without producing an excessive number of messages as you move the viewport.

This PR is that. It also lines up with @YaLTeR's "clients can compute on their own" direction from #1265 and @binarin's expanded request in #3305 (raw viewport info on workspaces, with widths/heights derivable from existing fields).

## How clients use it

To get a scrolling tile's position within the workspace view:

```
column_x      = sum of tile_size.0 across preceding columns (any tile per column)
tile_y_in_col = sum of tile_size.1 across preceding tiles in the same column
view_pos.x    = column_x - workspace.scrolling_view_pos
view_pos.y    = tile_y_in_col
```

`scrolling_view_pos` is usually negative — niri leaves a `gaps`-sized space to the left of column 1, plus more when the active column is centered (`center-focused-column`). The field doc spells this out.

Floating tiles continue to read from the existing `WindowLayout::tile_pos_in_workspace_view`.

## What this deliberately doesn't do

- **Per-tile workspace-view positions for scrolling tiles.** That's the cascading-update path the #2381 thread ruled out.
- **Overview-mode coordinate mapping.** Worth a follow-up via a separate optional field on `Workspace` as @jbms suggested in #3305.
- **Tabbed-column visibility.** Not exposed here; clients can infer from `pos_in_scrolling_layout`.

## Relationship to #3305

#3305 takes a complementary, pull-based approach: a one-shot `Request::WindowGeometries` returning per-window rects computed server-side. The two aren't mutually exclusive — a `niri msg window-geometries` convenience CLI built on top of this PR's primitives would address the same ergonomic gap for shell pipelines and `slurp`-style consumers. Suggest landing the primitives first and revisiting #3305 against them.

## Usage example

A working consumer: [kiryl/ashell @ feat/minimap-scrolling-view-pos](https://github.com/kiryl/ashell/tree/feat/minimap-scrolling-view-pos) implements a status-bar minimap module. The client-side reconstruction is in [`src/services/compositor/niri.rs`](https://github.com/kiryl/ashell/blob/feat/minimap-scrolling-view-pos/src/services/compositor/niri.rs) — one helper, ~50 lines.

<img width="387" height="59" alt="2026-05-29T10:07:53" src="https://github.com/user-attachments/assets/6808f164-0cdd-4193-81d5-595fafd0ad15" />

## Test plan

- niri-ipc unit tests pass, including a new test exercising `WorkspaceViewPosChanged` state application.
- `cargo clippy` and `cargo test` clean on the niri workspace.
- Drove the minimap against a local niri build: viewport movement emits one event per navigation step, the minimap updates accordingly, no per-tile IPC traffic on scroll.