### PR TITLE
input: detect touchpads via ID_INPUT_TOUCHPAD instead of tap_finger_count

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4763,8 +4763,18 @@ fn hardcoded_overview_bind(raw: Keysym, mods: ModifiersState) -> Option<Bind> {
 }
 
 pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::Device) {
-    // According to Mutter code, this setting is specific to touchpads.
-    let is_touchpad = device.config_tap_finger_count() > 0;
+    // Detect touchpads. Prefer udev's ID_INPUT_TOUCHPAD because
+    // config_tap_finger_count() can return 0 on devices that initialise
+    // in a degraded multi-touch state (e.g. Synaptics RMI4 clickpads),
+    // which would silently skip the entire touchpad{} config block.
+    // Falls back to the old check when no udev device is attached
+    // (e.g. winit backend during development).
+    let is_touchpad = if let Some(udev_device) = unsafe { device.udev_device() } {
+        udev_device.property_value("ID_INPUT_TOUCHPAD").is_some()
+            || device.config_tap_finger_count() > 0
+    } else {
+        device.config_tap_finger_count() > 0
+    };
     if is_touchpad {
         let c = &config.touchpad;
         let _ = device.config_send_events_set_mode(if c.off {


### PR DESCRIPTION
## Problem

`apply_libinput_settings` detects touchpads with:

```rust
let is_touchpad = device.config_tap_finger_count() > 0;
```

For touchpads that initialise in a degraded multi-touch state, libinput returns `0` from `config_tap_finger_count()`, so `is_touchpad` becomes `false` and the entire `touchpad {}` config block is silently skipped. The device then operates on libinput defaults (tap-to-click off, click-method `button-areas`, natural-scroll off, dwt on) regardless of what the user has in `niri` config.

The state persists for the whole session — even `niri msg action load-config-file` does not recover it, because the underlying `is_touchpad` check still returns false.

This reproduces reliably on a ThinkPad P1 Gen 2 with Synaptics TM3512-010 wired through rmi4 SMBus. It also matches symptoms reported in #2071 (which is closed but unresolved):

> *"if i exit Niri to my login screen and log in again into a Niri session, the touchpad might work. it seems a 50/50 chance, almost on alternating logins"*

## Fix

Use udev's `ID_INPUT_TOUCHPAD` property as the primary touchpad detection — this is what kernel/udev set for every device classified as a touchpad, regardless of multi-touch state. The same approach is already used a few lines below in this same function for trackballs (`ID_INPUT_TRACKBALL`) and trackpoints (`ID_INPUT_POINTINGSTICK`).

Fall back to the old `config_tap_finger_count` check when no udev device is attached (e.g. winit backend during development), so behaviour for non-udev paths is preserved.

```rust
let is_touchpad = if let Some(udev_device) = unsafe { device.udev_device() } {
    udev_device.property_value("ID_INPUT_TOUCHPAD").is_some()
        || device.config_tap_finger_count() > 0
} else {
    device.config_tap_finger_count() > 0
};
```

## Testing

Tested locally on:

- **Hardware**: ThinkPad P1 Gen 2, Synaptics TM3512-010 (vendor 06CB, fw 3624050)
- **Stack**: kernel 7.0.3, libinput latest, niri 26.04
- **Symptom before**: `libinput list-devices` shows `Tap-to-click: disabled`, `Click methods: *button-areas`, `Nat.scrolling: disabled`, `Disable-w-typing: enabled` — i.e. raw libinput defaults — despite `tap`, `natural-scroll`, `click-method "clickfinger"` etc. being set in niri config
- **Symptom after**: settings from `touchpad {}` consistently applied across sessions

## Related

Fixes #2071