### PR TITLE
Handle power-key wake and output resume

### DIFF
--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -734,6 +734,7 @@ impl Tty {
 
                 self.refresh_ipc_outputs(niri);
 
+                niri.suppress_power_key_after_resume();
                 niri.notify_activity();
                 niri.monitors_active = true;
                 self.set_monitors_active(true);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -534,6 +534,15 @@ impl State {
                     this.niri.screenshot_ui.set_space_down(pressed);
                 }
 
+                let disable_power_key_handling =
+                    this.niri.config.borrow().input.disable_power_key_handling;
+                let suppress_power_key_after_resume = !disable_power_key_handling
+                    && pressed
+                    && is_power_key(modified)
+                    && this
+                        .niri
+                        .take_power_key_resume_suppression(get_monotonic_time());
+
                 let res = {
                     let config = this.niri.config.borrow();
                     let bindings =
@@ -549,7 +558,8 @@ impl State {
                         pressed,
                         *mods,
                         &this.niri.screenshot_ui,
-                        this.niri.config.borrow().input.disable_power_key_handling,
+                        disable_power_key_handling,
+                        suppress_power_key_after_resume,
                         is_inhibiting_shortcuts,
                     )
                 };
@@ -4409,6 +4419,7 @@ fn should_intercept_key<'a>(
     mods: ModifiersState,
     screenshot_ui: &ScreenshotUi,
     disable_power_key_handling: bool,
+    suppress_power_key_after_resume: bool,
     is_inhibiting_shortcuts: bool,
 ) -> FilterResult<Option<Bind>> {
     // Actions are only triggered on presses, release of the key
@@ -4416,6 +4427,15 @@ fn should_intercept_key<'a>(
     // the key to suppress.
     if !pressed && !suppressed_keys.contains(&key_code) {
         return FilterResult::Forward;
+    }
+
+    if pressed
+        && suppress_power_key_after_resume
+        && !disable_power_key_handling
+        && is_power_key(modified)
+    {
+        suppressed_keys.insert(key_code);
+        return FilterResult::Intercept(None);
     }
 
     let mut final_bind = find_bind(
@@ -4480,6 +4500,10 @@ fn should_intercept_key<'a>(
         }
         (None, true) => FilterResult::Forward,
     }
+}
+
+fn is_power_key(keysym: Keysym) -> bool {
+    keysym.raw() == keysyms::KEY_XF86PowerOff
 }
 
 fn find_bind<'a>(
@@ -5217,6 +5241,7 @@ mod tests {
                 mods,
                 &screenshot_ui,
                 disable_power_key_handling,
+                false,
                 is_inhibiting_shortcuts.get(),
             )
         };
@@ -5234,6 +5259,7 @@ mod tests {
                 mods,
                 &screenshot_ui,
                 disable_power_key_handling,
+                false,
                 is_inhibiting_shortcuts.get(),
             )
         };
@@ -5362,6 +5388,83 @@ mod tests {
         let filter = close_key_event(&mut suppressed_keys, mods, false);
         assert!(matches!(filter, FilterResult::Intercept(None)));
         assert!(suppressed_keys.is_empty());
+    }
+
+    #[test]
+    fn power_key_wake_press_is_suppressed_after_resume() {
+        let mut suppressed_keys = HashSet::new();
+        let screenshot_ui = ScreenshotUi::new(Clock::default(), Default::default());
+        let power_key = Keysym::XF86_PowerOff;
+        let key_code = Keycode::from(power_key.raw() + 8);
+        let no_mods = ModifiersState::default();
+
+        let filter = should_intercept_key(
+            &mut suppressed_keys,
+            [],
+            ModKey::Super,
+            key_code,
+            power_key,
+            Some(power_key),
+            true,
+            no_mods,
+            &screenshot_ui,
+            false,
+            true,
+            false,
+        );
+
+        assert!(matches!(filter, FilterResult::Intercept(None)));
+        assert!(suppressed_keys.contains(&key_code));
+
+        let filter = should_intercept_key(
+            &mut suppressed_keys,
+            [],
+            ModKey::Super,
+            key_code,
+            power_key,
+            Some(power_key),
+            false,
+            no_mods,
+            &screenshot_ui,
+            false,
+            false,
+            false,
+        );
+
+        assert!(matches!(filter, FilterResult::Intercept(None)));
+        assert!(suppressed_keys.is_empty());
+    }
+
+    #[test]
+    fn power_key_still_suspends_outside_resume_suppression() {
+        let mut suppressed_keys = HashSet::new();
+        let screenshot_ui = ScreenshotUi::new(Clock::default(), Default::default());
+        let power_key = Keysym::XF86_PowerOff;
+        let key_code = Keycode::from(power_key.raw() + 8);
+
+        let filter = should_intercept_key(
+            &mut suppressed_keys,
+            [],
+            ModKey::Super,
+            key_code,
+            power_key,
+            Some(power_key),
+            true,
+            ModifiersState::default(),
+            &screenshot_ui,
+            false,
+            false,
+            false,
+        );
+
+        assert!(matches!(
+            filter,
+            FilterResult::Intercept(Some(Bind {
+                action: Action::Suspend,
+                ..
+            }))
+        ));
+        assert!(suppressed_keys.contains(&key_code));
     }
 
     #[test]

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -186,6 +186,7 @@ use crate::window::mapped::MappedId;
 use crate::window::{InitialConfigureState, Mapped, ResolvedWindowRules, Unmapped, WindowRef};
 
 const CLEAR_COLOR_LOCKED: [f32; 4] = [0.3, 0.1, 0.1, 1.];
+const POWER_KEY_RESUME_SUPPRESS_DURATION: Duration = Duration::from_secs(2);
 
 // We'll try to send frame callbacks at least once a second. We'll make a timer that fires once a
 // second, so with the worst timing the maximum interval between two frame callbacks for a surface
@@ -266,6 +267,7 @@ pub struct Niri {
     /// Libinput guarantees that the lid switch starts in open state, and if it was closed during
     /// startup, libinput will immediately send a closed event.
     pub is_lid_closed: bool,
+    pub suppress_power_key_until: Option<Duration>,
 
     pub devices: HashSet<input::Device>,
     pub tablets: HashMap<input::Device, TabletData>,
@@ -2522,6 +2524,7 @@ impl Niri {
             blocker_cleared_rx,
             monitors_active: true,
             is_lid_closed: false,
+            suppress_power_key_until: None,
 
             devices: HashSet::new(),
             tablets: HashMap::new(),
@@ -3050,8 +3053,22 @@ impl Niri {
 
         self.monitors_active = true;
         backend.set_monitors_active(true);
+        backend.on_output_config_changed(self);
 
         self.queue_redraw_all();
+    }
+
+    pub fn suppress_power_key_after_resume(&mut self) {
+        self.suppress_power_key_until =
+            Some(get_monotonic_time().saturating_add(POWER_KEY_RESUME_SUPPRESS_DURATION));
+    }
+
+    pub fn take_power_key_resume_suppression(&mut self, now: Duration) -> bool {
+        let Some(until) = self.suppress_power_key_until.take() else {
+            return false;
+        };
+
+        now <= until
     }
 
     pub fn output_under(&self, pos: Point<f64, Logical>) -> Option<(&Output, Point<f64, Logical>)> {


### PR DESCRIPTION
Fixes #4195.
Fixes #2233.

## Summary
- suppress the power-key press that wakes the compositor immediately after TTY resume
- keep the matching release suppressed without triggering suspend
- reapply output configuration when monitors are reactivated

## Tests
- cargo test -q power_key_wake_press_is_suppressed_after_resume
- cargo test -q power_key_still_suspends_outside_resume_suppression
- cargo check --message-format=short
- pre-push cargo check