### PR TITLE
nix: remove `rust-overlay`, bump inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,28 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1757989933,
-        "narHash": "sha256-9cpKYWWPCFhgwQTww8S94rTXgg8Q8ydFv9fXM6I8xQM=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "8249aa3442fb9b45e615a35f39eca2fe5510d7c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757967192,
-        "narHash": "sha256-/aA9A/OBmnuOMgwfzdsXRusqzUpd8rQnQY8jtrHK+To=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d7c15863b251a7a50265e57c1dca1a7add2e291",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,22 +2,12 @@
 {
   description = "Niri: A scrollable-tiling Wayland compositor.";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-
-    # NOTE: This is not necessary for end users
-    # You can omit it with `inputs.rust-overlay.follows = ""`
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
   outputs =
     {
       self,
       nixpkgs,
-      rust-overlay,
     }:
     let
       revision = self.shortRev or self.dirtyShortRev or "unknown";
@@ -182,33 +172,20 @@
         system:
         let
           pkgs = nixpkgsFor.${system};
-          rust-bin = rust-overlay.lib.mkRustBin { } pkgs;
+          rustfmt' = pkgs.rustfmt.override { asNightly = true; };
           inherit (self.packages.${system}) niri;
         in
         {
           default = pkgs.mkShell {
-            packages = [
-              # We don't use the toolchain from nixpkgs
-              # because we prefer a nightly toolchain
-              # and we *require* a nightly rustfmt
-              (rust-bin.selectLatestNightlyWith (
-                toolchain:
-                toolchain.default.override {
-                  extensions = [
-                    # includes already:
-                    # rustc
-                    # cargo
-                    # rust-std
-                    # rust-docs
-                    # rustfmt-preview
-                    # clippy-preview
-                    "rust-analyzer"
-                    "rust-src"
-                  ];
-                }
-              ))
-              pkgs.cargo-insta
-            ];
+            packages = builtins.attrValues {
+              inherit (pkgs)
+                rustc
+                cargo
+                clippy
+                cargo-insta
+                ;
+              inherit rustfmt';
+            };
 
             nativeBuildInputs = [
               pkgs.rustPlatform.bindgenHook


### PR DESCRIPTION
This PR does 2 things:
- remove `rust-overlay`: previously this was added to get the nightly `rustfmt` and toolchain. However, given that Niri does not use any nightly features and `rustfmt` from `nixpkgs` can be run as nightly just fine, this input has became redundant.
- bump inputs: the current `nixpkgs` lock seems to have an older version of `libglvnd` compared to my system, which causes Niri to crash on `cargo r`. Bumping the input seems to fix that for me. 