### PR TITLE
Add suspend action to IPC

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -399,6 +399,7 @@ impl From<niri_ipc::Action> for Action {
     fn from(value: niri_ipc::Action) -> Self {
         match value {
             niri_ipc::Action::Quit { skip_confirmation } => Self::Quit(skip_confirmation),
+            niri_ipc::Action::Suspend {} => Self::Suspend,
             niri_ipc::Action::PowerOffMonitors {} => Self::PowerOffMonitors,
             niri_ipc::Action::PowerOnMonitors {} => Self::PowerOnMonitors,
             niri_ipc::Action::Spawn { command } => Self::Spawn(command),

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -198,6 +198,8 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(short, long))]
         skip_confirmation: bool,
     },
+    /// Suspend the system.
+    Suspend {},
     /// Power off all monitors via DPMS.
     PowerOffMonitors {},
     /// Power on all monitors via DPMS.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,3 +135,23 @@ impl TryFrom<CompletionShell> for Shell {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_suspend_action() {
+        let cli = Cli::parse_from(["niri", "msg", "action", "suspend"]);
+
+        match cli.subcommand {
+            Some(Sub::Msg {
+                msg: Msg::Action {
+                    action: Action::Suspend {},
+                },
+                json: false,
+            }) => (),
+            _ => panic!("expected suspend action"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Expose `suspend` in `niri_ipc::Action` so `niri msg action suspend` parses.
- Map the IPC action to the existing compositor `Action::Suspend` path.

## Issues
- Fixes #3260

## Testing
- `cargo test -q parses_suspend_action`
- pre-push hook: `cargo check`