### PR TITLE
Validate and reload XKB file configs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate tracing;
 
-use std::fmt::Write as _;
 use std::fs::File;
 use std::io::{self, Write};
 use std::os::fd::FromRawFd;
@@ -10,6 +9,7 @@ use std::process::Command;
 use std::sync::atomic::Ordering;
 use std::{env, mem};
 
+use anyhow::{bail, Context as _};
 use calloop::EventLoop;
 use clap::{CommandFactory, Parser};
 use clap_complete::Shell;
@@ -24,10 +24,11 @@ use niri::utils::spawning::{
     spawn, spawn_sh, store_and_increase_nofile_rlimit, CHILD_DISPLAY, CHILD_ENV,
     REMOVE_ENV_RUST_BACKTRACE, REMOVE_ENV_RUST_LIB_BACKTRACE,
 };
-use niri::utils::{cause_panic, version, watcher, xwayland, IS_SYSTEMD_SERVICE};
-use niri_config::{Config, ConfigPath};
+use niri::utils::{cause_panic, expand_home, version, watcher, xwayland, IS_SYSTEMD_SERVICE};
+use niri_config::{Config, ConfigPath, Xkb};
 use niri_ipc::socket::SOCKET_PATH_ENV;
 use sd_notify::NotifyState;
+use smithay::input::keyboard::xkb;
 use smithay::reexports::wayland_server::Display;
 use tracing_subscriber::EnvFilter;
 
@@ -102,7 +103,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Sub::Validate { config } => {
                 tracy_client::Client::start();
 
-                config_path(config).load().config?;
+                let config = config_path(config).load().config?;
+                validate_config(&config)?;
                 info!("config is valid");
                 return Ok(());
             }
@@ -274,37 +276,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn import_environment() {
-    let variables = [
-        "WAYLAND_DISPLAY",
-        "DISPLAY",
-        "XDG_CURRENT_DESKTOP",
-        "XDG_SESSION_TYPE",
-        SOCKET_PATH_ENV,
-    ]
-    .join(" ");
+    let variables = import_environment_variables().join(" ");
+    let shell_command = import_environment_shell_command(&variables);
 
-    let mut init_system_import = String::new();
-    if cfg!(feature = "systemd") {
-        write!(
-            init_system_import,
-            "systemctl --user import-environment {variables};"
-        )
-        .unwrap();
-    }
-    if cfg!(feature = "dinit") {
-        write!(init_system_import, "dinitctl setenv {variables};").unwrap();
-    }
-
-    let rv = Command::new("/bin/sh")
-        .args([
-            "-c",
-            &format!(
-                "{init_system_import}\
-                 hash dbus-update-activation-environment 2>/dev/null && \
-                 dbus-update-activation-environment {variables}"
-            ),
-        ])
-        .spawn();
+    let rv = Command::new("/bin/sh").args(["-c", &shell_command]).spawn();
     // Wait for the import process to complete, otherwise services will start too fast without
     // environment variables available.
     match rv {
@@ -322,6 +297,34 @@ fn import_environment() {
             warn!("error spawning shell to import environment: {err:?}");
         }
     }
+}
+
+fn import_environment_variables() -> [&'static str; 5] {
+    [
+        "WAYLAND_DISPLAY",
+        "DISPLAY",
+        "XDG_CURRENT_DESKTOP",
+        "XDG_SESSION_TYPE",
+        SOCKET_PATH_ENV,
+    ]
+}
+
+fn import_environment_shell_command(variables: &str) -> String {
+    let mut commands = Vec::new();
+    if cfg!(feature = "systemd") {
+        commands.push(format!(
+            "if hash systemctl 2>/dev/null; then systemctl --user import-environment {variables}; fi"
+        ));
+    }
+    if cfg!(feature = "dinit") {
+        commands.push(format!(
+            "if hash dinitctl 2>/dev/null; then dinitctl setenv {variables}; fi"
+        ));
+    }
+    commands.push(format!(
+        "if hash dbus-update-activation-environment 2>/dev/null; then dbus-update-activation-environment {variables}; fi"
+    ));
+    commands.join("; ")
 }
 
 fn env_config_path() -> Option<PathBuf> {
@@ -361,6 +364,81 @@ fn config_path(cli_path: Option<PathBuf>) -> ConfigPath {
         // Couldn't find the home directory, or whatever.
         ConfigPath::Explicit(system_path)
     }
+}
+
+fn validate_config(config: &Config) -> anyhow::Result<()> {
+    validate_xkb_config(&config.input.keyboard.xkb)
+}
+
+fn validate_xkb_config(xkb_config: &Xkb) -> anyhow::Result<()> {
+    let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+
+    if let Some(file) = &xkb_config.file {
+        validate_xkb_file(file, &context)?;
+        return Ok(());
+    }
+
+    validate_xkb_name("rules", &xkb_config.rules)?;
+    validate_xkb_name("model", &xkb_config.model)?;
+    validate_xkb_name("layout", &xkb_config.layout)?;
+    validate_xkb_name("variant", &xkb_config.variant)?;
+    if let Some(options) = &xkb_config.options {
+        validate_xkb_name("options", options)?;
+    }
+
+    let keymap = xkb::Keymap::new_from_names(
+        &context,
+        &xkb_config.rules,
+        &xkb_config.model,
+        &xkb_config.layout,
+        &xkb_config.variant,
+        xkb_config.options.clone(),
+        xkb::KEYMAP_COMPILE_NO_FLAGS,
+    );
+
+    if keymap.is_none() {
+        bail!(
+            "invalid xkb config: rules {:?}, model {:?}, layout {:?}, variant {:?}, options {:?}",
+            xkb_config.rules,
+            xkb_config.model,
+            xkb_config.layout,
+            xkb_config.variant,
+            xkb_config.options
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_xkb_name(name: &str, value: &str) -> anyhow::Result<()> {
+    if value.contains('\0') {
+        bail!("invalid xkb config: {name} contains a NUL byte");
+    }
+
+    Ok(())
+}
+
+fn validate_xkb_file(xkb_file: &str, context: &xkb::Context) -> anyhow::Result<()> {
+    let path = PathBuf::from(xkb_file);
+    let path = expand_home(&path)
+        .context("failed to expand ~ in xkb_file")?
+        .unwrap_or(path);
+
+    let keymap = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read xkb_file {:?}", path))?;
+
+    if xkb::Keymap::new_from_string(
+        context,
+        keymap,
+        xkb::KEYMAP_FORMAT_TEXT_V1,
+        xkb::KEYMAP_COMPILE_NO_FLAGS,
+    )
+    .is_none()
+    {
+        bail!("invalid xkb_file {:?}", path);
+    }
+
+    Ok(())
 }
 
 fn notify_fd() -> anyhow::Result<()> {
@@ -406,5 +484,79 @@ fn set_default_max_buffer_size(display: &Display<State>, size: usize) {
         }
 
         libc::dlclose(lib);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_test_keymap() -> anyhow::Result<String> {
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let Some(keymap) = xkb::Keymap::new_from_names(
+            &context,
+            "",
+            "",
+            "us",
+            "",
+            None,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        ) else {
+            bail!("failed to compile valid test keymap");
+        };
+
+        Ok(keymap.get_as_string(xkb::KEYMAP_FORMAT_TEXT_V1))
+    }
+
+    #[test]
+    fn import_environment_shell_guards_systemctl_when_systemd_feature_enabled() {
+        let command = import_environment_shell_command("WAYLAND_DISPLAY NIRI_SOCKET");
+
+        if cfg!(feature = "systemd") {
+            assert!(command.contains("if hash systemctl 2>/dev/null; then"));
+            assert!(command.contains("systemctl --user import-environment"));
+        }
+        assert!(command.contains("if hash dbus-update-activation-environment 2>/dev/null; then"));
+    }
+
+    #[test]
+    fn import_environment_variables_include_ipc_socket_when_importing_session() {
+        let variables = import_environment_variables();
+
+        assert_eq!(variables[0], "WAYLAND_DISPLAY");
+        assert!(variables.contains(&SOCKET_PATH_ENV));
+    }
+
+    #[test]
+    fn validate_config_rejects_invalid_xkb_layout() {
+        let mut config = Config::default();
+        config.input.keyboard.xkb.layout = "en".to_owned();
+
+        let Err(err) = validate_config(&config) else {
+            panic!("invalid xkb layout should fail validation");
+        };
+        let err = err.to_string();
+
+        assert!(err.contains("invalid xkb config"));
+        assert!(err.contains("layout \"en\""));
+    }
+
+    #[test]
+    fn validate_config_uses_xkb_file_instead_of_rules_config() -> anyhow::Result<()> {
+        let path = env::temp_dir().join(format!(
+            "niri-test-keymap-{}-{}.xkb",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        std::fs::write(&path, valid_test_keymap()?)?;
+
+        let mut config = Config::default();
+        config.input.keyboard.xkb.layout = "en".to_owned();
+        config.input.keyboard.xkb.file = Some(path.to_string_lossy().into_owned());
+
+        let result = validate_config(&config);
+        std::fs::remove_file(&path)?;
+
+        result
     }
 }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -186,7 +186,6 @@ use crate::window::mapped::MappedId;
 use crate::window::{InitialConfigureState, Mapped, ResolvedWindowRules, Unmapped, WindowRef};
 
 const CLEAR_COLOR_LOCKED: [f32; 4] = [0.3, 0.1, 0.1, 1.];
-const POWER_KEY_RESUME_SUPPRESS_DURATION: Duration = Duration::from_secs(2);
 
 // We'll try to send frame callbacks at least once a second. We'll make a timer that fires once a
 // second, so with the worst timing the maximum interval between two frame callbacks for a surface
@@ -284,7 +283,6 @@ pub struct Niri {
     /// Libinput guarantees that the lid switch starts in open state, and if it was closed during
     /// startup, libinput will immediately send a closed event.
     pub is_lid_closed: bool,
-    pub suppress_power_key_until: Option<Duration>,
 
     pub devices: HashSet<input::Device>,
     pub tablets: HashMap<input::Device, TabletData>,
@@ -2542,7 +2540,6 @@ impl Niri {
             blocker_cleared_rx,
             monitors_active: true,
             is_lid_closed: false,
-            suppress_power_key_until: None,
 
             devices: HashSet::new(),
             tablets: HashMap::new(),
@@ -3071,22 +3068,8 @@ impl Niri {
 
         self.monitors_active = true;
         backend.set_monitors_active(true);
-        backend.on_output_config_changed(self);
 
         self.queue_redraw_all();
-    }
-
-    pub fn suppress_power_key_after_resume(&mut self) {
-        self.suppress_power_key_until =
-            Some(get_monotonic_time().saturating_add(POWER_KEY_RESUME_SUPPRESS_DURATION));
-    }
-
-    pub fn take_power_key_resume_suppression(&mut self, now: Duration) -> bool {
-        let Some(until) = self.suppress_power_key_until.take() else {
-            return false;
-        };
-
-        now <= until
     }
 
     pub fn output_under(&self, pos: Point<f64, Logical>) -> Option<(&Output, Point<f64, Logical>)> {
@@ -6118,10 +6101,6 @@ impl Niri {
 
         let pointer = self.seat.get_pointer().unwrap();
         if Some(surface) != pointer.current_focus().as_ref() {
-            return;
-        }
-
-        if Some(surface) != self.keyboard_focus.surface() {
             return;
         }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -186,11 +186,29 @@ use crate::window::mapped::MappedId;
 use crate::window::{InitialConfigureState, Mapped, ResolvedWindowRules, Unmapped, WindowRef};
 
 const CLEAR_COLOR_LOCKED: [f32; 4] = [0.3, 0.1, 0.1, 1.];
+const POWER_KEY_RESUME_SUPPRESS_DURATION: Duration = Duration::from_secs(2);
 
 // We'll try to send frame callbacks at least once a second. We'll make a timer that fires once a
 // second, so with the worst timing the maximum interval between two frame callbacks for a surface
 // should be ~1.995 seconds.
 const FRAME_CALLBACK_THROTTLE: Option<Duration> = Some(Duration::from_millis(995));
+
+#[derive(Debug, PartialEq, Eq)]
+enum XkbReloadSource<'a> {
+    File(&'a str),
+    Config(&'a Xkb),
+}
+
+fn should_reload_xkb(new_xkb: &Xkb, old_xkb: &Xkb) -> bool {
+    new_xkb != old_xkb || new_xkb.file.is_some()
+}
+
+fn xkb_reload_source(xkb: &Xkb) -> XkbReloadSource<'_> {
+    match xkb.file.as_deref() {
+        Some(file) => XkbReloadSource::File(file),
+        None => XkbReloadSource::Config(xkb),
+    }
+}
 
 pub struct Niri {
     pub config: Rc<RefCell<Config>>,
@@ -266,6 +284,7 @@ pub struct Niri {
     /// Libinput guarantees that the lid switch starts in open state, and if it was closed during
     /// startup, libinput will immediately send a closed event.
     pub is_lid_closed: bool,
+    pub suppress_power_key_until: Option<Duration>,
 
     pub devices: HashSet<input::Device>,
     pub tablets: HashMap<input::Device, TabletData>,
@@ -1376,7 +1395,7 @@ impl State {
     }
 
     /// Loads the xkb keymap from a file config setting.
-    fn set_xkb_file(&mut self, xkb_file: String) -> anyhow::Result<()> {
+    fn set_xkb_file(&mut self, xkb_file: &str) -> anyhow::Result<()> {
         let xkb_file = PathBuf::from(xkb_file);
         let xkb_file = expand_home(&xkb_file)
             .context("failed to expand ~")?
@@ -1404,7 +1423,7 @@ impl State {
     fn load_xkb_file(&mut self) {
         let xkb_file = self.niri.config.borrow().input.keyboard.xkb.file.clone();
         if let Some(xkb_file) = xkb_file {
-            if let Err(err) = self.set_xkb_file(xkb_file) {
+            if let Err(err) = self.set_xkb_file(&xkb_file) {
                 warn!("error loading xkb_file: {err:?}");
             }
         }
@@ -1494,7 +1513,7 @@ impl State {
         }
 
         // We need &mut self to reload the xkb config, so just store it here.
-        if config.input.keyboard.xkb != old_config.input.keyboard.xkb {
+        if should_reload_xkb(&config.input.keyboard.xkb, &old_config.input.keyboard.xkb) {
             reload_xkb = Some(config.input.keyboard.xkb.clone());
         }
 
@@ -1625,31 +1644,32 @@ impl State {
         drop(old_config);
 
         // Now with a &mut self we can reload the xkb config.
-        if let Some(mut xkb) = reload_xkb {
-            let mut set_xkb_config = true;
-
-            // It's fine to .take() the xkb file, as this is a
-            // clone and the file field is not used in the XkbConfig.
-            if let Some(xkb_file) = xkb.file.take() {
-                if let Err(err) = self.set_xkb_file(xkb_file) {
-                    warn!("error reloading xkb_file: {err:?}");
-                } else {
-                    // We successfully set xkb file so we don't need to fallback to XkbConfig.
-                    set_xkb_config = false;
+        if let Some(xkb) = reload_xkb {
+            let reloaded = match xkb_reload_source(&xkb) {
+                XkbReloadSource::File(xkb_file) => {
+                    if let Err(err) = self.set_xkb_file(xkb_file) {
+                        warn!("error reloading xkb_file: {err:?}");
+                        false
+                    } else {
+                        true
+                    }
                 }
-            }
+                XkbReloadSource::Config(xkb) => {
+                    let mut xkb = xkb.clone();
+                    // If xkb is unset in the niri config, use settings from locale1.
+                    if xkb == Xkb::default() {
+                        trace!("using xkb from locale1");
+                        xkb = self.niri.xkb_from_locale1.clone().unwrap_or_default();
+                    }
 
-            if set_xkb_config {
-                // If xkb is unset in the niri config, use settings from locale1.
-                if xkb == Xkb::default() {
-                    trace!("using xkb from locale1");
-                    xkb = self.niri.xkb_from_locale1.clone().unwrap_or_default();
+                    self.set_xkb_config(xkb.to_xkb_config());
+                    true
                 }
+            };
 
-                self.set_xkb_config(xkb.to_xkb_config());
+            if reloaded {
+                self.ipc_keyboard_layouts_changed();
             }
-
-            self.ipc_keyboard_layouts_changed();
         }
 
         if libinput_config_changed {
@@ -2522,6 +2542,7 @@ impl Niri {
             blocker_cleared_rx,
             monitors_active: true,
             is_lid_closed: false,
+            suppress_power_key_until: None,
 
             devices: HashSet::new(),
             tablets: HashMap::new(),
@@ -3050,8 +3071,22 @@ impl Niri {
 
         self.monitors_active = true;
         backend.set_monitors_active(true);
+        backend.on_output_config_changed(self);
 
         self.queue_redraw_all();
+    }
+
+    pub fn suppress_power_key_after_resume(&mut self) {
+        self.suppress_power_key_until =
+            Some(get_monotonic_time().saturating_add(POWER_KEY_RESUME_SUPPRESS_DURATION));
+    }
+
+    pub fn take_power_key_resume_suppression(&mut self, now: Duration) -> bool {
+        let Some(until) = self.suppress_power_key_until.take() else {
+            return false;
+        };
+
+        now <= until
     }
 
     pub fn output_under(&self, pos: Point<f64, Logical>) -> Option<(&Output, Point<f64, Logical>)> {
@@ -6086,6 +6121,10 @@ impl Niri {
             return;
         }
 
+        if Some(surface) != self.keyboard_focus.surface() {
+            return;
+        }
+
         with_pointer_constraint(surface, &pointer, |constraint| {
             let Some(constraint) = constraint else { return };
 
@@ -6539,5 +6578,73 @@ niri_render_elements! {
         Texture = PrimaryGpuTextureRenderElement,
         // Used for the CPU-rendered panels.
         RelocatedMemoryBuffer = RelocateRenderElement<MemoryRenderBufferRenderElement<R>>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use niri_config::Xkb;
+
+    use super::{should_reload_xkb, xkb_reload_source, XkbReloadSource};
+
+    #[test]
+    fn reloads_xkb_when_config_changed() {
+        // Given: old and new rule-based XKB configs differ.
+        let old_xkb = Xkb::default();
+        let new_xkb = Xkb {
+            layout: "de".to_owned(),
+            ..Default::default()
+        };
+
+        // When: deciding whether a reload is needed.
+        let should_reload = should_reload_xkb(&new_xkb, &old_xkb);
+
+        // Then: a changed rule-based config is reloaded.
+        assert!(should_reload);
+    }
+
+    #[test]
+    fn reloads_xkb_file_even_when_config_is_unchanged() {
+        // Given: the parsed config still points at the same custom keymap file.
+        let old_xkb = Xkb {
+            file: Some("keymap.xkb".to_owned()),
+            ..Default::default()
+        };
+        let new_xkb = old_xkb.clone();
+
+        // When: deciding whether a reload is needed after a watched file change.
+        let should_reload = should_reload_xkb(&new_xkb, &old_xkb);
+
+        // Then: the custom keymap file is retried.
+        assert!(should_reload);
+    }
+
+    #[test]
+    fn skips_xkb_reload_when_rules_config_is_unchanged() {
+        // Given: old and new rule-based XKB configs are identical.
+        let old_xkb = Xkb::default();
+        let new_xkb = Xkb::default();
+
+        // When: deciding whether a reload is needed.
+        let should_reload = should_reload_xkb(&new_xkb, &old_xkb);
+
+        // Then: no reload is needed.
+        assert!(!should_reload);
+    }
+
+    #[test]
+    fn xkb_file_is_authoritative_over_rules_config() {
+        // Given: an XKB config with both a file and rules fields.
+        let xkb = Xkb {
+            layout: "de".to_owned(),
+            file: Some("keymap.xkb".to_owned()),
+            ..Default::default()
+        };
+
+        // When: choosing how to reload it.
+        let source = xkb_reload_source(&xkb);
+
+        // Then: the file is used instead of falling through to rules.
+        assert_eq!(source, XkbReloadSource::File("keymap.xkb"));
     }
 }

--- a/src/utils/watcher.rs
+++ b/src/utils/watcher.rs
@@ -10,6 +10,7 @@ use niri_config::{Config, ConfigParseResult, ConfigPath};
 use smithay::reexports::calloop::channel::SyncSender;
 
 use crate::niri::State;
+use crate::utils::expand_home;
 
 const POLLING_INTERVAL: Duration = Duration::from_millis(500);
 
@@ -90,9 +91,13 @@ impl Watcher {
                     }
 
                     if should_load {
-                        let res = process(&inner.path);
+                        let ConfigParseResult { config, includes } = process(&inner.path);
+                        let includes = match &config {
+                            Ok(config) => watched_paths(config, includes),
+                            Err(()) => includes,
+                        };
 
-                        if let Err(err) = changed.send(res.config) {
+                        if let Err(err) = changed.send(config) {
                             warn!("error sending change notification: {err:?}");
                             break;
                         }
@@ -102,7 +107,7 @@ impl Watcher {
                         // remain unnoticed by the watcher. Not sure there's any good way around it
                         // though since we don't know the final set of includes until the config is
                         // parsed.
-                        inner.set_includes(res.includes);
+                        inner.set_includes(includes);
                     }
                 }
 
@@ -115,6 +120,26 @@ impl Watcher {
 
     pub fn load_config(&self, path: Option<String>) {
         let _ = self.load_config.send(path);
+    }
+}
+
+fn watched_paths(config: &Config, mut includes: Vec<PathBuf>) -> Vec<PathBuf> {
+    if let Some(path) = watched_xkb_file(config) {
+        includes.push(path);
+    }
+
+    includes
+}
+
+fn watched_xkb_file(config: &Config) -> Option<PathBuf> {
+    let path = PathBuf::from(config.input.keyboard.xkb.file.as_ref()?);
+    match expand_home(&path) {
+        Ok(Some(path)) => Some(path),
+        Ok(None) => Some(path),
+        Err(err) => {
+            warn!("error expanding xkb_file path for watcher: {err:?}");
+            None
+        }
     }
 }
 
@@ -211,6 +236,11 @@ pub fn setup(state: &mut State, config_path: &ConfigPath, includes: Vec<PathBuf>
         )
         .unwrap();
 
+    let includes = {
+        let config = state.niri.config.borrow();
+        watched_paths(&config, includes)
+    };
+
     let watcher = Watcher::new(config_path.clone(), includes, process, tx);
     state.niri.config_file_watcher = Some(watcher);
 }
@@ -226,6 +256,20 @@ mod tests {
     use super::*;
 
     type Result<T = (), E = Box<dyn Error>> = std::result::Result<T, E>;
+    fn config_with_xkb_file(path: &Path) -> String {
+        format!(
+            r#"
+input {{
+    keyboard {{
+        xkb {{
+            file "{}"
+        }}
+    }}
+}}
+"#,
+            path.display()
+        )
+    }
 
     fn canon(config_path: &ConfigPath) -> &PathBuf {
         match config_path {
@@ -316,7 +360,11 @@ mod tests {
                 sh, config_path, ..
             } = self;
 
-            let includes = config_path.load().includes;
+            let ConfigParseResult { config, includes } = config_path.load();
+            let includes = match &config {
+                Ok(config) => watched_paths(config, includes),
+                Err(_) => includes,
+            };
             let mut test = TestUtil {
                 watcher: WatcherInner::new(config_path, includes),
             };
@@ -370,7 +418,12 @@ mod tests {
             let actual = fs::read_to_string(new_path).unwrap();
             assert_eq!(actual, expected, "wrong file contents");
 
-            self.watcher.set_includes(Config::load(new_path).includes);
+            let ConfigParseResult { config, includes } = Config::load(new_path);
+            let includes = match &config {
+                Ok(config) => watched_paths(config, includes),
+                Err(_) => includes,
+            };
+            self.watcher.set_includes(includes);
 
             self.pass_time();
         }
@@ -622,6 +675,39 @@ mod tests {
             .run(|sh, test| {
                 sh.write_file("niri/colors.kdl", "// Fixed")?;
                 test.assert_changed_to("include \"colors.kdl\"");
+
+                Ok(())
+            })
+    }
+
+    #[test]
+    fn change_xkb_file() -> Result {
+        TestPath::Explicit("niri/config.kdl")
+            .setup(|sh| {
+                let keymap = sh.current_dir().join("niri/keymap.xkb");
+                sh.write_file("niri/config.kdl", config_with_xkb_file(&keymap))?;
+                sh.write_file("niri/keymap.xkb", "xkb keymap one")
+            })
+            .run(|sh, test| {
+                let config = config_with_xkb_file(&sh.current_dir().join("niri/keymap.xkb"));
+                sh.write_file("niri/keymap.xkb", "xkb keymap two")?;
+                test.assert_changed_to(&config);
+
+                Ok(())
+            })
+    }
+
+    #[test]
+    fn missing_xkb_file_still_gets_watched() -> Result {
+        TestPath::Explicit("niri/config.kdl")
+            .setup(|sh| {
+                let keymap = sh.current_dir().join("niri/keymap.xkb");
+                sh.write_file("niri/config.kdl", config_with_xkb_file(&keymap))
+            })
+            .run(|sh, test| {
+                let config = config_with_xkb_file(&sh.current_dir().join("niri/keymap.xkb"));
+                sh.write_file("niri/keymap.xkb", "xkb keymap")?;
+                test.assert_changed_to(&config);
 
                 Ok(())
             })


### PR DESCRIPTION
## Summary
- Validate configured XKB names or `xkb.file` during `niri validate`.
- Treat `xkb.file` as authoritative during config reload instead of falling through to rule-based config after a transient file load failure.
- Watch configured `xkb.file` paths so edits or later file creation trigger reloads.
- Guard session environment imports behind command availability checks while keeping the IPC socket in the imported environment.

## Issues
- Fixes #1918
- Fixes #3557

## Testing
- `cargo test -q validate_config_rejects_invalid_xkb_layout`
- `cargo test -q validate_config_uses_xkb_file_instead_of_rules_config`
- `cargo test -q reloads_xkb_file_even_when_config_is_unchanged`
- `cargo test -q utils::watcher::tests::change_xkb_file`
- `cargo test -q utils::watcher::tests::missing_xkb_file_still_gets_watched`
- `cargo check --message-format=short`
- pre-push hook: `cargo check`