### PR TITLE
feat: add opt-in layer open animations

### DIFF
--- a/docs/wiki/Configuration:-Animations.md
+++ b/docs/wiki/Configuration:-Animations.md
@@ -25,6 +25,11 @@ animations {
         curve "ease-out-expo"
     }
 
+    layer-open {
+        duration-ms 150
+        curve "ease-out-expo"
+    }
+
     window-close {
         duration-ms 150
         curve "ease-out-quad"
@@ -218,6 +223,22 @@ animations {
                 return color * niri_clamped_progress;
             }
         "
+    }
+}
+```
+
+#### `layer-open`
+
+Layer-shell surface opening animation.
+
+Layer-shell surfaces do not animate by default.
+Enable it for specific surfaces with the [`open-animation` layer rule](./Configuration:-Layer-Rules.md#open-animation).
+
+```kdl
+animations {
+    layer-open {
+        duration-ms 150
+        curve "ease-out-expo"
     }
 }
 ```

--- a/docs/wiki/Configuration:-Layer-Rules.md
+++ b/docs/wiki/Configuration:-Layer-Rules.md
@@ -35,6 +35,7 @@ layer-rule {
     geometry-corner-radius 12
     place-within-backdrop true
     baba-is-float true
+    open-animation true
 
     background-effect {
         xray true
@@ -225,6 +226,22 @@ layer-rule {
     match namespace="^launcher$"
 
     baba-is-float true
+}
+```
+
+#### `open-animation`
+
+Set to `true` to animate this layer surface opening.
+Layer surfaces do not animate by default.
+
+The timing is configured with [`animations.layer-open`](./Configuration:-Animations.md#layer-open).
+
+```kdl
+// Animate fuzzel opening.
+layer-rule {
+    match namespace="^launcher$"
+
+    open-animation true
 }
 ```
 

--- a/niri-config/src/animations.rs
+++ b/niri-config/src/animations.rs
@@ -10,6 +10,7 @@ pub struct Animations {
     pub slowdown: f64,
     pub workspace_switch: WorkspaceSwitchAnim,
     pub window_open: WindowOpenAnim,
+    pub layer_open: LayerOpenAnim,
     pub window_close: WindowCloseAnim,
     pub horizontal_view_movement: HorizontalViewMovementAnim,
     pub window_movement: WindowMovementAnim,
@@ -30,6 +31,7 @@ impl Default for Animations {
             horizontal_view_movement: Default::default(),
             window_movement: Default::default(),
             window_open: Default::default(),
+            layer_open: Default::default(),
             window_close: Default::default(),
             window_resize: Default::default(),
             config_notification_open_close: Default::default(),
@@ -53,6 +55,8 @@ pub struct AnimationsPart {
     pub workspace_switch: Option<WorkspaceSwitchAnim>,
     #[knuffel(child)]
     pub window_open: Option<WindowOpenAnim>,
+    #[knuffel(child)]
+    pub layer_open: Option<LayerOpenAnim>,
     #[knuffel(child)]
     pub window_close: Option<WindowCloseAnim>,
     #[knuffel(child)]
@@ -88,6 +92,7 @@ impl MergeWith<AnimationsPart> for Animations {
             (self, part),
             workspace_switch,
             window_open,
+            layer_open,
             window_close,
             horizontal_view_movement,
             window_movement,
@@ -169,6 +174,21 @@ impl Default for WindowOpenAnim {
             },
             custom_shader: None,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LayerOpenAnim(pub Animation);
+
+impl Default for LayerOpenAnim {
+    fn default() -> Self {
+        Self(Animation {
+            off: false,
+            kind: Kind::Easing(EasingParams {
+                duration_ms: 150,
+                curve: Curve::EaseOutExpo,
+            }),
+        })
     }
 }
 
@@ -394,6 +414,21 @@ where
             anim,
             custom_shader,
         })
+    }
+}
+
+impl<S> knuffel::Decode<S> for LayerOpenAnim
+where
+    S: knuffel::traits::ErrorSpan,
+{
+    fn decode_node(
+        node: &knuffel::ast::SpannedNode<S>,
+        ctx: &mut knuffel::decode::Context<S>,
+    ) -> Result<Self, DecodeError<S>> {
+        let default = Self::default().0;
+        Ok(Self(Animation::decode_node(node, ctx, default, |_, _| {
+            Ok(false)
+        })?))
     }
 }
 

--- a/niri-config/src/layer_rule.rs
+++ b/niri-config/src/layer_rule.rs
@@ -21,6 +21,8 @@ pub struct LayerRule {
     pub place_within_backdrop: Option<bool>,
     #[knuffel(child, unwrap(argument))]
     pub baba_is_float: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub open_animation: Option<bool>,
     #[knuffel(child, default)]
     pub background_effect: BackgroundEffectRule,
     #[knuffel(child, default)]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -857,6 +857,11 @@ mod tests {
 
                 window-open { off; }
 
+                layer-open {
+                    duration-ms 250
+                    curve "ease-out-cubic"
+                }
+
                 window-close {
                     curve "cubic-bezier" 0.05 0.7 0.1 1
                 }
@@ -910,6 +915,7 @@ mod tests {
             layer-rule {
                 match namespace="^notifications$"
                 block-out-from "screencast"
+                open-animation true
             }
 
             binds {
@@ -1533,6 +1539,17 @@ mod tests {
                     },
                     custom_shader: None,
                 },
+                layer_open: LayerOpenAnim(
+                    Animation {
+                        off: false,
+                        kind: Easing(
+                            EasingParams {
+                                duration_ms: 250,
+                                curve: EaseOutCubic,
+                            },
+                        ),
+                    },
+                ),
                 window_close: WindowCloseAnim {
                     anim: Animation {
                         off: false,
@@ -1933,6 +1950,9 @@ mod tests {
                     geometry_corner_radius: None,
                     place_within_backdrop: None,
                     baba_is_float: None,
+                    open_animation: Some(
+                        true,
+                    ),
                     background_effect: BackgroundEffectRule {
                         xray: None,
                         blur: None,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -302,6 +302,13 @@ animations {
 
     // Slow down all animations by this factor. Values below 1 speed them up instead.
     // slowdown 3.0
+
+    // Layer-shell opening animation. You need to enable it for specific surfaces
+    // with layer-rule { open-animation true; }.
+    // layer-open {
+    //     duration-ms 150
+    //     curve "ease-out-expo"
+    // }
 }
 
 // Window rules let you adjust behavior for individual windows.

--- a/src/layer/mapped.rs
+++ b/src/layer/mapped.rs
@@ -8,7 +8,8 @@ use smithay::wayland::compositor::{remove_pre_commit_hook, HookId};
 use smithay::wayland::shell::wlr_layer::{ExclusiveZone, Layer};
 
 use super::ResolvedLayerRules;
-use crate::animation::Clock;
+use crate::animation::{Animation, Clock};
+use crate::layout::opening_window::{OpenAnimation, OpeningWindowRenderElement};
 use crate::layout::shadow::Shadow;
 use crate::niri_render_elements;
 use crate::render_helpers::background_effect::BackgroundEffectElement;
@@ -42,6 +43,9 @@ pub struct MappedLayer {
     /// The shadow around the surface.
     shadow: Shadow,
 
+    /// The animation upon opening this layer surface.
+    open_animation: Option<OpenAnimation>,
+
     /// The blur config, passed for background effect rendering.
     blur_config: niri_config::Blur,
 
@@ -61,6 +65,7 @@ niri_render_elements! {
         SolidColor = SolidColorRenderElement,
         Shadow = ShadowRenderElement,
         BackgroundEffect = BackgroundEffectElement,
+        Opening = OpeningWindowRenderElement,
     }
 }
 
@@ -79,6 +84,8 @@ impl MappedLayer {
         shadow_config.on = false;
         shadow_config.merge_with(&rules.shadow);
 
+        let open_animation = layer_open_animation(&rules, clock.clone(), config);
+
         Self {
             surface,
             pre_commit_hook,
@@ -88,6 +95,7 @@ impl MappedLayer {
             view_size,
             scale,
             shadow: Shadow::new(shadow_config),
+            open_animation,
             blur_config: config.blur,
             clock,
         }
@@ -127,7 +135,17 @@ impl MappedLayer {
     }
 
     pub fn are_animations_ongoing(&self) -> bool {
-        self.rules.baba_is_float
+        self.rules.baba_is_float || self.open_animation.is_some()
+    }
+
+    pub fn advance_animations(&mut self) {
+        if self
+            .open_animation
+            .as_ref()
+            .is_some_and(OpenAnimation::is_done)
+        {
+            self.open_animation = None;
+        }
     }
 
     pub fn surface(&self) -> &LayerSurface {
@@ -192,10 +210,64 @@ impl MappedLayer {
         xray_pos: XrayPos,
         push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
     ) {
+        if let Some(open) = &self.open_animation {
+            if !open.is_done() {
+                let scale = Scale::from(self.scale);
+
+                let bob_offset = self.bob_offset();
+                let location = location + bob_offset;
+                let xray_pos = xray_pos.offset(bob_offset);
+
+                let mut ctx = ctx.as_gles();
+                let mut elements = Vec::new();
+                self.render_normal_inner(
+                    ctx.r(),
+                    ns,
+                    Point::new(0., 0.),
+                    xray_pos,
+                    false,
+                    &mut |elem| elements.push(elem),
+                );
+
+                match open.render(
+                    ctx.renderer,
+                    &elements,
+                    self.block_out_buffer.size(),
+                    location,
+                    scale,
+                    1.,
+                ) {
+                    Ok((elem, _data)) => {
+                        push(elem.into());
+                        return;
+                    }
+                    Err(err) => {
+                        warn!("error rendering layer surface opening animation: {err:?}");
+                    }
+                }
+            }
+        }
+
+        self.render_normal_inner(ctx.r(), ns, location, xray_pos, true, push);
+    }
+
+    fn render_normal_inner<R: NiriRenderer>(
+        &self,
+        mut ctx: RenderCtx<R>,
+        ns: Option<usize>,
+        location: Point<f64, Logical>,
+        xray_pos: XrayPos,
+        apply_bob: bool,
+        push: &mut dyn FnMut(LayerSurfaceRenderElement<R>),
+    ) {
         let scale = Scale::from(self.scale);
         let alpha = self.rules.opacity.unwrap_or(1.).clamp(0., 1.);
 
-        let bob_offset = self.bob_offset();
+        let bob_offset = if apply_bob {
+            self.bob_offset()
+        } else {
+            Point::from((0., 0.))
+        };
         let location = location + bob_offset;
         let xray_pos = xray_pos.offset(bob_offset);
 
@@ -324,6 +396,24 @@ impl MappedLayer {
             );
         }
     }
+}
+
+fn layer_open_animation(
+    rules: &ResolvedLayerRules,
+    clock: Clock,
+    config: &Config,
+) -> Option<OpenAnimation> {
+    if !rules.open_animation.unwrap_or(false) {
+        return None;
+    }
+
+    Some(OpenAnimation::new(Animation::new(
+        clock,
+        0.,
+        1.,
+        0.,
+        config.animations.layer_open.0,
+    )))
 }
 
 impl Drop for MappedLayer {

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -28,6 +28,9 @@ pub struct ResolvedLayerRules {
     /// Whether to bob this window up and down.
     pub baba_is_float: bool,
 
+    /// Whether to animate this layer surface opening.
+    pub open_animation: Option<bool>,
+
     /// Background effect configuration.
     pub background_effect: BackgroundEffect,
 
@@ -74,6 +77,9 @@ impl ResolvedLayerRules {
             }
             if let Some(x) = rule.baba_is_float {
                 resolved.baba_is_float = x;
+            }
+            if let Some(x) = rule.open_animation {
+                resolved.open_animation = Some(x);
             }
 
             resolved.shadow.merge_with(&rule.shadow);

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -4070,6 +4070,9 @@ impl Niri {
         self.exit_confirm_dialog.advance_animations();
         self.screenshot_ui.advance_animations();
         self.window_mru_ui.advance_animations();
+        for mapped in self.mapped_layer_surfaces.values_mut() {
+            mapped.advance_animations();
+        }
 
         for state in self.output_state.values_mut() {
             if let Some(transition) = &mut state.screen_transition {


### PR DESCRIPTION
Animates opening layers, such as fuzzel or another launcher.

Disabled by default to avoid undesirable behavior with bars and other
floating windows. Must be enabled in the layer_rule and configured in
the animations block.

I don't see a reason to have a layer-close animation (window-close is hardly noticeable for me).
If this is the wrong approach, please close.