### PR TITLE
Document locking with monitor poweroff

### DIFF
--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -365,6 +365,9 @@ binds {
     Mod+T hotkey-overlay-title="Open a Terminal: alacritty" { spawn "alacritty"; }
     Mod+D hotkey-overlay-title="Run an Application: fuzzel" { spawn "fuzzel"; }
     Super+Alt+L hotkey-overlay-title="Lock the Screen: swaylock" { spawn "swaylock"; }
+    // Replace the bind above with this one to also turn off monitors after locking.
+    // The sleep gives the locker a moment to start before DPMS powers off.
+    // Super+Alt+L hotkey-overlay-title="Lock the Screen: swaylock" { spawn-sh "swaylock -f & sleep 1; niri msg action power-off-monitors"; }
 
     // Use spawn-sh to run a shell command. Do this if you need pipes, multiple commands, etc.
     // Note: the entire command goes as a single argument. It's passed verbatim to `sh -c`.


### PR DESCRIPTION
## Summary
- Add a commented default-config example for locking with `swaylock` and then powering off monitors.

## Issues
- Fixes #856

## Testing
- `cargo run -q --bin niri -- validate -c resources/default-config.kdl`
- pre-push hook: `cargo check`