### PR TITLE
mru: urgent scope

### DIFF
--- a/niri-config/src/recent_windows.rs
+++ b/niri-config/src/recent_windows.rs
@@ -176,6 +176,7 @@ pub enum MruScope {
     Output,
     /// Windows on the active workspace.
     Workspace,
+    Urgent,
 }
 
 #[derive(knuffel::DecodeScalar, Clone, Copy, Debug, Default, PartialEq)]

--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -77,7 +77,12 @@ const FONT: &str = "sans 14px";
 /// Scopes in the order they are cycled through.
 ///
 /// Count must match one defined in `generate_scope_panels()`.
-static SCOPE_CYCLE: [MruScope; 3] = [MruScope::All, MruScope::Workspace, MruScope::Output];
+static SCOPE_CYCLE: [MruScope; 4] = [
+    MruScope::All,
+    MruScope::Workspace,
+    MruScope::Output,
+    MruScope::Urgent,
+];
 
 /// Window MRU traversal context.
 #[derive(Debug)]
@@ -199,7 +204,7 @@ struct TitleTexture {
 #[derive(Debug, Default)]
 struct ScopePanel {
     scale: f64,
-    textures: Option<Option<[MruTexture; 3]>>,
+    textures: Option<Option<[MruTexture; 4]>>,
 }
 
 #[derive(Debug)]
@@ -212,6 +217,7 @@ struct Thumbnail {
     on_current_workspace: bool,
     /// Whether the window is on the current MRU output.
     on_current_output: bool,
+    is_urgent: bool,
 
     /// Cached app ID of the window.
     ///
@@ -231,6 +237,8 @@ struct Thumbnail {
 
 impl Thumbnail {
     fn from_mapped(mapped: &Mapped, clock: Clock, config: niri_config::MruPreviews) -> Self {
+        let is_focused = mapped.is_focused();
+        let is_urgent = mapped.is_urgent() || is_focused;
         let app_id = with_toplevel_role(mapped.toplevel(), |role| role.app_id.clone());
 
         let background = FocusRing::new(niri_config::FocusRing {
@@ -250,6 +258,7 @@ impl Thumbnail {
             timestamp: mapped.get_focus_timestamp(),
             on_current_output: false,
             on_current_workspace: false,
+            is_urgent,
             app_id,
             size: mapped.size(),
             clock,
@@ -828,6 +837,7 @@ fn matches(scope: MruScope, app_id_filter: Option<&str>, thumbnail: &Thumbnail) 
         MruScope::All => true,
         MruScope::Output => thumbnail.on_current_output,
         MruScope::Workspace => thumbnail.on_current_workspace,
+        MruScope::Urgent => thumbnail.is_urgent,
     };
     if !x {
         return false;
@@ -1231,6 +1241,7 @@ impl WindowMruUi {
             MruScope::All => "all",
             MruScope::Output => "output",
             MruScope::Workspace => "workspace",
+            MruScope::Urgent => "urgent",
         };
         format!("Scope {scope}")
     }
@@ -1723,7 +1734,7 @@ impl ScopePanel {
 fn generate_scope_panels(
     renderer: &mut GlesRenderer,
     scale: f64,
-) -> anyhow::Result<[MruTexture; 3]> {
+) -> anyhow::Result<[MruTexture; 4]> {
     fn make_panel_text(idx: usize) -> String {
         let span_unselected = "<span fgcolor='#999999'>";
         let span_end = "</span>";
@@ -1743,6 +1754,7 @@ fn generate_scope_panels(
                 MruScope::All => format!("{span_shortcut}A{span_shortcut_end}ll"),
                 MruScope::Output => format!("{span_shortcut}O{span_shortcut_end}utput"),
                 MruScope::Workspace => format!("{span_shortcut}W{span_shortcut_end}orkspace"),
+                MruScope::Urgent => format!("{span_shortcut}U{span_shortcut_end}rgent"),
             };
             buf.push_str(&text);
             if scope as usize != idx {
@@ -1758,6 +1770,7 @@ fn generate_scope_panels(
         render_panel(renderer, scale, &make_panel_text(0))?,
         render_panel(renderer, scale, &make_panel_text(1))?,
         render_panel(renderer, scale, &make_panel_text(2))?,
+        render_panel(renderer, scale, &make_panel_text(3))?,
     ])
 }
 
@@ -1849,6 +1862,7 @@ fn make_preset_opened_binds() -> Vec<Bind> {
     push(Keysym::a, Action::MruSetScope(MruScope::All));
     push(Keysym::o, Action::MruSetScope(MruScope::Output));
     push(Keysym::w, Action::MruSetScope(MruScope::Workspace));
+    push(Keysym::u, Action::MruSetScope(MruScope::Urgent));
     push(Keysym::s, Action::MruCycleScope);
 
     // Leave these in since they are the most expected and generally uncontroversial keys, so that

--- a/src/ui/mru/tests.rs
+++ b/src/ui/mru/tests.rs
@@ -9,6 +9,7 @@ fn create_thumbnail() -> Thumbnail {
         timestamp: None,
         on_current_output: false,
         on_current_workspace: false,
+        is_urgent: false,
         app_id: None,
         size: Size::new(100, 100),
         clock: Clock::with_time(Duration::ZERO),
@@ -42,6 +43,7 @@ fn arbitrary_scope() -> impl Strategy<Value = MruScope> {
         Just(MruScope::All),
         Just(MruScope::Output),
         Just(MruScope::Workspace),
+        Just(MruScope::Urgent),
     ]
 }
 


### PR DESCRIPTION

> [!WARNING]
> This pr is a draft because I don't intend it to get into upstream. This is more so an easily findable, publicly available patch that people with niri forks can use.

New scope for the alt-tab / mru functionality — Urgent. Shows only windows with the urgent status. \
Yes, urgent windows are already highlighted pink in the other scopes, but that's not that useful if the highlighted window is 20 windows away :p \
With this, you'll be able to get a clean overview over only the windows that are urgent.

Notably, the currently focused window is still included, so that you go *back* to effectively cancel the ui, rather than necessarily pressing <kbd>Escape</kbd>. Also, thanks to including the focused window, the first time you press the Next window hotkey (and open the mru ui), you end up on the *first* urgent window, rather than on the second urgent window.

Normally the urgent status is just annoying. For instance, Todoist likes to become urgent for no reason on startup for me. But urgency can be used intentionally as a workflow.

In terminals, sending the bell character (`printf \a`) normally¹ makes the window urgent. So for long-running commands, you can add a `printf \a` at the end, plus maybe a notification, so that once the long-running command finishes, you can easily and quickly jump to the finished terminal using the urgency scope. \
Especially if you might run multiple long-running commands at a time, not having to think about *what* window finished is really useful in that regard.

¹ Almost always configurable in your terminal.

Also, pretty powerfully, `toggle-window-urgent`, `set-window-urgent`, `unset-window-urgent` niri actions exist. You can potentially use them to *mark* windows in a “I need to get back to this a bit later” way, and aids in the urgency workflow for windows that can't produce their own urgency logic (like a terminal can with the bell character)
