### PR TITLE
Use `RUSTFLAGS` instead of `CARGO_BUILD_RUSTFLAGS` in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,8 +139,8 @@
             '';
 
           env = {
-            # Force linking with libEGL and libwayland-client
-            # so they can be discovered by `dlopen()`
+            # Force linking with libEGL and libwayland-client so they end up in RPATH and
+            # can be discovered by `dlopen()`
             RUSTFLAGS = toString (
               map (arg: "-C link-arg=" + arg) [
                 "-Wl,--push-state,--no-as-needed"
@@ -225,8 +225,8 @@
               # It is required for `dlopen()` to work on some libraries; see the comment
               # in the package expression
               #
-              # This should only be set with `CARGO_BUILD_RUSTFLAGS="$CARGO_BUILD_RUSTFLAGS -C your-flags"`
-              CARGO_BUILD_RUSTFLAGS = niri.RUSTFLAGS;
+              # This should only be set with `RUSTFLAGS="$RUSTFLAGS -C your-flags"`
+              RUSTFLAGS = niri.RUSTFLAGS;
             };
           };
         }


### PR DESCRIPTION
`CARGO_BUILD_RUSTFLAGS` has a very low precedence and is overruled by global `target.<tuple>.rustflags`.
Since these rustflags are very important, ensure that they have a higher precedence. We could even go for `CARGO_ENCODED_RUSTFLAGS` which has the highest precedence, but is slightly annoying to construct and probably not worth it.