### PR TITLE
Implement a workspace toggle for centering the focused column

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -211,6 +211,7 @@ pub enum Action {
     SwapWindowRight,
     ToggleColumnTabbedDisplay,
     SetColumnDisplay(#[knuffel(argument, str)] ColumnDisplay),
+    ToggleCenterColumn,
     CenterColumn,
     CenterWindow,
     #[knuffel(skip)]
@@ -504,6 +505,7 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::ToggleColumnTabbedDisplay {} => Self::ToggleColumnTabbedDisplay,
             niri_ipc::Action::SetColumnDisplay { display } => Self::SetColumnDisplay(display),
             niri_ipc::Action::CenterColumn {} => Self::CenterColumn,
+            niri_ipc::Action::ToggleCenterColumn {} => Self::ToggleCenterColumn,
             niri_ipc::Action::CenterWindow { id: None } => Self::CenterWindow,
             niri_ipc::Action::CenterWindow { id: Some(id) } => Self::CenterWindowById(id),
             niri_ipc::Action::CenterVisibleColumns {} => Self::CenterVisibleColumns,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -454,6 +454,8 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg())]
         display: ColumnDisplay,
     },
+    /// Toggle whether the current workspace centers columns by default.
+    ToggleCenterColumn {},
     /// Center the focused column on the screen.
     CenterColumn {},
     /// Center a window on the screen.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1643,6 +1643,11 @@ impl State {
                     self.niri.layout.toggle_window_height(Some(&window), false);
                 }
             }
+            Action::ToggleCenterColumn => {
+                self.niri.layout.toggle_center_column();
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
             Action::CenterColumn => {
                 self.niri.layout.center_column();
                 // FIXME: granular

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2246,6 +2246,13 @@ impl<W: LayoutElement> Layout<W> {
         workspace.center_column();
     }
 
+    pub fn toggle_center_column(&mut self) {
+        let Some(workspace) = self.active_workspace_mut() else {
+            return;
+        };
+        workspace.toggle_center_column();
+    }
+
     pub fn center_window(&mut self, id: Option<&W::Id>) {
         if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
             if id.is_none() || id == Some(move_.tile.window().id()) {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -512,6 +512,7 @@ enum Op {
     ToggleColumnTabbedDisplay,
     SetColumnDisplay(#[proptest(strategy = "arbitrary_column_display()")] ColumnDisplay),
     CenterColumn,
+    ToggleCenterColumn,
     CenterWindow {
         #[proptest(strategy = "proptest::option::of(1..=5usize)")]
         id: Option<usize>,
@@ -1174,6 +1175,7 @@ impl Op {
             Op::ToggleColumnTabbedDisplay => layout.toggle_column_tabbed_display(),
             Op::SetColumnDisplay(display) => layout.set_column_display(display),
             Op::CenterColumn => layout.center_column(),
+            Op::ToggleCenterColumn => layout.toggle_center_column(),
             Op::CenterWindow { id } => {
                 let id = id.filter(|id| layout.has_window(id));
                 layout.center_window(id.as_ref());
@@ -1723,6 +1725,7 @@ fn operations_dont_panic() {
         Op::ConsumeWindowIntoColumn,
         Op::ExpelWindowFromColumn,
         Op::CenterColumn,
+        Op::ToggleCenterColumn,
         Op::FocusWorkspaceDown,
         Op::FocusWorkspaceUp,
         Op::FocusWorkspace(1),

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1142,6 +1142,30 @@ impl<W: LayoutElement> Workspace<W> {
         self.scrolling.toggle_column_tabbed_display();
     }
 
+    pub fn toggle_center_column(&mut self) {
+        let config = self.layout_config().cloned();
+
+        let mut config = config.unwrap_or_default();
+
+        if let Some(existing) = &mut config.center_focused_column {
+            match *existing {
+                CenterFocusedColumn::Never => *existing = CenterFocusedColumn::Always,
+                CenterFocusedColumn::Always => *existing = CenterFocusedColumn::Never,
+                CenterFocusedColumn::OnOverflow => *existing = CenterFocusedColumn::Always,
+            }
+        } else {
+            let result = match self.base_options.layout.center_focused_column {
+                CenterFocusedColumn::Never => CenterFocusedColumn::Always,
+                CenterFocusedColumn::Always => CenterFocusedColumn::Never,
+                CenterFocusedColumn::OnOverflow => CenterFocusedColumn::Always,
+            };
+
+            config.center_focused_column = Some(result);
+        }
+
+        self.update_layout_config(Some(config));
+    }
+
     pub fn set_column_display(&mut self, display: ColumnDisplay) {
         if self.floating_is_active.get() {
             return;


### PR DESCRIPTION
Essentially what it says on the tin. 

Introduces a new event you can fire on a keybind that toggles whether the current workspace centers the focused column or not. 

Video example:

https://github.com/user-attachments/assets/1440f1af-73bd-4e35-889e-cda9a49a351d

Of note is that it's per-workspace, so you can have one workspace be not-center-focused and one be center-focused. 

The keybind name is `toggle-center-column` and the IPC name should be similar.

-------------------------

The inspiration for this is my current workflow with an ultrawide; sometimes I just want to focus on one window at a time, and be able to keep track of other windows out of the corner of my eye (which is what center columns gives me), but sometimes I would rather be able to use two windows side-by-side, which is what `center-focused-column "never"` gives me.

I wasn't quite sure what to do with `on-overflow`; there's no real good option? 
- `on-overflow` acts like `never` in 99% of usecases, so switching to `always` seems reasonable.
- `on-overflow` doesn't really have a complimentary setting, so just leaving it as-is also seems reasonable.
