### PR TITLE
Remove unused layout test import

### DIFF
--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -1,6 +1,6 @@
 use std::cell::{Cell, OnceCell, RefCell};
 
-use niri_config::utils::{Flag, MergeWith as _};
+use niri_config::utils::Flag;
 use niri_config::workspace::WorkspaceName;
 use niri_config::{
     CenterFocusedColumn, FloatOrInt, OutputName, Struts, TabIndicatorLength, TabIndicatorPosition,


### PR DESCRIPTION
## Summary
- remove an unused layout-test import that warns during test builds

## Tests
- cargo test -q operations_dont_panic
- cargo check --message-format=short
- pre-push cargo check