### PR TITLE
mru: next/prev actions update to their set scope

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2356,6 +2356,11 @@ impl State {
                 filter,
             } => {
                 if self.niri.window_mru_ui.is_open() {
+                    if let Some(scope) = scope {
+                        if self.niri.window_mru_ui.scope() != scope {
+                            self.niri.window_mru_ui.set_scope(scope);
+                        }
+                    }
                     self.niri.window_mru_ui.advance(direction, filter);
                     self.niri.queue_redraw_mru_output();
                 } else if self.niri.config.borrow().recent_windows.on {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2359,9 +2359,12 @@ impl State {
                     if let Some(scope) = scope {
                         if self.niri.window_mru_ui.scope() != scope {
                             self.niri.window_mru_ui.set_scope(scope);
+                        } else {
+                            self.niri.window_mru_ui.advance(direction, filter);
                         }
+                    } else {
+                        self.niri.window_mru_ui.advance(direction, filter);
                     }
-                    self.niri.window_mru_ui.advance(direction, filter);
                     self.niri.queue_redraw_mru_output();
                 } else if self.niri.config.borrow().recent_windows.on {
                     self.niri.mru_apply_keyboard_commit();


### PR DESCRIPTION

> [!WARNING]
> This pr is a draft because I don't intend it to get into upstream. This is more so a easily findable, publically available patch that people with niri forks can use.

Normally, with this config ↓,
```kdl
binds {
   Mod+E { next-window scope="all"; }
   Mod+F { next-window scope="output"; }
}
```
if you press <kbd>mod+e</kbd> to get into the mru ui, and then press <kbd>mod+f</kbd>, you will continue scrolling through the “all” scope, despite the <kbd>mod+f</kbd> hotkey targetting the “output” scope. \
To switch scopes while in the open ui, you need to either explicitly select it, press <kbd>s</kbd> to rotate scopes, or cancel out of the ui altogether, to then press the <kbd>mod+f</kbd> hotkey fresh.

With this pr, the <kbd>mod+f</kbd> hotkey *does* switch the scope to “output”. So, `previous-window` and `next-window` hotkeys update to their scope, even while the ui is open. \
Instead of needing to close the ui, you can at once check windows in all of your scopes! :3

Considering how simple and obvious this change is, I feel pretty certain that it's *intentionally* not this way upstream. But I'm probably not the only one who prefers this behavior, especially with #4208 in mind.
