### PR TITLE
Require keyboard focus for pointer constraints

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -6086,6 +6086,10 @@ impl Niri {
             return;
         }
 
+        if Some(surface) != self.keyboard_focus.surface() {
+            return;
+        }
+
         with_pointer_constraint(surface, &pointer, |constraint| {
             let Some(constraint) = constraint else { return };
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -6086,7 +6086,7 @@ impl Niri {
             return;
         }
 
-        if Some(surface) != self.keyboard_focus.surface() {
+        if Some(&self.find_root_shell_surface(surface)) != self.keyboard_focus.surface() {
             return;
         }
 


### PR DESCRIPTION
Fixes #4121.

## Summary
- require keyboard focus to match pointer focus before activating a pointer constraint
- keep existing pointer-focus and region checks unchanged

## Tests
- cargo check --message-format=short
- pre-push cargo check