### PR TITLE
Add `window-under-cursor` ipc msg

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -81,6 +81,8 @@ pub enum Request {
     FocusedOutput,
     /// Request information about the focused window.
     FocusedWindow,
+    /// Request information about the window under the cursor.
+    WindowUnderCursor,
     /// Request picking a window and get its information.
     PickWindow,
     /// Request picking a color from the screen.
@@ -155,6 +157,8 @@ pub enum Response {
     FocusedOutput(Option<Output>),
     /// Information about the focused window.
     FocusedWindow(Option<Window>),
+    /// Information about the window under the cursor.
+    WindowUnderCursor(Option<Window>),
     /// Information about the picked window.
     PickedWindow(Option<Window>),
     /// Information about the picked color.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,6 +75,8 @@ pub enum Msg {
     FocusedOutput,
     /// Print information about the focused window.
     FocusedWindow,
+    /// Print information about the window under the cursor.
+    WindowUnderCursor,
     /// Pick a window with the mouse and print information about it.
     PickWindow,
     /// Pick a color from the screen with the mouse.

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -33,6 +33,7 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::Version => Request::Version,
         Msg::Outputs => Request::Outputs,
         Msg::FocusedWindow => Request::FocusedWindow,
+        Msg::WindowUnderCursor => Request::WindowUnderCursor,
         Msg::FocusedOutput => Request::FocusedOutput,
         Msg::PickWindow => Request::PickWindow,
         Msg::PickColor => Request::PickColor,
@@ -179,6 +180,23 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                 print_window(&window);
             } else {
                 println!("No window is focused.");
+            }
+        }
+        Msg::WindowUnderCursor => {
+            let Response::WindowUnderCursor(window) = response else {
+                bail!("unexpected response: expected WindowUnderCursor, got {response:?}");
+            };
+
+            if json {
+                let window = serde_json::to_string(&window).context("error formatting response")?;
+                println!("{window}");
+                return Ok(());
+            }
+
+            if let Some(window) = window {
+                print_window(&window);
+            } else {
+                println!("No window is under the cursor.");
             }
         }
         Msg::Windows => {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -340,6 +340,20 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let window = windows.values().find(|win| win.is_focused).cloned();
             Response::FocusedWindow(window)
         }
+        Request::WindowUnderCursor => {
+            let (tx, rx) = async_channel::bounded(1);
+            ctx.event_loop.insert_idle(move |state| {
+                let id = state.niri.window_under_cursor().map(Mapped::id);
+                let _ = tx.send_blocking(id);
+            });
+            let result = rx.recv().await;
+            let id = result.map_err(|_| String::from("error getting window under cursor info"))?;
+            let window = id.and_then(|id| {
+                let state = ctx.event_stream_state.borrow();
+                state.windows.windows.get(&id.get()).cloned()
+            });
+            Response::WindowUnderCursor(window)
+        }
         Request::PickWindow => {
             let (tx, rx) = async_channel::bounded(1);
             ctx.event_loop.insert_idle(move |state| {


### PR DESCRIPTION
**Summary**

Add a new `niri msg window-under-cursor` IPC command for getting information about the window currently under the cursor without requiring an extra mouse click.

Previously, `niri msg pick-window` was the only way to get a window id based on pointer position, but it always entered an interactive picker and required the user to left-click the target window. This made it awkward to use from scripts or key bindings where the cursor is already over the intended window.

**Changes**

- Add `Request::WindowUnderCursor` and `Response::WindowUnderCursor`.
- Add the `niri msg window-under-cursor` CLI command.
- Reuse the existing compositor-side `window_under_cursor()` logic, so behavior matches existing window activation/picking rules.

**Usage**

```sh
niri msg window-under-cursor
```

JSON output:

```sh
niri msg --json window-under-cursor
```

Example use with closing window under cursor:

```sh
niri msg action close-window --id $(niri msg --json window-under-cursor | jq .id)
```