### PR TITLE
feat: allow configuring center area

### DIFF
--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -466,7 +466,7 @@ impl FromStr for CenterSidePercent {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
 pub struct CenterAreaPercentage {
     // using Option means a person can just have `center-percentage;`
     // in their kdl file, which does nothing, so :( i guess

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -23,6 +23,7 @@ pub struct Input {
     pub workspace_auto_back_and_forth: bool,
     pub mod_key: Option<ModKey>,
     pub mod_key_nested: Option<ModKey>,
+    pub center_area_percentage: Option<CenterAreaPercentage>,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
@@ -53,6 +54,8 @@ pub struct InputPart {
     pub mod_key: Option<ModKey>,
     #[knuffel(child, unwrap(argument, str))]
     pub mod_key_nested: Option<ModKey>,
+    #[knuffel(child)]
+    pub center_area_percentage: Option<CenterAreaPercentage>,
 }
 
 impl MergeWith<InputPart> for Input {
@@ -80,6 +83,7 @@ impl MergeWith<InputPart> for Input {
             focus_follows_mouse,
             mod_key,
             mod_key_nested,
+            center_area_percentage,
         );
     }
 }
@@ -436,6 +440,42 @@ impl ModKey {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CenterSidePercent(pub f64);
+
+impl FromStr for CenterSidePercent {
+    type Err = miette::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let Some((value, empty)) = s.split_once('%') else {
+            return Err(miette!("value must end with '%'"));
+        };
+
+        if !empty.is_empty() {
+            return Err(miette!("trailing characters after '%' are not allowed"));
+        }
+
+        let value: f64 = value.parse().map_err(|_| miette!("error parsing value"))?;
+
+        if !(0.0..100.0).contains(&value) {
+            return Err(miette!(
+                "value must be between 0% (inclusive) and 100% (exclusive)"
+            ));
+        }
+        Ok(CenterSidePercent(value / 100.))
+    }
+}
+
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
+pub struct CenterAreaPercentage {
+    // using Option means a person can just have `center-percentage;`
+    // in their kdl file, which does nothing, so :( i guess
+    #[knuffel(property, str)]
+    pub width: Option<CenterSidePercent>,
+    #[knuffel(property, str)]
+    pub height: Option<CenterSidePercent>,
+}
+
 impl FromStr for ModKey {
     type Err = miette::Error;
 
@@ -745,5 +785,68 @@ mod tests {
             2.0,
         )
         ");
+    }
+
+    #[test]
+    fn parse_center_area_percentage() {
+        let parsed = do_parse(
+            r#"
+            center-area-percentage height="25%" width="25%"
+            "#,
+        );
+        assert_debug_snapshot!(parsed.center_area_percentage, @r#"
+        Some(
+            CenterAreaPercentage {
+                width: Some(
+                    CenterSidePercent(
+                        0.25,
+                    ),
+                ),
+                height: Some(
+                    CenterSidePercent(
+                        0.25,
+                    ),
+                ),
+            },
+        )
+        "#);
+        let parsed = do_parse(
+            r#"
+            center-area-percentage height="10%"
+            "#,
+        );
+        assert_debug_snapshot!(parsed.center_area_percentage, @r#"
+        Some(
+            CenterAreaPercentage {
+                width: None,
+                height: Some(
+                    CenterSidePercent(
+                        0.1,
+                    ),
+                ),
+            },
+        )
+        "#);
+        let parsed = do_parse(
+            r#"
+            center-area-percentage width="50%"
+            "#,
+        );
+        assert_debug_snapshot!(parsed.center_area_percentage, @r#"
+        Some(
+            CenterAreaPercentage {
+                width: Some(
+                    CenterSidePercent(
+                        0.5,
+                    ),
+                ),
+                height: None,
+            },
+        )
+        "#);
+        assert!("100%".parse::<CenterSidePercent>().is_err());
+        assert!("-1%".parse::<CenterSidePercent>().is_err());
+        assert!("50".parse::<CenterSidePercent>().is_err());
+        assert!("50%x".parse::<CenterSidePercent>().is_err());
     }
 }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1143,6 +1143,7 @@ mod tests {
                 mod_key_nested: Some(
                     Super,
                 ),
+                center_area_percentage: None,
             },
             outputs: Outputs(
                 [

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2929,8 +2929,13 @@ impl State {
                 else if button == Some(MouseButton::Right) && !pointer.is_grabbed() && mod_down {
                     let location = pointer.current_location();
                     let (output, pos_within_output) = self.niri.output_under(location).unwrap();
-                    let center_area_percentage =
-                        self.niri.config.borrow().input.center_area_percentage;
+                    let center_area_percentage = self
+                        .niri
+                        .config
+                        .borrow()
+                        .input
+                        .center_area_percentage
+                        .unwrap_or_default();
                     let edges = self
                         .niri
                         .layout

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2929,10 +2929,12 @@ impl State {
                 else if button == Some(MouseButton::Right) && !pointer.is_grabbed() && mod_down {
                     let location = pointer.current_location();
                     let (output, pos_within_output) = self.niri.output_under(location).unwrap();
+                    let center_area_percentage =
+                        self.niri.config.borrow().input.center_area_percentage;
                     let edges = self
                         .niri
                         .layout
-                        .resize_edges_under(output, pos_within_output)
+                        .resize_edges_under(output, pos_within_output, center_area_percentage)
                         .unwrap_or(ResizeEdge::empty());
 
                     if !edges.is_empty() {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2337,7 +2337,7 @@ impl<W: LayoutElement> Layout<W> {
         &self,
         output: &Output,
         pos_within_output: Point<f64, Logical>,
-        center_area_percentage: Option<CenterAreaPercentage>,
+        center_area_percentage: CenterAreaPercentage,
     ) -> Option<ResizeEdge> {
         let mon = self.monitor_for_output(output)?;
         mon.resize_edges_under(pos_within_output, center_area_percentage)

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -37,6 +37,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use monitor::{InsertHint, InsertPosition, InsertWorkspace, MonitorAddWindowTarget};
+use niri_config::input::CenterAreaPercentage;
 use niri_config::utils::MergeWith as _;
 use niri_config::{
     Config, CornerRadius, LayoutPart, PresetSize, Workspace as WorkspaceConfig, WorkspaceReference,
@@ -2336,9 +2337,10 @@ impl<W: LayoutElement> Layout<W> {
         &self,
         output: &Output,
         pos_within_output: Point<f64, Logical>,
+        center_area_percentage: Option<CenterAreaPercentage>,
     ) -> Option<ResizeEdge> {
         let mon = self.monitor_for_output(output)?;
-        mon.resize_edges_under(pos_within_output)
+        mon.resize_edges_under(pos_within_output, center_area_percentage)
     }
 
     pub fn workspace_under(

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -1579,7 +1579,7 @@ impl<W: LayoutElement> Monitor<W> {
     pub fn resize_edges_under(
         &self,
         pos_within_output: Point<f64, Logical>,
-        center_area_percentage: Option<CenterAreaPercentage>,
+        center_area_percentage: CenterAreaPercentage,
     ) -> Option<ResizeEdge> {
         if self.overview_progress.is_some() {
             return None;

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -3,6 +3,7 @@ use std::iter::zip;
 use std::rc::Rc;
 use std::time::Duration;
 
+use niri_config::input::CenterAreaPercentage;
 use niri_config::{CornerRadius, LayoutPart};
 use smithay::backend::renderer::element::utils::{
     CropRenderElement, Relocate, RelocateRenderElement, RescaleRenderElement,
@@ -1575,13 +1576,17 @@ impl<W: LayoutElement> Monitor<W> {
         }
     }
 
-    pub fn resize_edges_under(&self, pos_within_output: Point<f64, Logical>) -> Option<ResizeEdge> {
+    pub fn resize_edges_under(
+        &self,
+        pos_within_output: Point<f64, Logical>,
+        center_area_percentage: Option<CenterAreaPercentage>,
+    ) -> Option<ResizeEdge> {
         if self.overview_progress.is_some() {
             return None;
         }
 
         let (ws, geo) = self.workspace_under(pos_within_output)?;
-        ws.resize_edges_under(pos_within_output - geo.loc)
+        ws.resize_edges_under(pos_within_output - geo.loc, center_area_percentage)
     }
 
     pub(super) fn insert_position(

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1772,7 +1772,7 @@ impl<W: LayoutElement> Workspace<W> {
     pub fn resize_edges_under(
         &self,
         pos: Point<f64, Logical>,
-        center_area_percentage: Option<CenterAreaPercentage>,
+        center_area_percentage: CenterAreaPercentage,
     ) -> Option<ResizeEdge> {
         self.tiles_with_render_positions()
             .find_map(|(tile, tile_pos, visible)| {
@@ -1785,12 +1785,9 @@ impl<W: LayoutElement> Workspace<W> {
                 let pos_within_tile = pos - tile_pos;
 
                 if tile.hit(pos_within_tile).is_some() {
-                    let w = center_area_percentage
-                        .and_then(|c| c.width)
-                        .map(|p| p.0)
-                        .unwrap_or(1. / 3.);
+                    let w = center_area_percentage.width.map(|p| p.0).unwrap_or(1. / 3.);
                     let h = center_area_percentage
-                        .and_then(|c| c.height)
+                        .height
                         .map(|p| p.0)
                         .unwrap_or(1. / 3.);
 
@@ -1799,12 +1796,12 @@ impl<W: LayoutElement> Workspace<W> {
                     let mut edges = ResizeEdge::empty();
                     if pos_within_tile.x < ((size.w * (1. - w)) / 2.) {
                         edges |= ResizeEdge::LEFT;
-                    } else if pos_within_tile.x > ((size.w * (1. + w)) / 2.) {
+                    } else if ((size.w * (1. + w)) / 2.) < pos_within_tile.x {
                         edges |= ResizeEdge::RIGHT;
                     }
                     if pos_within_tile.y < ((size.h * (1. - h)) / 2.) {
                         edges |= ResizeEdge::TOP;
-                    } else if pos_within_tile.y > ((size.h * (1. + h)) / 2.) {
+                    } else if ((size.h * (1. + h)) / 2.) < pos_within_tile.y {
                         edges |= ResizeEdge::BOTTOM;
                     }
                     return Some(edges);

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -2,6 +2,7 @@ use std::cmp::max;
 use std::rc::Rc;
 use std::time::Duration;
 
+use niri_config::input::CenterAreaPercentage;
 use niri_config::utils::MergeWith as _;
 use niri_config::{
     CenterFocusedColumn, CornerRadius, OutputName, PresetSize, Workspace as WorkspaceConfig,
@@ -1768,7 +1769,11 @@ impl<W: LayoutElement> Workspace<W> {
         self.scrolling.window_under(pos)
     }
 
-    pub fn resize_edges_under(&self, pos: Point<f64, Logical>) -> Option<ResizeEdge> {
+    pub fn resize_edges_under(
+        &self,
+        pos: Point<f64, Logical>,
+        center_area_percentage: Option<CenterAreaPercentage>,
+    ) -> Option<ResizeEdge> {
         self.tiles_with_render_positions()
             .find_map(|(tile, tile_pos, visible)| {
                 // This logic should be consistent with window_under() in when it returns Some vs.
@@ -1780,17 +1785,26 @@ impl<W: LayoutElement> Workspace<W> {
                 let pos_within_tile = pos - tile_pos;
 
                 if tile.hit(pos_within_tile).is_some() {
+                    let w = center_area_percentage
+                        .and_then(|c| c.width)
+                        .map(|p| p.0)
+                        .unwrap_or(1. / 3.);
+                    let h = center_area_percentage
+                        .and_then(|c| c.height)
+                        .map(|p| p.0)
+                        .unwrap_or(1. / 3.);
+
                     let size = tile.tile_size().to_f64();
 
                     let mut edges = ResizeEdge::empty();
-                    if pos_within_tile.x < size.w / 3. {
+                    if pos_within_tile.x < ((size.w * (1. - w)) / 2.) {
                         edges |= ResizeEdge::LEFT;
-                    } else if 2. * size.w / 3. < pos_within_tile.x {
+                    } else if pos_within_tile.x > ((size.w * (1. + w)) / 2.) {
                         edges |= ResizeEdge::RIGHT;
                     }
-                    if pos_within_tile.y < size.h / 3. {
+                    if pos_within_tile.y < ((size.h * (1. - h)) / 2.) {
                         edges |= ResizeEdge::TOP;
-                    } else if 2. * size.h / 3. < pos_within_tile.y {
+                    } else if pos_within_tile.y > ((size.h * (1. + h)) / 2.) {
                         edges |= ResizeEdge::BOTTOM;
                     }
                     return Some(edges);


### PR DESCRIPTION
This is slightly similar to [AltSnap](https://github.com/RamonUnch/AltSnap)'s configuration for resizing the area.

<img width="337" height="284" alt="image" src="https://github.com/user-attachments/assets/20d26f69-121f-4a75-9eab-e7c50617795a" />

In AltSnap, you can customise the centre's percentage area, so in the screenshot above, the centre area is 50% width and height. This PR aims to provide a configuration option similar to that.

config:
```kdl
input {
    center-area-percentage width="33%" height="33%"
}
```

<details>
<summary>ascii version of video describing the feature</summary>

<p>

For example, you have a window like this
<pre>
┌───────────┐
│           │
│           │
│           │
└───────────┘
</pre>
If you set the centre percentage to 50% width and 50% height
<pre>
┌──┬─────┬──┐
├──┼─────┼──┤
│  │     │  │
├──┼─────┼──┤
└──┴─────┴──┘
</pre>
Only the outer edges and corners can be used to resize

If you set the centre percentage to 0% width and 50% height
<pre>
┌─────┬─────┐
├─────┼─────┤
│     │     │
├─────┼─────┤
└─────┴─────┘
</pre>
there is no top and bottom edge resizing

If you set the centre percentage to 0% width and 0% height
<pre>
┌─────┬─────┐
│     │     │
├─────┼─────┤
│     │     │
└─────┴─────┘
</pre>
There is now only corner resizing

---

</p>
</details>

https://github.com/user-attachments/assets/daa9deab-1008-46dd-8bcf-b410e553aa2f

Some notes on design choices:
- AI was used as my rubber ducky, I'm quite new to :crab: rust :crab: 
- I decided to pass the `CenterAreaPercentage` to the `layout/workspace.rs`, which means changing `layout/monitor.rs`, `layout/mod.rs` and `input/mod.rs`. I couldn't find a better way to pass this struct. It would be nice if someone could guide me
- I also decided that a new `CenterSidePercent` was the best way to go to validate the percentage, I'm not sure how to do it any other way
- I named it `center-area-percentage` and not `non-resizable-area` because it would become a breaking change if resizing in the center is allowed _eventually_ (this guy is not coping trust)
- The range is 0% inclusive to 100% exclusive because I don't want the corner resizing to be fully unavailable, although you can get almost 100 by using `99.99999%`, so that's something I guess
- The `width` and `height` are optional, which means people can do `center-area-percentage;`, so uhh...
- It's not a nested definition, I didn't like the look of this below
	```kdl
   input {
       center-area-percentage {
           width "50%"
           height "50%"
       }
   }
   ```