### PR TITLE
Add Mutter RemoteDesktop support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,6 +2281,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
+ "reis",
  "sd-notify",
  "serde",
  "serde_json",
@@ -3223,6 +3224,18 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reis"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3fedd2777cde52c1be5e572efbec485eac7b801c47820eda388d4f13b9c4b"
+dependencies = [
+ "calloop 0.14.4",
+ "enumflags2",
+ "log",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ pangocairo = "0.21.5"
 pipewire = { version = "0.9.2", optional = true, features = ["v0_3_33"] }
 png = "0.18.1"
 profiling = "1.0.17"
+reis = { version = "0.7.0", features = ["calloop"], optional = true }
 sd-notify = "0.5.0"
 serde.workspace = true
 serde_json.workspace = true
@@ -134,7 +135,7 @@ dbus = ["dep:zbus", "dep:async-io", "dep:accesskit", "dep:accesskit_unix"]
 # Enables systemd integration (global environment, apps in transient scopes).
 systemd = ["dbus"]
 # Enables screencasting support through xdg-desktop-portal-gnome.
-xdp-gnome-screencast = ["dbus", "pipewire"]
+xdp-gnome-screencast = ["dbus", "pipewire", "dep:reis"]
 # Enables the Tracy profiler instrumentation.
 profile-with-tracy = ["profiling/profile-with-tracy", "tracy-client/default", "smithay/tracy_gpu_profiling"]
 # Enables the on-demand Tracy profiler instrumentation.

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -13,7 +13,11 @@ pub mod mutter_display_config;
 pub mod mutter_service_channel;
 
 #[cfg(feature = "xdp-gnome-screencast")]
+pub mod mutter_remote_desktop;
+#[cfg(feature = "xdp-gnome-screencast")]
 pub mod mutter_screen_cast;
+#[cfg(feature = "xdp-gnome-screencast")]
+use mutter_remote_desktop::{RemoteDesktop, RemoteDesktopSessionRegistry};
 #[cfg(feature = "xdp-gnome-screencast")]
 use mutter_screen_cast::ScreenCast;
 
@@ -34,6 +38,10 @@ pub struct DBusServers {
     pub conn_screen_saver: Option<Connection>,
     pub conn_screen_shot: Option<Connection>,
     pub conn_introspect: Option<Connection>,
+    #[cfg(feature = "xdp-gnome-screencast")]
+    pub conn_remote_desktop: Option<Connection>,
+    #[cfg(feature = "xdp-gnome-screencast")]
+    pub remote_desktop_sessions: Option<RemoteDesktopSessionRegistry>,
     #[cfg(feature = "xdp-gnome-screencast")]
     pub conn_screen_cast: Option<Connection>,
     pub conn_login1: Option<Connection>,
@@ -118,6 +126,21 @@ impl DBusServers {
 
             #[cfg(feature = "xdp-gnome-screencast")]
             {
+                let remote_desktop_sessions = RemoteDesktopSessionRegistry::default();
+                let (to_remote_desktop_niri, from_remote_desktop) = calloop::channel::channel();
+                niri.event_loop
+                    .insert_source(from_remote_desktop, move |event, _, state| match event {
+                        calloop::channel::Event::Msg(msg) => {
+                            mutter_remote_desktop::dispatch_to_niri(state, msg)
+                        }
+                        calloop::channel::Event::Closed => (),
+                    })
+                    .unwrap();
+                let remote_desktop =
+                    RemoteDesktop::new(to_remote_desktop_niri, remote_desktop_sessions.clone());
+                dbus.conn_remote_desktop = try_start(remote_desktop);
+                dbus.remote_desktop_sessions = Some(remote_desktop_sessions.clone());
+
                 let (to_niri, from_screen_cast) = calloop::channel::channel();
                 niri.event_loop
                     .insert_source(from_screen_cast, {
@@ -127,7 +150,8 @@ impl DBusServers {
                         }
                     })
                     .unwrap();
-                let screen_cast = ScreenCast::new(backend.ipc_outputs(), to_niri);
+                let screen_cast =
+                    ScreenCast::new(backend.ipc_outputs(), to_niri, remote_desktop_sessions);
                 dbus.conn_screen_cast = try_start(screen_cast);
             }
 

--- a/src/dbus/mutter_remote_desktop/clipboard.rs
+++ b/src/dbus/mutter_remote_desktop/clipboard.rs
@@ -1,0 +1,247 @@
+use std::collections::HashMap;
+use std::os::fd::OwnedFd as StdOwnedFd;
+use std::os::unix::net::UnixStream;
+use std::sync::Arc;
+
+use smithay::wayland::selection::data_device::{
+    clear_data_device_selection, current_data_device_selection_userdata,
+    request_data_device_client_selection, set_data_device_selection, SelectionRequestError,
+};
+use zbus::fdo;
+use zbus::object_server::SignalEmitter;
+use zbus::zvariant::Value;
+
+use super::registry::RemoteDesktopSessionRegistry;
+use crate::handlers::{write_selection_bytes, SelectionData};
+use crate::niri::State;
+
+pub type RemoteDesktopClipboardReply = async_channel::Sender<Result<(), String>>;
+pub type RemoteDesktopClipboardReadReply = async_channel::Sender<Result<StdOwnedFd, String>>;
+
+#[derive(Debug, Default)]
+pub(super) struct RemoteDesktopClipboardSession {
+    pub(super) enabled: bool,
+    pub(super) signal_emitter: Option<SignalEmitter<'static>>,
+    pub(super) pending_writes: HashMap<u32, StdOwnedFd>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct RemoteDesktopClipboardOwner {
+    pub(super) session_id: Option<String>,
+    pub(super) mime_types: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RemoteDesktopClipboardSelection {
+    session_id: String,
+    registry: RemoteDesktopSessionRegistry,
+    mime_types: Arc<[String]>,
+}
+
+impl RemoteDesktopClipboardSelection {
+    pub fn new(
+        session_id: String,
+        registry: RemoteDesktopSessionRegistry,
+        mime_types: Vec<String>,
+    ) -> Self {
+        Self {
+            session_id,
+            registry,
+            mime_types: mime_types.into(),
+        }
+    }
+
+    pub fn contains_mime_type(&self, mime_type: &str) -> bool {
+        self.mime_types
+            .iter()
+            .any(|candidate| candidate == mime_type)
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    pub fn request_transfer(&self, mime_type: String, fd: StdOwnedFd) -> Result<(), String> {
+        if !self.contains_mime_type(&mime_type) {
+            return Err(format!(
+                "remote clipboard selection does not offer {mime_type}"
+            ));
+        }
+
+        self.registry
+            .request_clipboard_transfer(&self.session_id, mime_type, fd)
+            .map_err(|err| format!("{err:?}"))
+    }
+}
+
+pub fn parse_clipboard_mime_types(
+    options: &HashMap<&str, Value<'_>>,
+) -> fdo::Result<Option<Vec<String>>> {
+    let Some(value) = options.get("mime-types") else {
+        return Ok(None);
+    };
+
+    let value = value
+        .try_clone()
+        .map_err(|err| fdo::Error::Failed(format!("failed to clone mime-types: {err:?}")))?;
+    let mime_types = Vec::<String>::try_from(
+        value
+            .try_clone()
+            .map_err(|err| fdo::Error::Failed(format!("failed to clone mime-types: {err:?}")))?,
+    )
+    .or_else(|_| <(Vec<String>,)>::try_from(value).map(|tuple| tuple.0))
+    .map_err(|_| fdo::Error::InvalidArgs("mime-types must be a string array".to_owned()))?;
+    validate_mime_types(mime_types).map(Some)
+}
+
+pub fn enable_clipboard(
+    state: &mut State,
+    session_id: String,
+    mime_types: Option<Vec<String>>,
+) -> Result<(), String> {
+    let registry = remote_desktop_registry(state)?;
+    registry.enable_clipboard(&session_id)?;
+
+    if let Some(mime_types) = mime_types {
+        set_remote_clipboard_selection(state, registry, session_id, mime_types)
+    } else {
+        registry
+            .notify_session_current_clipboard_owner(&session_id)
+            .map_err(|err| format!("{err:?}"))
+    }
+}
+
+pub fn disable_clipboard(state: &mut State, session_id: String) -> Result<(), String> {
+    let registry = remote_desktop_registry(state)?;
+    let was_owner = registry.disable_clipboard(&session_id)?;
+
+    if was_owner {
+        clear_data_device_selection(&state.niri.display_handle, &state.niri.seat);
+        registry.notify_clipboard_owner_changed(None, Vec::new());
+    }
+
+    Ok(())
+}
+
+pub fn set_selection(
+    state: &mut State,
+    session_id: String,
+    mime_types: Option<Vec<String>>,
+) -> Result<(), String> {
+    let registry = remote_desktop_registry(state)?;
+    registry.ensure_clipboard_enabled(&session_id)?;
+
+    if let Some(mime_types) = mime_types {
+        set_remote_clipboard_selection(state, registry, session_id, mime_types)
+    } else if registry.clear_clipboard_owner_if_session(&session_id)? {
+        clear_data_device_selection(&state.niri.display_handle, &state.niri.seat);
+        registry.notify_clipboard_owner_changed(None, Vec::new());
+        Ok(())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn read_clipboard(
+    state: &mut State,
+    session_id: String,
+    mime_type: String,
+) -> Result<StdOwnedFd, String> {
+    let registry = remote_desktop_registry(state)?;
+    registry.ensure_clipboard_enabled(&session_id)?;
+
+    let (read_fd, write_fd) = fd_pair()?;
+
+    if let Some(selection) = current_data_device_selection_userdata(&state.niri.seat) {
+        send_compositor_selection(&session_id, &mime_type, write_fd, &selection)?;
+        return Ok(read_fd);
+    }
+
+    request_data_device_client_selection(&state.niri.seat, mime_type, write_fd)
+        .map_err(selection_request_error)?;
+    Ok(read_fd)
+}
+
+pub(super) fn fd_pair() -> Result<(StdOwnedFd, StdOwnedFd), String> {
+    let (reader, writer) =
+        UnixStream::pair().map_err(|err| format!("failed to create clipboard pipe: {err:?}"))?;
+    Ok((reader.into(), writer.into()))
+}
+
+fn set_remote_clipboard_selection(
+    state: &mut State,
+    registry: RemoteDesktopSessionRegistry,
+    session_id: String,
+    mime_types: Vec<String>,
+) -> Result<(), String> {
+    let mime_types = validate_mime_types(mime_types).map_err(|err| format!("{err:?}"))?;
+    let selection = RemoteDesktopClipboardSelection::new(
+        session_id.clone(),
+        registry.clone(),
+        mime_types.clone(),
+    );
+    set_data_device_selection(
+        &state.niri.display_handle,
+        &state.niri.seat,
+        mime_types.clone(),
+        SelectionData::RemoteDesktop(selection),
+    );
+    registry.notify_clipboard_owner_changed(Some(session_id), mime_types);
+    Ok(())
+}
+
+fn send_compositor_selection(
+    requesting_session_id: &str,
+    mime_type: &str,
+    fd: StdOwnedFd,
+    selection: &SelectionData,
+) -> Result<(), String> {
+    if !selection.contains_mime_type(mime_type) {
+        return Err(format!("clipboard selection does not offer {mime_type}"));
+    }
+
+    match selection {
+        SelectionData::Bytes { data, .. } => write_selection_bytes(fd, data.clone()),
+        SelectionData::RemoteDesktop(remote_selection) => {
+            if remote_selection.session_id() == requesting_session_id {
+                return Err("remote desktop session cannot read its own clipboard".to_owned());
+            }
+
+            remote_selection.request_transfer(mime_type.to_owned(), fd)
+        }
+    }
+}
+
+fn remote_desktop_registry(state: &State) -> Result<RemoteDesktopSessionRegistry, String> {
+    state
+        .niri
+        .dbus
+        .as_ref()
+        .and_then(|dbus| dbus.remote_desktop_sessions.clone())
+        .ok_or_else(|| "remote desktop session registry is not available".to_owned())
+}
+
+fn validate_mime_types(mime_types: Vec<String>) -> fdo::Result<Vec<String>> {
+    if mime_types.is_empty() {
+        return Err(fdo::Error::InvalidArgs(
+            "mime-types must not be empty".to_owned(),
+        ));
+    }
+
+    if mime_types.iter().any(|mime_type| mime_type.is_empty()) {
+        return Err(fdo::Error::InvalidArgs(
+            "mime-types must not contain empty values".to_owned(),
+        ));
+    }
+
+    Ok(mime_types)
+}
+
+fn selection_request_error(err: SelectionRequestError) -> String {
+    match err {
+        SelectionRequestError::InvalidMimetype => "requested clipboard MIME type is not available",
+        SelectionRequestError::ServerSideSelection => "current clipboard selection is server-side",
+        SelectionRequestError::NoSelection => "no clipboard selection is active",
+    }
+    .to_owned()
+}

--- a/src/dbus/mutter_remote_desktop/clipboard_registry.rs
+++ b/src/dbus/mutter_remote_desktop/clipboard_registry.rs
@@ -1,0 +1,204 @@
+use std::os::fd::OwnedFd as StdOwnedFd;
+use std::sync::atomic::Ordering;
+
+use zbus::fdo;
+use zbus::object_server::SignalEmitter;
+
+use super::clipboard::{fd_pair, RemoteDesktopClipboardOwner};
+use super::clipboard_signals::{copy_fd, emit_owner_changed, emit_selection_transfer};
+use super::registry::RemoteDesktopSessionRegistry;
+
+impl RemoteDesktopSessionRegistry {
+    pub fn set_clipboard_signal_emitter(
+        &self,
+        session_id: &str,
+        signal_emitter: SignalEmitter<'static>,
+    ) -> fdo::Result<()> {
+        self.with_session(session_id, |session| {
+            session.clipboard.signal_emitter = Some(signal_emitter);
+            Ok(())
+        })
+    }
+
+    pub fn enable_clipboard(&self, session_id: &str) -> Result<(), String> {
+        self.with_session(session_id, |session| {
+            if session.clipboard.enabled {
+                return Err(fdo::Error::Failed(
+                    "clipboard is already enabled".to_owned(),
+                ));
+            }
+
+            session.clipboard.enabled = true;
+            Ok(())
+        })
+        .map_err(|err| format!("{err:?}"))
+    }
+
+    pub fn disable_clipboard(&self, session_id: &str) -> Result<bool, String> {
+        self.with_session(session_id, |session| {
+            session.clipboard.enabled = false;
+            session.clipboard.pending_writes.clear();
+            Ok(())
+        })
+        .map_err(|err| format!("{err:?}"))?;
+
+        let mut owner = self
+            .clipboard_owner
+            .lock()
+            .map_err(|_| "remote desktop clipboard owner is poisoned".to_owned())?;
+        let was_owner = owner.session_id.as_deref() == Some(session_id);
+        if was_owner {
+            *owner = RemoteDesktopClipboardOwner::default();
+        }
+
+        Ok(was_owner)
+    }
+
+    pub fn clear_clipboard_owner_if_session(&self, session_id: &str) -> Result<bool, String> {
+        let mut owner = self
+            .clipboard_owner
+            .lock()
+            .map_err(|_| "remote desktop clipboard owner is poisoned".to_owned())?;
+        if owner.session_id.as_deref() != Some(session_id) {
+            return Ok(false);
+        }
+
+        *owner = RemoteDesktopClipboardOwner::default();
+        Ok(true)
+    }
+
+    pub fn ensure_clipboard_enabled(&self, session_id: &str) -> Result<(), String> {
+        self.with_session(session_id, |session| {
+            if !session.clipboard.enabled {
+                return Err(fdo::Error::Failed("clipboard is not enabled".to_owned()));
+            }
+
+            Ok(())
+        })
+        .map_err(|err| format!("{err:?}"))
+    }
+
+    pub fn selection_write(&self, session_id: &str, serial: u32) -> fdo::Result<StdOwnedFd> {
+        self.with_session(session_id, |session| {
+            if !session.clipboard.enabled {
+                return Err(fdo::Error::Failed("clipboard is not enabled".to_owned()));
+            }
+
+            let Some(fd) = session.clipboard.pending_writes.remove(&serial) else {
+                return Err(fdo::Error::InvalidArgs(format!(
+                    "unknown clipboard transfer serial: {serial}"
+                )));
+            };
+
+            Ok(fd)
+        })
+    }
+
+    pub fn selection_write_done(&self, session_id: &str, serial: u32) -> fdo::Result<()> {
+        self.with_session(session_id, |session| {
+            if !session.clipboard.enabled {
+                return Err(fdo::Error::Failed("clipboard is not enabled".to_owned()));
+            }
+
+            session.clipboard.pending_writes.remove(&serial);
+            Ok(())
+        })
+    }
+
+    pub fn request_clipboard_transfer(
+        &self,
+        session_id: &str,
+        mime_type: String,
+        target_fd: StdOwnedFd,
+    ) -> fdo::Result<()> {
+        let serial = self.next_clipboard_serial.fetch_add(1, Ordering::SeqCst);
+        let (read_fd, write_fd) = fd_pair().map_err(fdo::Error::Failed)?;
+        let signal_emitter = self.with_session(session_id, |session| {
+            if !session.clipboard.enabled {
+                return Err(fdo::Error::Failed("clipboard is not enabled".to_owned()));
+            }
+
+            let Some(signal_emitter) = session.clipboard.signal_emitter.clone() else {
+                return Err(fdo::Error::Failed(
+                    "clipboard signal emitter is not registered".to_owned(),
+                ));
+            };
+
+            session.clipboard.pending_writes.insert(serial, write_fd);
+            Ok(signal_emitter)
+        })?;
+
+        copy_fd(read_fd, target_fd);
+        emit_selection_transfer(signal_emitter, mime_type, serial);
+        Ok(())
+    }
+
+    pub fn notify_clipboard_owner_changed(
+        &self,
+        owner_session_id: Option<String>,
+        mime_types: Vec<String>,
+    ) {
+        if let Ok(mut owner) = self.clipboard_owner.lock() {
+            owner.session_id = owner_session_id.clone();
+            owner.mime_types = mime_types.clone();
+        } else {
+            warn!("remote desktop clipboard owner is poisoned");
+            return;
+        }
+
+        let emissions =
+            match self.clipboard_owner_emissions(owner_session_id.as_deref(), mime_types) {
+                Ok(emissions) => emissions,
+                Err(err) => {
+                    warn!("error collecting remote desktop clipboard notifications: {err:?}");
+                    return;
+                }
+            };
+
+        for (signal_emitter, session_is_owner, mime_types) in emissions {
+            emit_owner_changed(signal_emitter, session_is_owner, mime_types);
+        }
+    }
+
+    pub fn notify_session_current_clipboard_owner(&self, session_id: &str) -> fdo::Result<()> {
+        let owner = self.clipboard_owner.lock().map_err(|_| {
+            fdo::Error::Failed("remote desktop clipboard owner is poisoned".to_owned())
+        })?;
+        let session_is_owner = owner.session_id.as_deref() == Some(session_id);
+        let mime_types = owner.mime_types.clone();
+        drop(owner);
+
+        let signal_emitter = self.with_session(session_id, |session| {
+            if !session.clipboard.enabled {
+                return Err(fdo::Error::Failed("clipboard is not enabled".to_owned()));
+            }
+
+            session.clipboard.signal_emitter.clone().ok_or_else(|| {
+                fdo::Error::Failed("clipboard signal emitter is not registered".to_owned())
+            })
+        })?;
+
+        emit_owner_changed(signal_emitter, session_is_owner, mime_types);
+        Ok(())
+    }
+
+    fn clipboard_owner_emissions(
+        &self,
+        owner_session_id: Option<&str>,
+        mime_types: Vec<String>,
+    ) -> fdo::Result<Vec<(SignalEmitter<'static>, bool, Vec<String>)>> {
+        self.with_sessions(|sessions| {
+            Ok(sessions
+                .iter()
+                .filter_map(|(session_id, session)| {
+                    if !session.clipboard.enabled {
+                        return None;
+                    }
+                    let signal_emitter = session.clipboard.signal_emitter.clone()?;
+                    let session_is_owner = owner_session_id == Some(session_id.as_str());
+                    Some((signal_emitter, session_is_owner, mime_types.clone()))
+                })
+                .collect())
+        })
+    }
+}

--- a/src/dbus/mutter_remote_desktop/clipboard_signals.rs
+++ b/src/dbus/mutter_remote_desktop/clipboard_signals.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::os::fd::OwnedFd as StdOwnedFd;
+use std::thread;
+
+use zbus::object_server::SignalEmitter;
+use zbus::zvariant::Value;
+
+use super::session::Session;
+
+pub(super) fn emit_owner_changed(
+    signal_emitter: SignalEmitter<'static>,
+    session_is_owner: bool,
+    mime_types: Vec<String>,
+) {
+    let task_name = "emit remote desktop clipboard owner changed";
+    let connection = signal_emitter.connection().clone();
+    connection
+        .executor()
+        .spawn(
+            async move {
+                let mut options = HashMap::new();
+                options.insert("mime-types", Value::new(mime_types));
+                options.insert("session-is-owner", Value::new(session_is_owner));
+
+                if let Err(err) = Session::selection_owner_changed(&signal_emitter, options).await {
+                    warn!("error emitting RemoteDesktop SelectionOwnerChanged signal: {err:?}");
+                }
+            },
+            task_name,
+        )
+        .detach();
+}
+
+pub(super) fn emit_selection_transfer(
+    signal_emitter: SignalEmitter<'static>,
+    mime_type: String,
+    serial: u32,
+) {
+    let task_name = "emit remote desktop clipboard transfer";
+    let connection = signal_emitter.connection().clone();
+    connection
+        .executor()
+        .spawn(
+            async move {
+                if let Err(err) =
+                    Session::selection_transfer(&signal_emitter, &mime_type, serial).await
+                {
+                    warn!("error emitting RemoteDesktop SelectionTransfer signal: {err:?}");
+                }
+            },
+            task_name,
+        )
+        .detach();
+}
+
+pub(super) fn copy_fd(source_fd: StdOwnedFd, target_fd: StdOwnedFd) {
+    thread::spawn(move || {
+        let mut source = File::from(source_fd);
+        let mut target = File::from(target_fd);
+        if let Err(err) = std::io::copy(&mut source, &mut target) {
+            warn!("error copying remote desktop clipboard transfer: {err:?}");
+        }
+    });
+}

--- a/src/dbus/mutter_remote_desktop/clipboard_tests.rs
+++ b/src/dbus/mutter_remote_desktop/clipboard_tests.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+
+use zbus::zvariant::Value;
+
+use super::clipboard::parse_clipboard_mime_types;
+
+#[test]
+fn parses_plain_mime_type_arrays() {
+    let options = HashMap::from([(
+        "mime-types",
+        Value::new(vec![
+            "text/plain;charset=utf-8".to_owned(),
+            "text/plain".to_owned(),
+        ]),
+    )]);
+
+    let mime_types = parse_clipboard_mime_types(&options).unwrap().unwrap();
+
+    assert_eq!(mime_types, ["text/plain;charset=utf-8", "text/plain"]);
+}
+
+#[test]
+fn rejects_empty_mime_type_arrays() {
+    let options = HashMap::from([("mime-types", Value::new(Vec::<String>::new()))]);
+
+    let err = parse_clipboard_mime_types(&options).unwrap_err();
+
+    assert!(format!("{err:?}").contains("must not be empty"));
+}

--- a/src/dbus/mutter_remote_desktop/device_types.rs
+++ b/src/dbus/mutter_remote_desktop/device_types.rs
@@ -1,0 +1,107 @@
+use std::collections::HashMap;
+
+use reis::enumflags2::BitFlags;
+use reis::request::DeviceCapability;
+use zbus::fdo;
+use zbus::zvariant::Value;
+
+pub const DEVICE_TYPE_KEYBOARD: u32 = 1;
+pub const DEVICE_TYPE_POINTER: u32 = 2;
+pub const DEVICE_TYPE_TOUCHSCREEN: u32 = 4;
+
+const SUPPORTED_DEVICE_TYPES: u32 =
+    DEVICE_TYPE_KEYBOARD | DEVICE_TYPE_POINTER | DEVICE_TYPE_TOUCHSCREEN;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemoteDesktopDeviceTypes {
+    bits: u32,
+}
+
+impl Default for RemoteDesktopDeviceTypes {
+    fn default() -> Self {
+        Self {
+            bits: SUPPORTED_DEVICE_TYPES,
+        }
+    }
+}
+
+impl RemoteDesktopDeviceTypes {
+    pub fn from_options(options: &HashMap<&str, Value<'_>>) -> fdo::Result<Self> {
+        let bits = match options.get("device-types") {
+            Some(value) => value
+                .downcast_ref::<u32>()
+                .map_err(|_| fdo::Error::InvalidArgs("device-types must be a uint32".to_owned()))?,
+            None => SUPPORTED_DEVICE_TYPES,
+        };
+
+        if bits & !SUPPORTED_DEVICE_TYPES != 0 {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "unsupported remote desktop device types: 0x{:x}",
+                bits & !SUPPORTED_DEVICE_TYPES
+            )));
+        }
+
+        Ok(Self {
+            bits: bits & SUPPORTED_DEVICE_TYPES,
+        })
+    }
+
+    pub fn keyboard(self) -> bool {
+        self.bits & DEVICE_TYPE_KEYBOARD != 0
+    }
+
+    pub fn pointer(self) -> bool {
+        self.bits & DEVICE_TYPE_POINTER != 0
+    }
+
+    pub fn touchscreen(self) -> bool {
+        self.bits & DEVICE_TYPE_TOUCHSCREEN != 0
+    }
+
+    pub fn capabilities(self) -> BitFlags<DeviceCapability> {
+        let mut capabilities = BitFlags::empty();
+
+        if self.pointer() {
+            capabilities |= DeviceCapability::Pointer;
+            capabilities |= DeviceCapability::PointerAbsolute;
+            capabilities |= DeviceCapability::Button;
+            capabilities |= DeviceCapability::Scroll;
+        }
+
+        if self.keyboard() {
+            capabilities |= DeviceCapability::Keyboard;
+        }
+
+        if self.touchscreen() {
+            capabilities |= DeviceCapability::Touch;
+        }
+
+        capabilities
+    }
+}
+
+pub fn supported_device_types() -> u32 {
+    SUPPORTED_DEVICE_TYPES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_types_default_to_every_supported_type() {
+        let types = RemoteDesktopDeviceTypes::from_options(&HashMap::new()).unwrap();
+
+        assert!(types.keyboard());
+        assert!(types.pointer());
+        assert!(types.touchscreen());
+    }
+
+    #[test]
+    fn device_types_reject_unknown_bits() {
+        let options = HashMap::from([("device-types", Value::new(8_u32))]);
+        let err = RemoteDesktopDeviceTypes::from_options(&options).unwrap_err();
+
+        assert!(format!("{err:?}").contains("unsupported"));
+    }
+}

--- a/src/dbus/mutter_remote_desktop/eis.rs
+++ b/src/dbus/mutter_remote_desktop/eis.rs
@@ -1,0 +1,648 @@
+use std::os::unix::net::UnixStream;
+
+use calloop::PostAction;
+use reis::calloop::{EisRequestSource, EisRequestSourceEvent};
+use reis::eis::device::DeviceType;
+use reis::enumflags2::BitFlags;
+use reis::request::{
+    Bind, Connection, Device, DeviceCapability, DeviceClosed, EisRequest, RequestDevice,
+};
+use smithay::backend::input::{AxisSource, ButtonState, KeyState, Keycode};
+
+use super::device_types::RemoteDesktopDeviceTypes;
+use super::input::{dispatch_to_niri, RemoteDesktopAxisFrame, RemoteDesktopPosition};
+use super::keymap::current_keymap_file;
+use super::legacy_input::XKB_KEYCODE_OFFSET;
+use super::registry::{
+    RemoteDesktopOutputRegion, RemoteDesktopSessionRegistry, RemoteDesktopStreamPosition,
+};
+use crate::dbus::mutter_remote_desktop::RemoteDesktopToNiri;
+use crate::niri::State;
+
+#[derive(Debug)]
+pub struct RemoteDesktopEisConnection {
+    socket: UnixStream,
+    session_id: String,
+    registry: RemoteDesktopSessionRegistry,
+    device_types: RemoteDesktopDeviceTypes,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct EisOutputRegion {
+    mapping_id: String,
+    output_name: String,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+}
+
+#[derive(Default)]
+struct RemoteDesktopEisState {
+    session_id: String,
+    registry: RemoteDesktopSessionRegistry,
+    device_types: RemoteDesktopDeviceTypes,
+    regions: Vec<EisOutputRegion>,
+    seat: Option<reis::request::Seat>,
+    keyboard: Option<Device>,
+    pointer: Option<Device>,
+    pointer_absolute: Option<Device>,
+    touch: Option<Device>,
+}
+
+impl RemoteDesktopEisConnection {
+    pub fn new(
+        socket: UnixStream,
+        session_id: String,
+        registry: RemoteDesktopSessionRegistry,
+        device_types: RemoteDesktopDeviceTypes,
+    ) -> Self {
+        Self {
+            socket,
+            session_id,
+            registry,
+            device_types,
+        }
+    }
+}
+
+pub fn connect_to_niri(
+    state: &mut State,
+    connection: RemoteDesktopEisConnection,
+) -> Result<(), String> {
+    let context = reis::eis::Context::new(connection.socket)
+        .map_err(|err| format!("failed to create EIS context: {err:?}"))?;
+    let source = EisRequestSource::new(context, 1);
+    let mut eis_state = RemoteDesktopEisState {
+        session_id: connection.session_id,
+        registry: connection.registry,
+        device_types: connection.device_types,
+        regions: Vec::new(),
+        seat: None,
+        keyboard: None,
+        pointer: None,
+        pointer_absolute: None,
+        touch: None,
+    };
+
+    state
+        .niri
+        .event_loop
+        .insert_source(source, move |event, connection, state| {
+            Ok(eis_state.handle_source_event(event, connection, state))
+        })
+        .map_err(|err| format!("failed to insert EIS source: {err:?}"))?;
+
+    Ok(())
+}
+
+impl RemoteDesktopEisState {
+    fn handle_source_event(
+        &mut self,
+        event: Result<EisRequestSourceEvent, reis::Error>,
+        connection: &mut Connection,
+        state: &mut State,
+    ) -> PostAction {
+        let action = match event {
+            Ok(EisRequestSourceEvent::Connected) => {
+                self.handle_connected(connection);
+                PostAction::Continue
+            }
+            Ok(EisRequestSourceEvent::Request(request)) => {
+                self.handle_request(connection, state, request)
+            }
+            Err(err) => {
+                warn!("error communicating with remote desktop EIS client: {err:?}");
+                PostAction::Remove
+            }
+        };
+
+        if let Err(err) = connection.flush() {
+            warn!("error flushing remote desktop EIS connection: {err:?}");
+            return PostAction::Remove;
+        }
+
+        action
+    }
+
+    fn handle_connected(&mut self, connection: &Connection) {
+        self.regions = match output_regions(&self.registry, &self.session_id) {
+            Ok(regions) => regions,
+            Err(err) => {
+                warn!("error resolving remote desktop EIS output regions: {err:?}");
+                Vec::new()
+            }
+        };
+        self.seat = Some(connection.add_seat(Some("niri"), self.device_types.capabilities()));
+    }
+
+    fn handle_request(
+        &mut self,
+        connection: &Connection,
+        state: &mut State,
+        request: EisRequest,
+    ) -> PostAction {
+        match request {
+            EisRequest::Disconnect => PostAction::Remove,
+            EisRequest::Bind(request) => {
+                self.handle_bind(connection, state, request);
+                PostAction::Continue
+            }
+            EisRequest::RequestDevice(request) => {
+                self.handle_request_device(connection, state, request);
+                PostAction::Continue
+            }
+            EisRequest::DeviceClosed(request) => {
+                self.handle_device_closed(request);
+                PostAction::Continue
+            }
+            EisRequest::KeyboardKey(event) => {
+                dispatch_to_niri(state, keyboard_key_event(event.key, event.state));
+                PostAction::Continue
+            }
+            EisRequest::PointerMotion(event) => {
+                dispatch_to_niri(
+                    state,
+                    RemoteDesktopToNiri::PointerMotionRelative {
+                        dx: f64::from(event.dx),
+                        dy: f64::from(event.dy),
+                    },
+                );
+                PostAction::Continue
+            }
+            EisRequest::PointerMotionAbsolute(event) => {
+                if let Some(position) = self
+                    .absolute_position(f64::from(event.dx_absolute), f64::from(event.dy_absolute))
+                {
+                    dispatch_to_niri(
+                        state,
+                        RemoteDesktopToNiri::PointerMotionAbsolute { position },
+                    );
+                }
+                PostAction::Continue
+            }
+            EisRequest::Button(event) => {
+                dispatch_to_niri(
+                    state,
+                    RemoteDesktopToNiri::PointerButton {
+                        button: event.button,
+                        state: button_state(event.state),
+                    },
+                );
+                PostAction::Continue
+            }
+            EisRequest::ScrollDelta(event) => {
+                dispatch_to_niri(
+                    state,
+                    RemoteDesktopToNiri::PointerAxis {
+                        frame: smooth_scroll_frame(f64::from(event.dx), f64::from(event.dy)),
+                    },
+                );
+                PostAction::Continue
+            }
+            EisRequest::ScrollStop(event) => {
+                dispatch_to_niri(
+                    state,
+                    RemoteDesktopToNiri::PointerAxis {
+                        frame: stop_scroll_frame(event.x, event.y),
+                    },
+                );
+                PostAction::Continue
+            }
+            EisRequest::ScrollCancel(event) => {
+                dispatch_to_niri(
+                    state,
+                    RemoteDesktopToNiri::PointerAxis {
+                        frame: cancel_scroll_frame(event.x, event.y),
+                    },
+                );
+                PostAction::Continue
+            }
+            EisRequest::ScrollDiscrete(event) => {
+                dispatch_to_niri(
+                    state,
+                    RemoteDesktopToNiri::PointerAxis {
+                        frame: discrete_scroll_frame(event.discrete_dx, event.discrete_dy),
+                    },
+                );
+                PostAction::Continue
+            }
+            EisRequest::TouchDown(event) => {
+                if let Some(position) =
+                    self.absolute_position(f64::from(event.x), f64::from(event.y))
+                {
+                    dispatch_to_niri(
+                        state,
+                        RemoteDesktopToNiri::TouchDown {
+                            slot: event.touch_id,
+                            position,
+                        },
+                    );
+                }
+                PostAction::Continue
+            }
+            EisRequest::TouchMotion(event) => {
+                if let Some(position) =
+                    self.absolute_position(f64::from(event.x), f64::from(event.y))
+                {
+                    dispatch_to_niri(
+                        state,
+                        RemoteDesktopToNiri::TouchMotion {
+                            slot: event.touch_id,
+                            position,
+                        },
+                    );
+                }
+                PostAction::Continue
+            }
+            EisRequest::TouchUp(event) => {
+                dispatch_to_niri(
+                    state,
+                    RemoteDesktopToNiri::TouchUp {
+                        slot: event.touch_id,
+                    },
+                );
+                PostAction::Continue
+            }
+            EisRequest::TouchCancel(event) => {
+                dispatch_to_niri(
+                    state,
+                    RemoteDesktopToNiri::TouchUp {
+                        slot: event.touch_id,
+                    },
+                );
+                PostAction::Continue
+            }
+            EisRequest::Frame(_)
+            | EisRequest::Ready(_)
+            | EisRequest::DeviceStartEmulating(_)
+            | EisRequest::DeviceStopEmulating(_)
+            | EisRequest::TextKeysym(_)
+            | EisRequest::TextUtf8(_) => PostAction::Continue,
+        }
+    }
+
+    fn handle_bind(&mut self, connection: &Connection, state: &State, request: Bind) {
+        if self.seat.is_none() {
+            self.seat = Some(request.seat.clone());
+        }
+        self.add_requested_devices(connection, state, &request.seat, request.capabilities);
+    }
+
+    fn handle_request_device(
+        &mut self,
+        connection: &Connection,
+        state: &State,
+        request: RequestDevice,
+    ) {
+        self.add_requested_devices(connection, state, &request.seat, request.capabilities);
+    }
+
+    fn add_requested_devices(
+        &mut self,
+        connection: &Connection,
+        state: &State,
+        seat: &reis::request::Seat,
+        capabilities: BitFlags<DeviceCapability>,
+    ) {
+        if self.keyboard.is_none()
+            && self.device_types.keyboard()
+            && capabilities.contains(DeviceCapability::Keyboard)
+        {
+            self.keyboard = self.add_device(
+                connection,
+                state,
+                seat,
+                "niri remote desktop keyboard",
+                DeviceCapability::Keyboard.into(),
+            );
+        }
+
+        if self.pointer.is_none()
+            && self.device_types.pointer()
+            && capabilities.contains(DeviceCapability::Pointer)
+        {
+            self.pointer = self.add_device(
+                connection,
+                state,
+                seat,
+                "niri remote desktop pointer",
+                pointer_capabilities(capabilities),
+            );
+        }
+
+        if self.pointer_absolute.is_none()
+            && self.device_types.pointer()
+            && capabilities.contains(DeviceCapability::PointerAbsolute)
+        {
+            self.pointer_absolute = self.add_device(
+                connection,
+                state,
+                seat,
+                "niri remote desktop absolute pointer",
+                pointer_absolute_capabilities(capabilities),
+            );
+        }
+
+        if self.touch.is_none()
+            && self.device_types.touchscreen()
+            && capabilities.contains(DeviceCapability::Touch)
+        {
+            self.touch = self.add_device(
+                connection,
+                state,
+                seat,
+                "niri remote desktop touch",
+                DeviceCapability::Touch.into(),
+            );
+        }
+    }
+
+    fn add_device(
+        &self,
+        connection: &Connection,
+        state: &State,
+        seat: &reis::request::Seat,
+        name: &str,
+        capabilities: BitFlags<DeviceCapability>,
+    ) -> Option<Device> {
+        if capabilities.is_empty() {
+            return None;
+        }
+
+        let regions = if capabilities.contains(DeviceCapability::PointerAbsolute)
+            || capabilities.contains(DeviceCapability::Touch)
+        {
+            self.regions.clone()
+        } else {
+            Vec::new()
+        };
+        let keymap_file = if capabilities.contains(DeviceCapability::Keyboard) {
+            match current_keymap_file(state) {
+                Ok(file) => Some(file),
+                Err(err) => {
+                    warn!("error compiling remote desktop EIS keymap: {err}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let device = seat.add_device(Some(name), DeviceType::Virtual, capabilities, |device| {
+            if let Some(keymap_file) = keymap_file.as_ref() {
+                if let Some(keyboard) = device.interface::<reis::eis::Keyboard>() {
+                    if let Err(err) = keymap_file.with_fd(true, |fd, len| {
+                        keyboard.keymap(reis::eis::keyboard::KeymapType::Xkb, len as u32, fd);
+                    }) {
+                        warn!("error creating remote desktop EIS keymap fd: {err:?}");
+                    }
+                }
+            }
+
+            for region in &regions {
+                device.device().region_mapping_id(&region.mapping_id);
+                device
+                    .device()
+                    .region(region.x, region.y, region.width, region.height, 1.0);
+            }
+        });
+        device.resumed();
+        if connection.context_type() == reis::eis::handshake::ContextType::Receiver {
+            device.start_emulating(1);
+        }
+
+        Some(device)
+    }
+
+    fn handle_device_closed(&mut self, request: DeviceClosed) {
+        request.device.remove();
+        clear_matching_device(&mut self.keyboard, &request.device);
+        clear_matching_device(&mut self.pointer, &request.device);
+        clear_matching_device(&mut self.pointer_absolute, &request.device);
+        clear_matching_device(&mut self.touch, &request.device);
+    }
+
+    fn absolute_position(&self, x: f64, y: f64) -> Option<RemoteDesktopPosition> {
+        if !x.is_finite() || !y.is_finite() {
+            warn!("remote desktop EIS absolute coordinates must be finite");
+            return None;
+        }
+
+        let position = self.regions.iter().find_map(|region| {
+            let region_x = f64::from(region.x);
+            let region_y = f64::from(region.y);
+            let width = f64::from(region.width);
+            let height = f64::from(region.height);
+            if x < region_x || y < region_y || x >= region_x + width || y >= region_y + height {
+                return None;
+            }
+
+            Some(RemoteDesktopStreamPosition {
+                output_name: region.output_name.clone(),
+                x: x - region_x,
+                y: y - region_y,
+                width: i32::try_from(region.width).unwrap_or(i32::MAX),
+                height: i32::try_from(region.height).unwrap_or(i32::MAX),
+            })
+        });
+
+        let Some(position) = position else {
+            warn!("remote desktop EIS absolute coordinates did not match any output region");
+            return None;
+        };
+
+        Some(RemoteDesktopPosition {
+            output_name: position.output_name,
+            x: position.x,
+            y: position.y,
+            width: position.width,
+            height: position.height,
+        })
+    }
+}
+
+fn output_regions(
+    registry: &RemoteDesktopSessionRegistry,
+    session_id: &str,
+) -> Result<Vec<EisOutputRegion>, String> {
+    let regions = registry
+        .output_regions(session_id)
+        .map_err(|err| format!("{err:?}"))?;
+    normalize_regions(&regions)
+}
+
+fn normalize_regions(
+    regions: &[RemoteDesktopOutputRegion],
+) -> Result<Vec<EisOutputRegion>, String> {
+    let min_x = regions.iter().map(|region| region.x).min().unwrap_or(0);
+    let min_y = regions.iter().map(|region| region.y).min().unwrap_or(0);
+
+    regions
+        .iter()
+        .map(|region| normalize_region(region, min_x, min_y))
+        .collect()
+}
+
+fn normalize_region(
+    region: &RemoteDesktopOutputRegion,
+    min_x: i32,
+    min_y: i32,
+) -> Result<EisOutputRegion, String> {
+    let width = u32::try_from(region.width)
+        .map_err(|_| format!("output {} has a negative width", region.output_name))?;
+    let height = u32::try_from(region.height)
+        .map_err(|_| format!("output {} has a negative height", region.output_name))?;
+    if width == 0 || height == 0 {
+        return Err(format!("output {} has an empty region", region.output_name));
+    }
+
+    Ok(EisOutputRegion {
+        mapping_id: region.mapping_id.to_string(),
+        output_name: region.output_name.clone(),
+        x: u32::try_from(region.x - min_x)
+            .map_err(|_| format!("output {} has an invalid x offset", region.output_name))?,
+        y: u32::try_from(region.y - min_y)
+            .map_err(|_| format!("output {} has an invalid y offset", region.output_name))?,
+        width,
+        height,
+    })
+}
+
+fn pointer_capabilities(requested: BitFlags<DeviceCapability>) -> BitFlags<DeviceCapability> {
+    let mut capabilities = DeviceCapability::Pointer.into();
+    if requested.contains(DeviceCapability::Button) {
+        capabilities |= DeviceCapability::Button;
+    }
+    if requested.contains(DeviceCapability::Scroll) {
+        capabilities |= DeviceCapability::Scroll;
+    }
+    capabilities
+}
+
+fn pointer_absolute_capabilities(
+    requested: BitFlags<DeviceCapability>,
+) -> BitFlags<DeviceCapability> {
+    let mut capabilities = DeviceCapability::PointerAbsolute.into();
+    if requested.contains(DeviceCapability::Button) {
+        capabilities |= DeviceCapability::Button;
+    }
+    if requested.contains(DeviceCapability::Scroll) {
+        capabilities |= DeviceCapability::Scroll;
+    }
+    capabilities
+}
+
+fn clear_matching_device(slot: &mut Option<Device>, device: &Device) {
+    if slot.as_ref() == Some(device) {
+        *slot = None;
+    }
+}
+
+fn keyboard_key_event(key: u32, state: reis::eis::keyboard::KeyState) -> RemoteDesktopToNiri {
+    RemoteDesktopToNiri::KeyboardKeycode {
+        keycode: Keycode::from(key.saturating_add(XKB_KEYCODE_OFFSET)),
+        state: key_state(state),
+    }
+}
+
+fn key_state(state: reis::eis::keyboard::KeyState) -> KeyState {
+    match state {
+        reis::eis::keyboard::KeyState::Released => KeyState::Released,
+        reis::eis::keyboard::KeyState::Press => KeyState::Pressed,
+    }
+}
+
+fn button_state(state: reis::eis::button::ButtonState) -> ButtonState {
+    match state {
+        reis::eis::button::ButtonState::Released => ButtonState::Released,
+        reis::eis::button::ButtonState::Press => ButtonState::Pressed,
+    }
+}
+
+fn smooth_scroll_frame(dx: f64, dy: f64) -> RemoteDesktopAxisFrame {
+    RemoteDesktopAxisFrame {
+        smooth: Some((dx, dy)),
+        v120: None,
+        source: AxisSource::Wheel,
+        stop: (false, false),
+    }
+}
+
+fn stop_scroll_frame(x: bool, y: bool) -> RemoteDesktopAxisFrame {
+    RemoteDesktopAxisFrame {
+        smooth: Some((0.0, 0.0)),
+        v120: None,
+        source: AxisSource::Wheel,
+        stop: (x, y),
+    }
+}
+
+fn cancel_scroll_frame(x: bool, y: bool) -> RemoteDesktopAxisFrame {
+    RemoteDesktopAxisFrame {
+        smooth: Some((if x { 0.01 } else { 0.0 }, if y { 0.01 } else { 0.0 })),
+        v120: None,
+        source: AxisSource::Wheel,
+        stop: (x, y),
+    }
+}
+
+fn discrete_scroll_frame(dx: i32, dy: i32) -> RemoteDesktopAxisFrame {
+    RemoteDesktopAxisFrame {
+        smooth: None,
+        v120: Some((f64::from(dx), f64::from(dy))),
+        source: AxisSource::Wheel,
+        stop: (false, false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eis_regions_are_normalized_to_positive_coordinates() {
+        let regions = vec![
+            RemoteDesktopOutputRegion {
+                mapping_id: 11,
+                output_name: "HDMI-A-1".to_owned(),
+                x: -1920,
+                y: 120,
+                width: 1920,
+                height: 1080,
+            },
+            RemoteDesktopOutputRegion {
+                mapping_id: 12,
+                output_name: "DP-1".to_owned(),
+                x: 0,
+                y: 0,
+                width: 2560,
+                height: 1440,
+            },
+        ];
+
+        let normalized = normalize_regions(&regions).unwrap();
+
+        assert_eq!(
+            normalized,
+            vec![
+                EisOutputRegion {
+                    mapping_id: "11".to_owned(),
+                    output_name: "HDMI-A-1".to_owned(),
+                    x: 0,
+                    y: 120,
+                    width: 1920,
+                    height: 1080,
+                },
+                EisOutputRegion {
+                    mapping_id: "12".to_owned(),
+                    output_name: "DP-1".to_owned(),
+                    x: 1920,
+                    y: 0,
+                    width: 2560,
+                    height: 1440,
+                },
+            ]
+        );
+    }
+}

--- a/src/dbus/mutter_remote_desktop/input/device.rs
+++ b/src/dbus/mutter_remote_desktop/input/device.rs
@@ -1,0 +1,113 @@
+use std::path::PathBuf;
+
+use smithay::backend::input::{Device, DeviceCapability};
+use smithay::output::Output;
+
+use crate::input::backend_ext::NiriInputDevice;
+use crate::niri::State;
+
+#[derive(Debug)]
+pub(super) struct RemoteDesktopInputBackend;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) struct RemoteDesktopDevice {
+    kind: RemoteDesktopDeviceKind,
+    output_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum RemoteDesktopDeviceKind {
+    Keyboard,
+    Pointer,
+    Touch,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RemoteDesktopEventBase {
+    pub(super) device: RemoteDesktopDevice,
+    pub(super) time_msec: u32,
+}
+
+impl RemoteDesktopEventBase {
+    pub(super) fn keyboard(time_msec: u32) -> Self {
+        Self {
+            device: RemoteDesktopDevice::keyboard(),
+            time_msec,
+        }
+    }
+
+    pub(super) fn pointer(time_msec: u32, output_name: Option<String>) -> Self {
+        Self {
+            device: RemoteDesktopDevice::pointer(output_name),
+            time_msec,
+        }
+    }
+
+    pub(super) fn touch(time_msec: u32, output_name: Option<String>) -> Self {
+        Self {
+            device: RemoteDesktopDevice::touch(output_name),
+            time_msec,
+        }
+    }
+}
+
+impl RemoteDesktopDevice {
+    fn keyboard() -> Self {
+        Self {
+            kind: RemoteDesktopDeviceKind::Keyboard,
+            output_name: None,
+        }
+    }
+
+    fn pointer(output_name: Option<String>) -> Self {
+        Self {
+            kind: RemoteDesktopDeviceKind::Pointer,
+            output_name,
+        }
+    }
+
+    fn touch(output_name: Option<String>) -> Self {
+        Self {
+            kind: RemoteDesktopDeviceKind::Touch,
+            output_name,
+        }
+    }
+}
+
+impl Device for RemoteDesktopDevice {
+    fn id(&self) -> String {
+        format!("niri-remote-desktop-{:?}", self.kind)
+    }
+
+    fn name(&self) -> String {
+        "niri remote desktop".to_owned()
+    }
+
+    fn has_capability(&self, capability: DeviceCapability) -> bool {
+        matches!(
+            (self.kind, capability),
+            (
+                RemoteDesktopDeviceKind::Keyboard,
+                DeviceCapability::Keyboard
+            ) | (RemoteDesktopDeviceKind::Pointer, DeviceCapability::Pointer)
+                | (RemoteDesktopDeviceKind::Touch, DeviceCapability::Touch)
+        )
+    }
+
+    fn usb_id(&self) -> Option<(u32, u32)> {
+        None
+    }
+
+    fn syspath(&self) -> Option<PathBuf> {
+        None
+    }
+}
+
+impl NiriInputDevice for RemoteDesktopDevice {
+    fn output(&self, state: &State) -> Option<Output> {
+        self.output_name
+            .as_deref()
+            .and_then(|name| state.niri.output_by_name_match(name))
+            .cloned()
+    }
+}

--- a/src/dbus/mutter_remote_desktop/input/events.rs
+++ b/src/dbus/mutter_remote_desktop/input/events.rs
@@ -1,0 +1,249 @@
+use smithay::backend::input::{
+    AbsolutePositionEvent, Axis, AxisRelativeDirection, AxisSource, ButtonState, Event,
+    InputBackend, KeyState, KeyboardKeyEvent, Keycode, PointerAxisEvent, PointerButtonEvent,
+    PointerMotionAbsoluteEvent, PointerMotionEvent, TouchDownEvent, TouchEvent, TouchFrameEvent,
+    TouchMotionEvent, TouchSlot, TouchUpEvent, UnusedEvent,
+};
+
+use super::device::{RemoteDesktopDevice, RemoteDesktopEventBase, RemoteDesktopInputBackend};
+use super::{RemoteDesktopAxisFrame, RemoteDesktopPosition};
+
+#[derive(Debug, Clone)]
+pub(super) struct RemoteDesktopKeyboardEvent {
+    pub(super) base: RemoteDesktopEventBase,
+    pub(super) keycode: Keycode,
+    pub(super) state: KeyState,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RemoteDesktopPointerMotionEvent {
+    pub(super) base: RemoteDesktopEventBase,
+    pub(super) dx: f64,
+    pub(super) dy: f64,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RemoteDesktopPointerMotionAbsoluteEvent {
+    pub(super) base: RemoteDesktopEventBase,
+    pub(super) position: RemoteDesktopPosition,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RemoteDesktopPointerButtonEvent {
+    pub(super) base: RemoteDesktopEventBase,
+    pub(super) button: u32,
+    pub(super) state: ButtonState,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RemoteDesktopPointerAxisEvent {
+    pub(super) base: RemoteDesktopEventBase,
+    pub(super) frame: RemoteDesktopAxisFrame,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RemoteDesktopTouchPositionEvent {
+    pub(super) base: RemoteDesktopEventBase,
+    pub(super) slot: u32,
+    pub(super) position: RemoteDesktopPosition,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RemoteDesktopTouchSlotEvent {
+    pub(super) base: RemoteDesktopEventBase,
+    pub(super) slot: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RemoteDesktopTouchFrameEvent {
+    pub(super) base: RemoteDesktopEventBase,
+}
+
+fn tuple_axis<T: Copy>(tuple: (T, T), axis: Axis) -> T {
+    match axis {
+        Axis::Horizontal => tuple.0,
+        Axis::Vertical => tuple.1,
+    }
+}
+
+macro_rules! impl_event {
+    ($ty:ty) => {
+        impl Event<RemoteDesktopInputBackend> for $ty {
+            fn time_msec(&self) -> u32 {
+                self.base.time_msec
+            }
+
+            fn time(&self) -> u64 {
+                u64::from(self.base.time_msec).saturating_mul(1000)
+            }
+
+            fn device(&self) -> RemoteDesktopDevice {
+                self.base.device.clone()
+            }
+        }
+    };
+}
+
+impl_event!(RemoteDesktopKeyboardEvent);
+impl_event!(RemoteDesktopPointerMotionEvent);
+impl_event!(RemoteDesktopPointerMotionAbsoluteEvent);
+impl_event!(RemoteDesktopPointerButtonEvent);
+impl_event!(RemoteDesktopPointerAxisEvent);
+impl_event!(RemoteDesktopTouchPositionEvent);
+impl_event!(RemoteDesktopTouchSlotEvent);
+impl_event!(RemoteDesktopTouchFrameEvent);
+
+impl KeyboardKeyEvent<RemoteDesktopInputBackend> for RemoteDesktopKeyboardEvent {
+    fn key_code(&self) -> Keycode {
+        self.keycode
+    }
+
+    fn state(&self) -> KeyState {
+        self.state
+    }
+
+    fn count(&self) -> u32 {
+        1
+    }
+}
+
+impl PointerMotionEvent<RemoteDesktopInputBackend> for RemoteDesktopPointerMotionEvent {
+    fn delta_x(&self) -> f64 {
+        self.dx
+    }
+
+    fn delta_y(&self) -> f64 {
+        self.dy
+    }
+
+    fn delta_x_unaccel(&self) -> f64 {
+        self.dx
+    }
+
+    fn delta_y_unaccel(&self) -> f64 {
+        self.dy
+    }
+}
+
+impl AbsolutePositionEvent<RemoteDesktopInputBackend> for RemoteDesktopPointerMotionAbsoluteEvent {
+    fn x(&self) -> f64 {
+        self.position.x / f64::from(self.position.width)
+    }
+
+    fn y(&self) -> f64 {
+        self.position.y / f64::from(self.position.height)
+    }
+
+    fn x_transformed(&self, width: i32) -> f64 {
+        self.position.x * f64::from(width) / f64::from(self.position.width)
+    }
+
+    fn y_transformed(&self, height: i32) -> f64 {
+        self.position.y * f64::from(height) / f64::from(self.position.height)
+    }
+}
+
+impl PointerMotionAbsoluteEvent<RemoteDesktopInputBackend>
+    for RemoteDesktopPointerMotionAbsoluteEvent
+{
+}
+
+impl PointerButtonEvent<RemoteDesktopInputBackend> for RemoteDesktopPointerButtonEvent {
+    fn button_code(&self) -> u32 {
+        self.button
+    }
+
+    fn state(&self) -> ButtonState {
+        self.state
+    }
+}
+
+impl PointerAxisEvent<RemoteDesktopInputBackend> for RemoteDesktopPointerAxisEvent {
+    fn amount(&self, axis: Axis) -> Option<f64> {
+        if tuple_axis(self.frame.stop, axis) {
+            return Some(0.0);
+        }
+
+        self.frame.smooth.map(|smooth| tuple_axis(smooth, axis))
+    }
+
+    fn amount_v120(&self, axis: Axis) -> Option<f64> {
+        if tuple_axis(self.frame.stop, axis) {
+            return None;
+        }
+
+        self.frame.v120.map(|v120| tuple_axis(v120, axis))
+    }
+
+    fn source(&self) -> AxisSource {
+        self.frame.source
+    }
+
+    fn relative_direction(&self, _axis: Axis) -> AxisRelativeDirection {
+        AxisRelativeDirection::Identical
+    }
+}
+
+impl TouchEvent<RemoteDesktopInputBackend> for RemoteDesktopTouchPositionEvent {
+    fn slot(&self) -> TouchSlot {
+        TouchSlot::from(Some(self.slot))
+    }
+}
+
+impl AbsolutePositionEvent<RemoteDesktopInputBackend> for RemoteDesktopTouchPositionEvent {
+    fn x(&self) -> f64 {
+        self.position.x / f64::from(self.position.width)
+    }
+
+    fn y(&self) -> f64 {
+        self.position.y / f64::from(self.position.height)
+    }
+
+    fn x_transformed(&self, width: i32) -> f64 {
+        self.position.x * f64::from(width) / f64::from(self.position.width)
+    }
+
+    fn y_transformed(&self, height: i32) -> f64 {
+        self.position.y * f64::from(height) / f64::from(self.position.height)
+    }
+}
+
+impl TouchDownEvent<RemoteDesktopInputBackend> for RemoteDesktopTouchPositionEvent {}
+impl TouchMotionEvent<RemoteDesktopInputBackend> for RemoteDesktopTouchPositionEvent {}
+
+impl TouchEvent<RemoteDesktopInputBackend> for RemoteDesktopTouchSlotEvent {
+    fn slot(&self) -> TouchSlot {
+        TouchSlot::from(Some(self.slot))
+    }
+}
+
+impl TouchUpEvent<RemoteDesktopInputBackend> for RemoteDesktopTouchSlotEvent {}
+impl TouchFrameEvent<RemoteDesktopInputBackend> for RemoteDesktopTouchFrameEvent {}
+
+impl InputBackend for RemoteDesktopInputBackend {
+    type Device = RemoteDesktopDevice;
+    type KeyboardKeyEvent = RemoteDesktopKeyboardEvent;
+    type PointerAxisEvent = RemoteDesktopPointerAxisEvent;
+    type PointerButtonEvent = RemoteDesktopPointerButtonEvent;
+    type PointerMotionEvent = RemoteDesktopPointerMotionEvent;
+    type PointerMotionAbsoluteEvent = RemoteDesktopPointerMotionAbsoluteEvent;
+    type GestureSwipeBeginEvent = UnusedEvent;
+    type GestureSwipeUpdateEvent = UnusedEvent;
+    type GestureSwipeEndEvent = UnusedEvent;
+    type GesturePinchBeginEvent = UnusedEvent;
+    type GesturePinchUpdateEvent = UnusedEvent;
+    type GesturePinchEndEvent = UnusedEvent;
+    type GestureHoldBeginEvent = UnusedEvent;
+    type GestureHoldEndEvent = UnusedEvent;
+    type TouchDownEvent = RemoteDesktopTouchPositionEvent;
+    type TouchUpEvent = RemoteDesktopTouchSlotEvent;
+    type TouchMotionEvent = RemoteDesktopTouchPositionEvent;
+    type TouchCancelEvent = UnusedEvent;
+    type TouchFrameEvent = RemoteDesktopTouchFrameEvent;
+    type TabletToolAxisEvent = UnusedEvent;
+    type TabletToolProximityEvent = UnusedEvent;
+    type TabletToolTipEvent = UnusedEvent;
+    type TabletToolButtonEvent = UnusedEvent;
+    type SwitchToggleEvent = UnusedEvent;
+    type SpecialEvent = UnusedEvent;
+}

--- a/src/dbus/mutter_remote_desktop/input/mod.rs
+++ b/src/dbus/mutter_remote_desktop/input/mod.rs
@@ -1,0 +1,269 @@
+mod device;
+mod events;
+
+use smithay::backend::input::{AxisSource, ButtonState, InputEvent, KeyState, Keycode};
+
+use self::device::{RemoteDesktopEventBase, RemoteDesktopInputBackend};
+use self::events::{
+    RemoteDesktopKeyboardEvent, RemoteDesktopPointerAxisEvent, RemoteDesktopPointerButtonEvent,
+    RemoteDesktopPointerMotionAbsoluteEvent, RemoteDesktopPointerMotionEvent,
+    RemoteDesktopTouchFrameEvent, RemoteDesktopTouchPositionEvent, RemoteDesktopTouchSlotEvent,
+};
+use super::clipboard::{
+    disable_clipboard, enable_clipboard, read_clipboard, set_selection,
+    RemoteDesktopClipboardReadReply, RemoteDesktopClipboardReply,
+};
+use super::eis::RemoteDesktopEisConnection;
+use super::keymap::{
+    apply_keymap_change, set_layout_index, RemoteDesktopKeymapChange, RemoteDesktopKeymapReply,
+};
+use crate::niri::State;
+use crate::utils::get_monotonic_time;
+
+#[derive(Debug)]
+pub enum RemoteDesktopToNiri {
+    ConnectEis(RemoteDesktopEisConnection),
+    SetKeymap {
+        change: RemoteDesktopKeymapChange,
+        reply: RemoteDesktopKeymapReply,
+    },
+    SetKeymapLayoutIndex {
+        index: u32,
+        reply: RemoteDesktopKeymapReply,
+    },
+    EnableClipboard {
+        session_id: String,
+        mime_types: Option<Vec<String>>,
+        reply: RemoteDesktopClipboardReply,
+    },
+    DisableClipboard {
+        session_id: String,
+        reply: RemoteDesktopClipboardReply,
+    },
+    SetSelection {
+        session_id: String,
+        mime_types: Option<Vec<String>>,
+        reply: RemoteDesktopClipboardReply,
+    },
+    ReadClipboard {
+        session_id: String,
+        mime_type: String,
+        reply: RemoteDesktopClipboardReadReply,
+    },
+    KeyboardKeycode {
+        keycode: Keycode,
+        state: KeyState,
+    },
+    PointerButton {
+        button: u32,
+        state: ButtonState,
+    },
+    PointerAxis {
+        frame: RemoteDesktopAxisFrame,
+    },
+    PointerMotionRelative {
+        dx: f64,
+        dy: f64,
+    },
+    PointerMotionAbsolute {
+        position: RemoteDesktopPosition,
+    },
+    TouchDown {
+        slot: u32,
+        position: RemoteDesktopPosition,
+    },
+    TouchMotion {
+        slot: u32,
+        position: RemoteDesktopPosition,
+    },
+    TouchUp {
+        slot: u32,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RemoteDesktopAxisFrame {
+    pub smooth: Option<(f64, f64)>,
+    pub v120: Option<(f64, f64)>,
+    pub source: AxisSource,
+    pub stop: (bool, bool),
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoteDesktopPosition {
+    pub output_name: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: i32,
+    pub height: i32,
+}
+
+pub fn dispatch_to_niri(state: &mut State, msg: RemoteDesktopToNiri) {
+    let time_msec = event_time_msec();
+
+    match msg {
+        RemoteDesktopToNiri::ConnectEis(connection) => {
+            if let Err(err) = super::eis::connect_to_niri(state, connection) {
+                warn!("error connecting remote desktop EIS client: {err}");
+            }
+        }
+        RemoteDesktopToNiri::SetKeymap { change, reply } => {
+            let _ = reply.try_send(apply_keymap_change(state, change));
+        }
+        RemoteDesktopToNiri::SetKeymapLayoutIndex { index, reply } => {
+            let _ = reply.try_send(set_layout_index(state, index));
+        }
+        RemoteDesktopToNiri::EnableClipboard {
+            session_id,
+            mime_types,
+            reply,
+        } => {
+            let _ = reply.try_send(enable_clipboard(state, session_id, mime_types));
+        }
+        RemoteDesktopToNiri::DisableClipboard { session_id, reply } => {
+            let _ = reply.try_send(disable_clipboard(state, session_id));
+        }
+        RemoteDesktopToNiri::SetSelection {
+            session_id,
+            mime_types,
+            reply,
+        } => {
+            let _ = reply.try_send(set_selection(state, session_id, mime_types));
+        }
+        RemoteDesktopToNiri::ReadClipboard {
+            session_id,
+            mime_type,
+            reply,
+        } => {
+            let _ = reply.try_send(read_clipboard(state, session_id, mime_type));
+        }
+        RemoteDesktopToNiri::KeyboardKeycode {
+            keycode,
+            state: key_state,
+        } => {
+            state.process_input_event(InputEvent::<RemoteDesktopInputBackend>::Keyboard {
+                event: RemoteDesktopKeyboardEvent {
+                    base: RemoteDesktopEventBase::keyboard(time_msec),
+                    keycode,
+                    state: key_state,
+                },
+            });
+        }
+        RemoteDesktopToNiri::PointerButton {
+            button,
+            state: button_state,
+        } => {
+            state.process_input_event(InputEvent::<RemoteDesktopInputBackend>::PointerButton {
+                event: RemoteDesktopPointerButtonEvent {
+                    base: RemoteDesktopEventBase::pointer(time_msec, None),
+                    button,
+                    state: button_state,
+                },
+            });
+        }
+        RemoteDesktopToNiri::PointerAxis { frame } => {
+            state.process_input_event(InputEvent::<RemoteDesktopInputBackend>::PointerAxis {
+                event: RemoteDesktopPointerAxisEvent {
+                    base: RemoteDesktopEventBase::pointer(time_msec, None),
+                    frame,
+                },
+            });
+        }
+        RemoteDesktopToNiri::PointerMotionRelative { dx, dy } => {
+            state.process_input_event(InputEvent::<RemoteDesktopInputBackend>::PointerMotion {
+                event: RemoteDesktopPointerMotionEvent {
+                    base: RemoteDesktopEventBase::pointer(time_msec, None),
+                    dx,
+                    dy,
+                },
+            });
+        }
+        RemoteDesktopToNiri::PointerMotionAbsolute { position } => {
+            let output_name = Some(position.output_name.clone());
+            state.process_input_event(
+                InputEvent::<RemoteDesktopInputBackend>::PointerMotionAbsolute {
+                    event: RemoteDesktopPointerMotionAbsoluteEvent {
+                        base: RemoteDesktopEventBase::pointer(time_msec, output_name),
+                        position,
+                    },
+                },
+            );
+        }
+        RemoteDesktopToNiri::TouchDown { slot, position } => {
+            dispatch_touch_position(
+                state,
+                timed_touch(time_msec, slot, position),
+                TouchPhase::Down,
+            );
+        }
+        RemoteDesktopToNiri::TouchMotion { slot, position } => {
+            dispatch_touch_position(
+                state,
+                timed_touch(time_msec, slot, position),
+                TouchPhase::Motion,
+            );
+        }
+        RemoteDesktopToNiri::TouchUp { slot } => {
+            state.process_input_event(InputEvent::<RemoteDesktopInputBackend>::TouchUp {
+                event: RemoteDesktopTouchSlotEvent {
+                    base: RemoteDesktopEventBase::touch(time_msec, None),
+                    slot,
+                },
+            });
+            dispatch_touch_frame(state, time_msec);
+        }
+    }
+}
+
+enum TouchPhase {
+    Down,
+    Motion,
+}
+
+struct TimedTouch {
+    time_msec: u32,
+    slot: u32,
+    position: RemoteDesktopPosition,
+}
+
+fn timed_touch(time_msec: u32, slot: u32, position: RemoteDesktopPosition) -> TimedTouch {
+    TimedTouch {
+        time_msec,
+        slot,
+        position,
+    }
+}
+
+fn dispatch_touch_position(state: &mut State, touch: TimedTouch, phase: TouchPhase) {
+    let output_name = Some(touch.position.output_name.clone());
+    let event = RemoteDesktopTouchPositionEvent {
+        base: RemoteDesktopEventBase::touch(touch.time_msec, output_name),
+        slot: touch.slot,
+        position: touch.position,
+    };
+
+    match phase {
+        TouchPhase::Down => {
+            state.process_input_event(InputEvent::<RemoteDesktopInputBackend>::TouchDown { event });
+        }
+        TouchPhase::Motion => {
+            state.process_input_event(InputEvent::<RemoteDesktopInputBackend>::TouchMotion {
+                event,
+            });
+        }
+    }
+
+    dispatch_touch_frame(state, touch.time_msec);
+}
+
+fn dispatch_touch_frame(state: &mut State, time_msec: u32) {
+    state.process_input_event(InputEvent::<RemoteDesktopInputBackend>::TouchFrame {
+        event: RemoteDesktopTouchFrameEvent {
+            base: RemoteDesktopEventBase::touch(time_msec, None),
+        },
+    });
+}
+
+fn event_time_msec() -> u32 {
+    u32::try_from(get_monotonic_time().as_millis()).unwrap_or(u32::MAX)
+}

--- a/src/dbus/mutter_remote_desktop/keymap.rs
+++ b/src/dbus/mutter_remote_desktop/keymap.rs
@@ -1,0 +1,270 @@
+use std::collections::HashMap;
+use std::io::Read;
+use std::os::fd::OwnedFd as StdOwnedFd;
+
+use anyhow::Context;
+use smithay::input::keyboard::{xkb, KeymapFile, Layout};
+use zbus::fdo;
+use zbus::zvariant::Value;
+
+use crate::niri::State;
+use crate::utils::expand_home;
+
+const KEYMAP_TYPE_XKB: u32 = 0;
+const KEYMAP_SOURCE_EXTERNAL: u32 = 0;
+const KEYMAP_SOURCE_SESSION: u32 = 1;
+const XKB_KEYMAP_FORMAT_TEXT_V1: u32 = 1;
+const XKB_KEYMAP_FORMAT_TEXT_V2: u32 = 2;
+
+#[derive(Debug)]
+pub enum RemoteDesktopKeymapChange {
+    Reset,
+    Xkb { keymap: String, layout_index: u32 },
+}
+
+pub type RemoteDesktopKeymapReply = async_channel::Sender<Result<(), String>>;
+
+pub fn keymap_capabilities() -> HashMap<String, Value<'static>> {
+    HashMap::from([
+        (
+            "supported-keymap-types".to_owned(),
+            Value::new(vec![KEYMAP_TYPE_XKB]),
+        ),
+        (
+            "supported-xkb-keymap-formats".to_owned(),
+            Value::new(vec![XKB_KEYMAP_FORMAT_TEXT_V1]),
+        ),
+    ])
+}
+
+pub fn current_keymap(session_keymap: bool) -> HashMap<String, Value<'static>> {
+    let source = if session_keymap {
+        KEYMAP_SOURCE_SESSION
+    } else {
+        KEYMAP_SOURCE_EXTERNAL
+    };
+
+    HashMap::from([
+        ("source".to_owned(), Value::new(source)),
+        ("name".to_owned(), Value::new("niri")),
+    ])
+}
+
+pub fn parse_set_keymap_options(
+    options: &HashMap<&str, Value<'_>>,
+) -> fdo::Result<RemoteDesktopKeymapChange> {
+    let Some(keymap_type) = optional_u32(options, "keymap-type")? else {
+        return Ok(RemoteDesktopKeymapChange::Reset);
+    };
+
+    if keymap_type != KEYMAP_TYPE_XKB {
+        return Err(fdo::Error::NotSupported(format!(
+            "remote desktop keymap type {keymap_type} is not supported"
+        )));
+    }
+
+    let format = optional_u32(options, "xkb-keymap-format")?.unwrap_or(XKB_KEYMAP_FORMAT_TEXT_V1);
+    match format {
+        XKB_KEYMAP_FORMAT_TEXT_V1 => (),
+        XKB_KEYMAP_FORMAT_TEXT_V2 => {
+            return Err(fdo::Error::NotSupported(
+                "XKB keymap text v2 is not supported".to_owned(),
+            ));
+        }
+        _ => {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "unknown XKB keymap format: {format}"
+            )));
+        }
+    }
+
+    if optional_bool(options, "lock-keymap")?.unwrap_or(false) {
+        return Err(fdo::Error::NotSupported(
+            "locked remote desktop keymaps are not supported".to_owned(),
+        ));
+    }
+
+    let keymap = read_keymap(options)?;
+    let layout_index = optional_u32(options, "xkb-keymap-layout-index")?.unwrap_or(0);
+
+    Ok(RemoteDesktopKeymapChange::Xkb {
+        keymap,
+        layout_index,
+    })
+}
+
+pub fn apply_keymap_change(
+    state: &mut State,
+    change: RemoteDesktopKeymapChange,
+) -> Result<(), String> {
+    match change {
+        RemoteDesktopKeymapChange::Reset => reset_keymap(state),
+        RemoteDesktopKeymapChange::Xkb {
+            keymap,
+            layout_index,
+        } => {
+            set_keymap_from_string(state, keymap)?;
+            set_layout_index(state, layout_index)
+        }
+    }
+}
+
+pub fn set_layout_index(state: &mut State, index: u32) -> Result<(), String> {
+    let keyboard = state.niri.seat.get_keyboard().ok_or_else(|| {
+        "remote desktop keymap layout cannot be changed without a keyboard".to_owned()
+    })?;
+    keyboard.with_xkb_state(state, |mut context| {
+        context.set_layout(Layout(index));
+    });
+    Ok(())
+}
+
+pub fn current_keymap_file(state: &State) -> Result<KeymapFile, String> {
+    let configured = state.niri.config.borrow().input.keyboard.xkb.clone();
+    let xkb_config = if configured == niri_config::Xkb::default() {
+        state.niri.xkb_from_locale1.clone().unwrap_or(configured)
+    } else {
+        configured
+    };
+
+    let keymap = if let Some(path) = xkb_config.file.clone() {
+        let path = std::path::PathBuf::from(path);
+        let path = expand_home(&path)
+            .map_err(|err| format!("failed to expand keymap path: {err:?}"))?
+            .unwrap_or(path);
+        let keymap = std::fs::read_to_string(path)
+            .map_err(|err| format!("failed to read configured keymap file: {err:?}"))?;
+        xkb::Keymap::new_from_string(
+            &xkb::Context::new(xkb::CONTEXT_NO_FLAGS),
+            keymap,
+            xkb::KEYMAP_FORMAT_TEXT_V1,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        )
+        .ok_or_else(|| "failed to compile configured keymap file".to_owned())?
+    } else {
+        let config = xkb_config.to_xkb_config();
+        xkb::Keymap::new_from_names(
+            &xkb::Context::new(xkb::CONTEXT_NO_FLAGS),
+            config.rules,
+            config.model,
+            config.layout,
+            config.variant,
+            config.options,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        )
+        .ok_or_else(|| "failed to compile configured keymap".to_owned())?
+    };
+
+    Ok(KeymapFile::new(&keymap))
+}
+
+fn reset_keymap(state: &mut State) -> Result<(), String> {
+    let xkb_config = state.niri.config.borrow().input.keyboard.xkb.clone();
+    if let Some(path) = xkb_config.file {
+        let path = std::path::PathBuf::from(path);
+        let path = expand_home(&path)
+            .map_err(|err| format!("failed to expand keymap path: {err:?}"))?
+            .unwrap_or(path);
+        let keymap = std::fs::read_to_string(path)
+            .map_err(|err| format!("failed to read configured keymap file: {err:?}"))?;
+        set_keymap_from_string(state, keymap)
+    } else {
+        let xkb_config = if xkb_config == niri_config::Xkb::default() {
+            state.niri.xkb_from_locale1.clone().unwrap_or(xkb_config)
+        } else {
+            xkb_config
+        };
+        state.set_xkb_config(xkb_config.to_xkb_config());
+        Ok(())
+    }
+}
+
+fn set_keymap_from_string(state: &mut State, keymap: String) -> Result<(), String> {
+    let keyboard =
+        state.niri.seat.get_keyboard().ok_or_else(|| {
+            "remote desktop keymap cannot be changed without a keyboard".to_owned()
+        })?;
+    let num_lock = keyboard.modifier_state().num_lock;
+
+    keyboard
+        .set_keymap_from_string(state, keymap)
+        .map_err(|err| format!("failed to set remote desktop keymap: {err:?}"))?;
+
+    let mut mods_state = keyboard.modifier_state();
+    if mods_state.num_lock != num_lock {
+        mods_state.num_lock = num_lock;
+        keyboard.set_modifier_state(mods_state);
+    }
+
+    Ok(())
+}
+
+fn read_keymap(options: &HashMap<&str, Value<'_>>) -> fdo::Result<String> {
+    let value = options.get("xkb-keymap").ok_or_else(|| {
+        fdo::Error::InvalidArgs("xkb-keymap fd is required for XKB keymaps".to_owned())
+    })?;
+    let fd = match value
+        .try_clone()
+        .map_err(|err| fdo::Error::Failed(format!("failed to clone keymap fd: {err:?}")))?
+    {
+        Value::Fd(fd) => StdOwnedFd::try_from(fd)
+            .map_err(|err| fdo::Error::Failed(format!("failed to own keymap fd: {err:?}")))?,
+        _ => {
+            return Err(fdo::Error::InvalidArgs(
+                "xkb-keymap must be a file descriptor".to_owned(),
+            ));
+        }
+    };
+    let mut file = std::fs::File::from(fd);
+    let mut keymap = String::new();
+    file.read_to_string(&mut keymap)
+        .context("failed to read XKB keymap fd")
+        .map_err(|err| fdo::Error::Failed(format!("{err:?}")))?;
+
+    Ok(keymap)
+}
+
+fn optional_u32(options: &HashMap<&str, Value<'_>>, name: &str) -> fdo::Result<Option<u32>> {
+    options
+        .get(name)
+        .map(|value| {
+            value
+                .downcast_ref::<u32>()
+                .map_err(|_| fdo::Error::InvalidArgs(format!("{name} must be a uint32")))
+        })
+        .transpose()
+}
+
+fn optional_bool(options: &HashMap<&str, Value<'_>>, name: &str) -> fdo::Result<Option<bool>> {
+    options
+        .get(name)
+        .map(|value| {
+            value
+                .downcast_ref::<bool>()
+                .map_err(|_| fdo::Error::InvalidArgs(format!("{name} must be a boolean")))
+        })
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_keymap_without_keymap_type_resets_to_external_keymap() {
+        let change = parse_set_keymap_options(&HashMap::new()).unwrap();
+
+        assert!(matches!(change, RemoteDesktopKeymapChange::Reset));
+    }
+
+    #[test]
+    fn set_keymap_rejects_unsupported_xkb_v2_format() {
+        let options = HashMap::from([
+            ("keymap-type", Value::new(KEYMAP_TYPE_XKB)),
+            ("xkb-keymap-format", Value::new(XKB_KEYMAP_FORMAT_TEXT_V2)),
+        ]);
+        let err = parse_set_keymap_options(&options).unwrap_err();
+
+        assert!(format!("{err:?}").contains("text v2"));
+    }
+}

--- a/src/dbus/mutter_remote_desktop/legacy_input.rs
+++ b/src/dbus/mutter_remote_desktop/legacy_input.rs
@@ -1,0 +1,118 @@
+use smithay::backend::input::{AxisSource, ButtonState, KeyState};
+use zbus::fdo;
+
+use super::input::RemoteDesktopAxisFrame;
+
+pub const XKB_KEYCODE_OFFSET: u32 = 8;
+
+const AXIS_FLAG_FINISH: u32 = 1 << 0;
+const AXIS_FLAG_SOURCE_WHEEL: u32 = 1 << 1;
+const AXIS_FLAG_SOURCE_FINGER: u32 = 1 << 2;
+const AXIS_FLAG_SOURCE_CONTINUOUS: u32 = 1 << 3;
+const SOURCE_FLAGS: u32 =
+    AXIS_FLAG_SOURCE_WHEEL | AXIS_FLAG_SOURCE_FINGER | AXIS_FLAG_SOURCE_CONTINUOUS;
+
+pub fn key_state(state: bool) -> KeyState {
+    if state {
+        KeyState::Pressed
+    } else {
+        KeyState::Released
+    }
+}
+
+pub fn button_state(state: bool) -> ButtonState {
+    if state {
+        ButtonState::Pressed
+    } else {
+        ButtonState::Released
+    }
+}
+
+pub fn smooth_axis_frame(dx: f64, dy: f64, flags: u32) -> fdo::Result<RemoteDesktopAxisFrame> {
+    let source = axis_source(flags)?;
+    let is_finished = flags & AXIS_FLAG_FINISH != 0;
+    let amount = if is_finished { (0.0, 0.0) } else { (dx, dy) };
+
+    Ok(RemoteDesktopAxisFrame {
+        smooth: Some(amount),
+        v120: None,
+        source,
+        stop: (is_finished, is_finished),
+    })
+}
+
+pub fn discrete_axis_frame(axis: u32, steps: i32) -> fdo::Result<RemoteDesktopAxisFrame> {
+    let value = f64::from(steps) * 120.0;
+    let v120 = match axis {
+        0 => (0.0, value),
+        1 => (value, 0.0),
+        _ => {
+            return Err(fdo::Error::InvalidArgs(
+                "remote desktop discrete axis must be 0 or 1".to_owned(),
+            ));
+        }
+    };
+
+    Ok(RemoteDesktopAxisFrame {
+        smooth: None,
+        v120: Some(v120),
+        source: AxisSource::Wheel,
+        stop: (false, false),
+    })
+}
+
+fn axis_source(flags: u32) -> fdo::Result<AxisSource> {
+    match flags & SOURCE_FLAGS {
+        0 | AXIS_FLAG_SOURCE_FINGER => Ok(AxisSource::Finger),
+        AXIS_FLAG_SOURCE_WHEEL => Ok(AxisSource::Wheel),
+        AXIS_FLAG_SOURCE_CONTINUOUS => Ok(AxisSource::Continuous),
+        _ => Err(fdo::Error::InvalidArgs(
+            "remote desktop axis flags contain multiple sources".to_owned(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smooth_axis_frame_defaults_to_finger_when_no_source_flag_is_set() {
+        let frame = smooth_axis_frame(2.0, -3.0, 0).unwrap();
+
+        assert_eq!(frame.source, AxisSource::Finger);
+        assert_eq!(frame.smooth, Some((2.0, -3.0)));
+        assert_eq!(frame.stop, (false, false));
+    }
+
+    #[test]
+    fn smooth_axis_frame_converts_finish_flag_to_zero_stop_frame() {
+        let frame = smooth_axis_frame(2.0, -3.0, AXIS_FLAG_FINISH).unwrap();
+
+        assert_eq!(frame.source, AxisSource::Finger);
+        assert_eq!(frame.smooth, Some((0.0, 0.0)));
+        assert_eq!(frame.stop, (true, true));
+    }
+
+    #[test]
+    fn smooth_axis_frame_rejects_multiple_source_flags() {
+        let err = smooth_axis_frame(
+            0.0,
+            0.0,
+            AXIS_FLAG_SOURCE_WHEEL | AXIS_FLAG_SOURCE_CONTINUOUS,
+        )
+        .unwrap_err();
+
+        assert!(format!("{err:?}").contains("multiple sources"));
+    }
+
+    #[test]
+    fn discrete_axis_frame_converts_steps_to_v120_wheel_scroll() {
+        let vertical = discrete_axis_frame(0, -2).unwrap();
+        let horizontal = discrete_axis_frame(1, 3).unwrap();
+
+        assert_eq!(vertical.source, AxisSource::Wheel);
+        assert_eq!(vertical.v120, Some((0.0, -240.0)));
+        assert_eq!(horizontal.v120, Some((360.0, 0.0)));
+    }
+}

--- a/src/dbus/mutter_remote_desktop/mod.rs
+++ b/src/dbus/mutter_remote_desktop/mod.rs
@@ -1,0 +1,187 @@
+mod clipboard;
+mod clipboard_registry;
+mod clipboard_signals;
+#[cfg(test)]
+mod clipboard_tests;
+mod device_types;
+mod eis;
+mod input;
+mod keymap;
+mod legacy_input;
+mod registry;
+mod session;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use calloop::channel::Sender;
+use zbus::fdo::{self, RequestNameFlags};
+use zbus::message::Header;
+use zbus::names::OwnedUniqueName;
+use zbus::zvariant::OwnedObjectPath;
+use zbus::{interface, ObjectServer};
+
+pub use self::clipboard::RemoteDesktopClipboardSelection;
+use self::device_types::supported_device_types;
+pub use self::input::{dispatch_to_niri, RemoteDesktopToNiri};
+pub use self::registry::{
+    RemoteDesktopOutputStream, RemoteDesktopSessionRegistry, RemoteDesktopStream,
+};
+pub use self::session::Session;
+use super::Start;
+
+const REMOTE_DESKTOP_VERSION: i32 = 1;
+const SESSION_PATH_PREFIX: &str = "/org/gnome/Mutter/RemoteDesktop/Session/u";
+
+static NEXT_SESSION_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone)]
+pub struct RemoteDesktop {
+    to_niri: Sender<RemoteDesktopToNiri>,
+    sessions: RemoteDesktopSessionRegistry,
+}
+
+#[interface(name = "org.gnome.Mutter.RemoteDesktop")]
+impl RemoteDesktop {
+    async fn create_session(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        #[zbus(object_server)] server: &ObjectServer,
+    ) -> fdo::Result<OwnedObjectPath> {
+        let peer_name = peer_name(&hdr)?;
+        let id = NEXT_SESSION_ID.fetch_add(1, Ordering::SeqCst);
+        let path = session_path(id)?;
+        let session_id = format!("niri-remote-desktop-session-{id}");
+        let session = Session::new(
+            id,
+            session_id.clone(),
+            peer_name,
+            self.to_niri.clone(),
+            self.sessions.clone(),
+        );
+
+        self.sessions.insert_session(session_id.clone())?;
+
+        match server.at(&path, session).await {
+            Ok(true) => {
+                let iface = server.interface::<_, Session>(&path).await.map_err(|err| {
+                    fdo::Error::Failed(format!(
+                        "error looking up remote desktop session interface: {err:?}"
+                    ))
+                })?;
+                self.sessions
+                    .set_clipboard_signal_emitter(&session_id, iface.signal_emitter().to_owned())?;
+                debug!(id, "RemoteDesktop session created");
+                Ok(path)
+            }
+            Ok(false) => {
+                self.sessions.remove_session(&session_id)?;
+                Err(fdo::Error::ObjectPathInUse(format!(
+                    "session path already exists: {path}"
+                )))
+            }
+            Err(err) => {
+                self.sessions.remove_session(&session_id)?;
+                Err(fdo::Error::Failed(format!(
+                    "error creating remote desktop session: {err:?}"
+                )))
+            }
+        }
+    }
+
+    #[zbus(property)]
+    async fn supported_device_types(&self) -> u32 {
+        supported_device_types()
+    }
+
+    #[zbus(property)]
+    async fn version(&self) -> i32 {
+        REMOTE_DESKTOP_VERSION
+    }
+}
+
+impl RemoteDesktop {
+    pub fn new(
+        to_niri: Sender<RemoteDesktopToNiri>,
+        sessions: RemoteDesktopSessionRegistry,
+    ) -> Self {
+        Self { to_niri, sessions }
+    }
+}
+
+impl Start for RemoteDesktop {
+    fn start(self) -> anyhow::Result<zbus::blocking::Connection> {
+        let conn = zbus::blocking::Connection::session()?;
+        let flags = RequestNameFlags::AllowReplacement
+            | RequestNameFlags::ReplaceExisting
+            | RequestNameFlags::DoNotQueue;
+
+        conn.object_server()
+            .at("/org/gnome/Mutter/RemoteDesktop", self)?;
+        conn.request_name_with_flags("org.gnome.Mutter.RemoteDesktop", flags)?;
+
+        Ok(conn)
+    }
+}
+
+fn session_path(id: u64) -> fdo::Result<OwnedObjectPath> {
+    OwnedObjectPath::try_from(format!("{SESSION_PATH_PREFIX}{id}"))
+        .map_err(|err| fdo::Error::Failed(format!("invalid session object path: {err}")))
+}
+
+fn peer_name(hdr: &Header<'_>) -> fdo::Result<OwnedUniqueName> {
+    let Some(sender) = hdr.sender() else {
+        return Err(fdo::Error::Failed(
+            "remote desktop request has no sender".to_owned(),
+        ));
+    };
+
+    Ok(OwnedUniqueName::from(sender.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use calloop::channel;
+    use zbus::object_server::Interface;
+
+    use super::*;
+
+    #[test]
+    fn advertises_truthful_mutter_contract() {
+        assert_eq!(REMOTE_DESKTOP_VERSION, 1);
+        assert_eq!(supported_device_types(), 7);
+    }
+
+    #[test]
+    fn generated_session_paths_are_valid_object_paths() {
+        assert_eq!(
+            session_path(7).unwrap().as_str(),
+            "/org/gnome/Mutter/RemoteDesktop/Session/u7"
+        );
+    }
+
+    #[test]
+    fn introspection_exposes_mutter_entrypoints() {
+        let (to_niri, _from_remote_desktop) = channel::channel();
+        let remote_desktop =
+            RemoteDesktop::new(to_niri.clone(), RemoteDesktopSessionRegistry::default());
+        let mut xml = String::new();
+        remote_desktop.introspect_to_writer(&mut xml, 0);
+        assert!(xml.contains(r#"<method name="CreateSession">"#));
+        assert!(xml.contains(r#"name="SupportedDeviceTypes""#));
+        assert!(xml.contains(r#"type="u""#));
+
+        let mut xml = String::new();
+        Session::new(
+            7,
+            "niri-remote-desktop-session-7".to_owned(),
+            OwnedUniqueName::try_from(":1.7").unwrap(),
+            to_niri,
+            RemoteDesktopSessionRegistry::default(),
+        )
+        .introspect_to_writer(&mut xml, 0);
+        assert!(xml.contains(r#"name="SessionId""#));
+        assert!(xml.contains(r#"type="s""#));
+        assert!(xml.contains(r#"<method name="ConnectToEIS">"#));
+        assert!(xml.contains(r#"<method name="SelectionWrite">"#));
+    }
+}

--- a/src/dbus/mutter_remote_desktop/registry.rs
+++ b/src/dbus/mutter_remote_desktop/registry.rs
@@ -1,0 +1,393 @@
+use std::collections::HashMap;
+use std::sync::atomic::AtomicU32;
+use std::sync::{Arc, Mutex};
+
+use zbus::fdo;
+
+use super::clipboard::{RemoteDesktopClipboardOwner, RemoteDesktopClipboardSession};
+use crate::utils::{CastSessionId, CastStreamId};
+
+#[derive(Clone, Debug)]
+pub struct RemoteDesktopSessionRegistry {
+    pub(super) sessions: Arc<Mutex<HashMap<String, RemoteDesktopSession>>>,
+    pub(super) clipboard_owner: Arc<Mutex<RemoteDesktopClipboardOwner>>,
+    pub(super) next_clipboard_serial: Arc<AtomicU32>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RemoteDesktopStream {
+    pub stream_id: CastStreamId,
+    target: RemoteDesktopStreamTarget,
+}
+
+#[derive(Clone, Debug)]
+pub struct RemoteDesktopOutputStream {
+    pub name: String,
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+#[derive(Clone, Debug)]
+pub enum RemoteDesktopStreamTarget {
+    Output {
+        name: String,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    },
+    Window,
+}
+
+#[derive(Clone, Debug)]
+pub struct RemoteDesktopStreamPosition {
+    pub output_name: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: i32,
+    pub height: i32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RemoteDesktopOutputRegion {
+    pub mapping_id: u64,
+    pub output_name: String,
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct RemoteDesktopSession {
+    pub(super) started: bool,
+    pub(super) screen_cast_session: Option<CastSessionId>,
+    pub(super) streams: HashMap<String, RemoteDesktopStream>,
+    pub(super) clipboard: RemoteDesktopClipboardSession,
+}
+
+impl Default for RemoteDesktopSessionRegistry {
+    fn default() -> Self {
+        Self {
+            sessions: Arc::default(),
+            clipboard_owner: Arc::default(),
+            next_clipboard_serial: Arc::new(AtomicU32::new(1)),
+        }
+    }
+}
+
+impl RemoteDesktopSessionRegistry {
+    pub fn insert_session(&self, session_id: String) -> fdo::Result<()> {
+        self.with_sessions(|sessions| {
+            if sessions.contains_key(&session_id) {
+                return Err(fdo::Error::Failed(format!(
+                    "remote desktop session already exists: {session_id}"
+                )));
+            }
+
+            sessions.insert(session_id, RemoteDesktopSession::default());
+            Ok(())
+        })
+    }
+
+    pub fn remove_session(&self, session_id: &str) -> fdo::Result<()> {
+        self.with_sessions(|sessions| {
+            sessions.remove(session_id);
+            Ok(())
+        })
+    }
+
+    pub fn mark_started(&self, session_id: &str) -> fdo::Result<()> {
+        self.with_session(session_id, |session| {
+            session.started = true;
+            Ok(())
+        })
+    }
+
+    pub fn associate_screen_cast(
+        &self,
+        session_id: &str,
+        screen_cast_session: CastSessionId,
+    ) -> fdo::Result<()> {
+        self.with_session(session_id, |session| {
+            if session.started {
+                return Err(fdo::Error::Failed(format!(
+                    "remote desktop session is already started: {session_id}"
+                )));
+            }
+
+            if session.screen_cast_session.is_some() {
+                return Err(fdo::Error::Failed(format!(
+                    "remote desktop session already has a screen cast: {session_id}"
+                )));
+            }
+
+            session.screen_cast_session = Some(screen_cast_session);
+            Ok(())
+        })
+    }
+
+    pub fn clear_screen_cast(&self, screen_cast_session: CastSessionId) -> fdo::Result<()> {
+        self.with_sessions(|sessions| {
+            for session in sessions.values_mut() {
+                if session.screen_cast_session == Some(screen_cast_session) {
+                    session.screen_cast_session = None;
+                    session.streams.clear();
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    pub fn register_stream(
+        &self,
+        screen_cast_session: CastSessionId,
+        path: String,
+        stream: RemoteDesktopStream,
+    ) -> fdo::Result<()> {
+        self.with_sessions(|sessions| {
+            let Some(session) = sessions
+                .values_mut()
+                .find(|session| session.screen_cast_session == Some(screen_cast_session))
+            else {
+                return Err(fdo::Error::Failed(
+                    "screen cast session is not attached to a remote desktop session".to_owned(),
+                ));
+            };
+
+            session.streams.insert(path, stream);
+            Ok(())
+        })
+    }
+
+    pub fn stream_position(
+        &self,
+        stream_path: &str,
+        x: f64,
+        y: f64,
+    ) -> fdo::Result<RemoteDesktopStreamPosition> {
+        if !x.is_finite() || !y.is_finite() {
+            return Err(fdo::Error::InvalidArgs(
+                "remote desktop coordinates must be finite".to_owned(),
+            ));
+        }
+
+        self.with_sessions(|sessions| {
+            let Some(stream) = sessions
+                .values()
+                .find_map(|session| session.streams.get(stream_path))
+            else {
+                return Err(fdo::Error::Failed(format!(
+                    "remote desktop stream not found: {stream_path}"
+                )));
+            };
+
+            stream.position(x, y)
+        })
+    }
+
+    pub fn output_regions(&self, session_id: &str) -> fdo::Result<Vec<RemoteDesktopOutputRegion>> {
+        self.with_session(session_id, |session| {
+            let mut regions = session
+                .streams
+                .values()
+                .filter_map(RemoteDesktopStream::output_region)
+                .collect::<Vec<_>>();
+            regions.sort_by_key(|region| region.mapping_id);
+            Ok(regions)
+        })
+    }
+
+    pub(super) fn with_sessions<T>(
+        &self,
+        f: impl FnOnce(&mut HashMap<String, RemoteDesktopSession>) -> fdo::Result<T>,
+    ) -> fdo::Result<T> {
+        let mut sessions = self.sessions.lock().map_err(|_| {
+            fdo::Error::Failed("remote desktop session registry is poisoned".to_owned())
+        })?;
+        f(&mut sessions)
+    }
+
+    pub(super) fn with_session<T>(
+        &self,
+        session_id: &str,
+        f: impl FnOnce(&mut RemoteDesktopSession) -> fdo::Result<T>,
+    ) -> fdo::Result<T> {
+        self.with_sessions(|sessions| {
+            let Some(session) = sessions.get_mut(session_id) else {
+                return Err(fdo::Error::Failed(format!(
+                    "remote desktop session not found: {session_id}"
+                )));
+            };
+
+            f(session)
+        })
+    }
+}
+
+impl RemoteDesktopStream {
+    pub fn output(stream_id: CastStreamId, output: RemoteDesktopOutputStream) -> Self {
+        Self {
+            stream_id,
+            target: RemoteDesktopStreamTarget::Output {
+                name: output.name,
+                x: output.x,
+                y: output.y,
+                width: output.width,
+                height: output.height,
+            },
+        }
+    }
+
+    pub fn window(stream_id: CastStreamId) -> Self {
+        Self {
+            stream_id,
+            target: RemoteDesktopStreamTarget::Window,
+        }
+    }
+
+    fn position(&self, x: f64, y: f64) -> fdo::Result<RemoteDesktopStreamPosition> {
+        match &self.target {
+            RemoteDesktopStreamTarget::Output {
+                name,
+                x: _,
+                y: _,
+                width,
+                height,
+            } => Ok(RemoteDesktopStreamPosition {
+                output_name: name.clone(),
+                x,
+                y,
+                width: *width,
+                height: *height,
+            }),
+            RemoteDesktopStreamTarget::Window => Err(fdo::Error::NotSupported(
+                "remote desktop absolute input for window streams is not implemented".to_owned(),
+            )),
+        }
+    }
+
+    fn output_region(&self) -> Option<RemoteDesktopOutputRegion> {
+        match &self.target {
+            RemoteDesktopStreamTarget::Output {
+                name,
+                x,
+                y,
+                width,
+                height,
+            } => Some(RemoteDesktopOutputRegion {
+                mapping_id: self.stream_id.get(),
+                output_name: name.clone(),
+                x: *x,
+                y: *y,
+                width: *width,
+                height: *height,
+            }),
+            RemoteDesktopStreamTarget::Window => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_rejects_screen_cast_association_after_session_start() {
+        let registry = RemoteDesktopSessionRegistry::default();
+        let session_id = "started-session".to_owned();
+
+        registry.insert_session(session_id.clone()).unwrap();
+        registry.mark_started(&session_id).unwrap();
+        let err = registry
+            .associate_screen_cast(&session_id, CastSessionId::next())
+            .unwrap_err();
+
+        assert!(format!("{err:?}").contains("already started"));
+    }
+
+    #[test]
+    fn registry_resolves_output_stream_positions() {
+        let registry = RemoteDesktopSessionRegistry::default();
+        let session_id = "stream-session".to_owned();
+        let screen_cast_session = CastSessionId::next();
+        let stream_id = CastStreamId::next();
+
+        registry.insert_session(session_id.clone()).unwrap();
+        registry
+            .associate_screen_cast(&session_id, screen_cast_session)
+            .unwrap();
+        registry
+            .register_stream(
+                screen_cast_session,
+                "/org/gnome/Mutter/ScreenCast/Stream/u999".to_owned(),
+                RemoteDesktopStream::output(
+                    stream_id,
+                    RemoteDesktopOutputStream {
+                        name: "HDMI-A-1".to_owned(),
+                        x: 0,
+                        y: 0,
+                        width: 1920,
+                        height: 1080,
+                    },
+                ),
+            )
+            .unwrap();
+
+        let position = registry
+            .stream_position("/org/gnome/Mutter/ScreenCast/Stream/u999", 320.0, 240.0)
+            .unwrap();
+
+        assert_eq!(position.output_name, "HDMI-A-1");
+        assert_eq!(position.x, 320.0);
+        assert_eq!(position.y, 240.0);
+        assert_eq!(position.width, 1920);
+        assert_eq!(position.height, 1080);
+    }
+
+    #[test]
+    fn registry_lists_remote_desktop_output_regions() {
+        let registry = RemoteDesktopSessionRegistry::default();
+        let session_id = "stream-session".to_owned();
+        let screen_cast_session = CastSessionId::next();
+        let stream_id = CastStreamId::next();
+
+        registry.insert_session(session_id.clone()).unwrap();
+        registry
+            .associate_screen_cast(&session_id, screen_cast_session)
+            .unwrap();
+        registry
+            .register_stream(
+                screen_cast_session,
+                "/org/gnome/Mutter/ScreenCast/Stream/u999".to_owned(),
+                RemoteDesktopStream::output(
+                    stream_id,
+                    RemoteDesktopOutputStream {
+                        name: "HDMI-A-1".to_owned(),
+                        x: -1920,
+                        y: 120,
+                        width: 1920,
+                        height: 1080,
+                    },
+                ),
+            )
+            .unwrap();
+
+        let regions = registry.output_regions(&session_id).unwrap();
+
+        assert_eq!(
+            regions,
+            vec![RemoteDesktopOutputRegion {
+                mapping_id: stream_id.get(),
+                output_name: "HDMI-A-1".to_owned(),
+                x: -1920,
+                y: 120,
+                width: 1920,
+                height: 1080,
+            }]
+        );
+    }
+}

--- a/src/dbus/mutter_remote_desktop/session.rs
+++ b/src/dbus/mutter_remote_desktop/session.rs
@@ -1,0 +1,505 @@
+use std::collections::HashMap;
+use std::os::fd::OwnedFd as StdOwnedFd;
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use calloop::channel::Sender;
+use smithay::backend::input::Keycode;
+use zbus::message::Header;
+use zbus::names::OwnedUniqueName;
+use zbus::object_server::SignalEmitter;
+use zbus::zvariant::{OwnedFd, Value};
+use zbus::{fdo, interface, ObjectServer};
+
+use super::clipboard::parse_clipboard_mime_types;
+use super::device_types::RemoteDesktopDeviceTypes;
+use super::eis::RemoteDesktopEisConnection;
+use super::input::{RemoteDesktopPosition, RemoteDesktopToNiri};
+use super::keymap::{
+    current_keymap, keymap_capabilities, parse_set_keymap_options, RemoteDesktopKeymapChange,
+};
+use super::legacy_input::{
+    button_state, discrete_axis_frame, key_state, smooth_axis_frame, XKB_KEYCODE_OFFSET,
+};
+use super::registry::RemoteDesktopSessionRegistry;
+
+#[derive(Clone)]
+pub struct Session {
+    id: u64,
+    session_id: String,
+    peer_name: OwnedUniqueName,
+    to_niri: Sender<RemoteDesktopToNiri>,
+    registry: RemoteDesktopSessionRegistry,
+    started: Arc<AtomicBool>,
+    stopped: Arc<AtomicBool>,
+    session_keymap: Arc<AtomicBool>,
+}
+
+#[interface(name = "org.gnome.Mutter.RemoteDesktop.Session")]
+impl Session {
+    async fn start(&self, #[zbus(header)] hdr: Header<'_>) -> fdo::Result<()> {
+        self.ensure_open_for_peer(&hdr)?;
+        self.registry.mark_started(&self.session_id)?;
+        self.started.store(true, Ordering::SeqCst);
+        debug!(id = self.id, "RemoteDesktop session started");
+        Ok(())
+    }
+
+    async fn stop(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        #[zbus(object_server)] server: &ObjectServer,
+        #[zbus(signal_context)] ctxt: SignalEmitter<'_>,
+    ) -> fdo::Result<()> {
+        self.ensure_open_for_peer(&hdr)?;
+        debug!(id = self.id, "RemoteDesktop session stopped");
+
+        if self.stopped.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        if let Err(err) = self.registry.remove_session(&self.session_id) {
+            warn!("error removing RemoteDesktop session registry entry: {err:?}");
+        }
+
+        if let Err(err) = Session::closed(&ctxt).await {
+            warn!("error emitting RemoteDesktop Closed signal: {err:?}");
+        }
+
+        server
+            .remove::<Session, _>(ctxt.path())
+            .await
+            .map_err(|err| fdo::Error::Failed(format!("error removing session object: {err:?}")))?;
+
+        Ok(())
+    }
+
+    #[zbus(signal)]
+    async fn closed(ctxt: &SignalEmitter<'_>) -> zbus::Result<()>;
+
+    #[zbus(property)]
+    async fn session_id(&self) -> String {
+        self.session_id.clone()
+    }
+
+    async fn notify_keyboard_keycode(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        keycode: u32,
+        state: bool,
+    ) -> fdo::Result<()> {
+        self.ensure_started_for_peer(&hdr)?;
+        let keycode = keycode.checked_add(XKB_KEYCODE_OFFSET).ok_or_else(|| {
+            fdo::Error::InvalidArgs("remote desktop keycode is too large".to_owned())
+        })?;
+        self.send(RemoteDesktopToNiri::KeyboardKeycode {
+            keycode: Keycode::from(keycode),
+            state: key_state(state),
+        })
+    }
+
+    async fn notify_keyboard_keysym(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        _keysym: u32,
+        _state: bool,
+    ) -> fdo::Result<()> {
+        self.ensure_started_for_peer(&hdr)?;
+        self.unsupported("remote desktop keysym input")
+    }
+
+    async fn notify_pointer_button(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        button: i32,
+        state: bool,
+    ) -> fdo::Result<()> {
+        self.ensure_started_for_peer(&hdr)?;
+        let button = u32::try_from(button).map_err(|_| {
+            fdo::Error::InvalidArgs("remote desktop button must be non-negative".to_owned())
+        })?;
+        self.send(RemoteDesktopToNiri::PointerButton {
+            button,
+            state: button_state(state),
+        })
+    }
+
+    async fn notify_pointer_axis(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        dx: f64,
+        dy: f64,
+        flags: u32,
+    ) -> fdo::Result<()> {
+        self.ensure_started_for_peer(&hdr)?;
+        self.send(RemoteDesktopToNiri::PointerAxis {
+            frame: smooth_axis_frame(dx, dy, flags)?,
+        })
+    }
+
+    async fn notify_pointer_axis_discrete(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        axis: u32,
+        steps: i32,
+    ) -> fdo::Result<()> {
+        self.ensure_started_for_peer(&hdr)?;
+        if steps == 0 {
+            return Err(fdo::Error::InvalidArgs(
+                "remote desktop discrete axis steps must not be zero".to_owned(),
+            ));
+        }
+
+        self.send(RemoteDesktopToNiri::PointerAxis {
+            frame: discrete_axis_frame(axis, steps)?,
+        })
+    }
+
+    async fn notify_pointer_motion_relative(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        dx: f64,
+        dy: f64,
+    ) -> fdo::Result<()> {
+        self.ensure_started_for_peer(&hdr)?;
+        self.send(RemoteDesktopToNiri::PointerMotionRelative { dx, dy })
+    }
+
+    async fn notify_pointer_motion_absolute(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        stream: &str,
+        x: f64,
+        y: f64,
+    ) -> fdo::Result<()> {
+        self.ensure_started_for_peer(&hdr)?;
+        self.send(RemoteDesktopToNiri::PointerMotionAbsolute {
+            position: self.stream_position(stream, x, y)?,
+        })
+    }
+
+    async fn notify_touch_down(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        stream: &str,
+        slot: u32,
+        x: f64,
+        y: f64,
+    ) -> fdo::Result<()> {
+        self.ensure_started_for_peer(&hdr)?;
+        self.send(RemoteDesktopToNiri::TouchDown {
+            slot,
+            position: self.stream_position(stream, x, y)?,
+        })
+    }
+
+    async fn notify_touch_motion(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        stream: &str,
+        slot: u32,
+        x: f64,
+        y: f64,
+    ) -> fdo::Result<()> {
+        self.ensure_started_for_peer(&hdr)?;
+        self.send(RemoteDesktopToNiri::TouchMotion {
+            slot,
+            position: self.stream_position(stream, x, y)?,
+        })
+    }
+
+    async fn notify_touch_up(&self, #[zbus(header)] hdr: Header<'_>, slot: u32) -> fdo::Result<()> {
+        self.ensure_started_for_peer(&hdr)?;
+        self.send(RemoteDesktopToNiri::TouchUp { slot })
+    }
+
+    async fn enable_clipboard(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        options: HashMap<&str, Value<'_>>,
+    ) -> fdo::Result<()> {
+        self.ensure_open_for_peer(&hdr)?;
+        let mime_types = parse_clipboard_mime_types(&options)?;
+        self.send_clipboard_enable(mime_types).await
+    }
+
+    async fn disable_clipboard(&self, #[zbus(header)] hdr: Header<'_>) -> fdo::Result<()> {
+        self.ensure_open_for_peer(&hdr)?;
+        self.send_clipboard_disable().await
+    }
+
+    async fn set_selection(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        options: HashMap<&str, Value<'_>>,
+    ) -> fdo::Result<()> {
+        self.ensure_open_for_peer(&hdr)?;
+        let mime_types = parse_clipboard_mime_types(&options)?;
+        self.send_clipboard_selection(mime_types).await
+    }
+
+    async fn selection_write(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        serial: u32,
+    ) -> fdo::Result<OwnedFd> {
+        self.ensure_open_for_peer(&hdr)?;
+        let fd = self.registry.selection_write(&self.session_id, serial)?;
+        Ok(OwnedFd::from(fd))
+    }
+
+    async fn selection_write_done(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        serial: u32,
+        _success: bool,
+    ) -> fdo::Result<()> {
+        self.ensure_open_for_peer(&hdr)?;
+        self.registry.selection_write_done(&self.session_id, serial)
+    }
+
+    async fn selection_read(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        mime_type: &str,
+    ) -> fdo::Result<OwnedFd> {
+        self.ensure_open_for_peer(&hdr)?;
+        self.send_clipboard_read(mime_type.to_owned()).await
+    }
+
+    #[zbus(signal)]
+    pub async fn selection_owner_changed(
+        ctxt: &SignalEmitter<'_>,
+        options: HashMap<&str, Value<'_>>,
+    ) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    pub async fn selection_transfer(
+        ctxt: &SignalEmitter<'_>,
+        mime_type: &str,
+        serial: u32,
+    ) -> zbus::Result<()>;
+
+    #[zbus(property)]
+    async fn caps_lock_state(&self) -> bool {
+        false
+    }
+
+    #[zbus(property)]
+    async fn num_lock_state(&self) -> bool {
+        false
+    }
+
+    #[zbus(name = "ConnectToEIS")]
+    async fn connect_to_eis(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        options: HashMap<&str, Value<'_>>,
+    ) -> fdo::Result<OwnedFd> {
+        self.ensure_open_for_peer(&hdr)?;
+        let device_types = RemoteDesktopDeviceTypes::from_options(&options)?;
+        let (server_socket, client_socket) = UnixStream::pair()
+            .map_err(|err| fdo::Error::Failed(format!("failed to create EIS socket: {err:?}")))?;
+        let connection = RemoteDesktopEisConnection::new(
+            server_socket,
+            self.session_id.clone(),
+            self.registry.clone(),
+            device_types,
+        );
+        self.send(RemoteDesktopToNiri::ConnectEis(connection))?;
+
+        let client_fd: StdOwnedFd = client_socket.into();
+        Ok(OwnedFd::from(client_fd))
+    }
+
+    #[zbus(property)]
+    async fn keymap_capabilities(&self) -> HashMap<String, Value<'static>> {
+        keymap_capabilities()
+    }
+
+    async fn set_keymap(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        options: HashMap<&str, Value<'_>>,
+    ) -> fdo::Result<()> {
+        self.ensure_open_for_peer(&hdr)?;
+        let change = parse_set_keymap_options(&options)?;
+        let is_session_keymap = matches!(change, RemoteDesktopKeymapChange::Xkb { .. });
+        self.send_keymap_change(change).await?;
+        self.session_keymap
+            .store(is_session_keymap, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn set_keymap_layout_index(
+        &self,
+        #[zbus(header)] hdr: Header<'_>,
+        index: u32,
+    ) -> fdo::Result<()> {
+        self.ensure_open_for_peer(&hdr)?;
+        if !self.session_keymap.load(Ordering::SeqCst) {
+            return Err(fdo::Error::Failed(
+                "remote desktop session keymap is not current".to_owned(),
+            ));
+        }
+
+        let (reply, rx) = async_channel::bounded(1);
+        self.send(RemoteDesktopToNiri::SetKeymapLayoutIndex { index, reply })?;
+        rx.recv()
+            .await
+            .map_err(|_| fdo::Error::Failed("niri event loop is gone".to_owned()))?
+            .map_err(fdo::Error::Failed)
+    }
+
+    #[zbus(property)]
+    async fn current_keymap(&self) -> HashMap<String, Value<'static>> {
+        current_keymap(self.session_keymap.load(Ordering::SeqCst))
+    }
+}
+
+impl Session {
+    pub fn new(
+        id: u64,
+        session_id: String,
+        peer_name: OwnedUniqueName,
+        to_niri: Sender<RemoteDesktopToNiri>,
+        registry: RemoteDesktopSessionRegistry,
+    ) -> Self {
+        Self {
+            id,
+            session_id,
+            peer_name,
+            to_niri,
+            registry,
+            started: Arc::new(AtomicBool::new(false)),
+            stopped: Arc::new(AtomicBool::new(false)),
+            session_keymap: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn stream_position(&self, stream: &str, x: f64, y: f64) -> fdo::Result<RemoteDesktopPosition> {
+        let position = self.registry.stream_position(stream, x, y)?;
+        Ok(RemoteDesktopPosition {
+            output_name: position.output_name,
+            x: position.x,
+            y: position.y,
+            width: position.width,
+            height: position.height,
+        })
+    }
+
+    fn send(&self, msg: RemoteDesktopToNiri) -> fdo::Result<()> {
+        self.to_niri
+            .send(msg)
+            .map_err(|_| fdo::Error::Failed("niri event loop is gone".to_owned()))
+    }
+
+    async fn send_keymap_change(&self, change: RemoteDesktopKeymapChange) -> fdo::Result<()> {
+        let (reply, rx) = async_channel::bounded(1);
+        self.send(RemoteDesktopToNiri::SetKeymap { change, reply })?;
+        rx.recv()
+            .await
+            .map_err(|_| fdo::Error::Failed("niri event loop is gone".to_owned()))?
+            .map_err(fdo::Error::Failed)
+    }
+
+    async fn send_clipboard_enable(&self, mime_types: Option<Vec<String>>) -> fdo::Result<()> {
+        let (reply, rx) = async_channel::bounded(1);
+        self.send(RemoteDesktopToNiri::EnableClipboard {
+            session_id: self.session_id.clone(),
+            mime_types,
+            reply,
+        })?;
+        recv_clipboard_reply(rx).await
+    }
+
+    async fn send_clipboard_disable(&self) -> fdo::Result<()> {
+        let (reply, rx) = async_channel::bounded(1);
+        self.send(RemoteDesktopToNiri::DisableClipboard {
+            session_id: self.session_id.clone(),
+            reply,
+        })?;
+        recv_clipboard_reply(rx).await
+    }
+
+    async fn send_clipboard_selection(&self, mime_types: Option<Vec<String>>) -> fdo::Result<()> {
+        let (reply, rx) = async_channel::bounded(1);
+        self.send(RemoteDesktopToNiri::SetSelection {
+            session_id: self.session_id.clone(),
+            mime_types,
+            reply,
+        })?;
+        recv_clipboard_reply(rx).await
+    }
+
+    async fn send_clipboard_read(&self, mime_type: String) -> fdo::Result<OwnedFd> {
+        let (reply, rx) = async_channel::bounded(1);
+        self.send(RemoteDesktopToNiri::ReadClipboard {
+            session_id: self.session_id.clone(),
+            mime_type,
+            reply,
+        })?;
+        let fd = rx
+            .recv()
+            .await
+            .map_err(|_| fdo::Error::Failed("niri event loop is gone".to_owned()))?
+            .map_err(fdo::Error::Failed)?;
+        Ok(OwnedFd::from(fd))
+    }
+
+    fn unsupported<T>(&self, feature: &str) -> fdo::Result<T> {
+        self.ensure_open()?;
+        Err(fdo::Error::NotSupported(format!(
+            "{feature} is not implemented"
+        )))
+    }
+
+    fn ensure_started(&self) -> fdo::Result<()> {
+        self.ensure_open()?;
+        if !self.started.load(Ordering::SeqCst) {
+            return Err(fdo::Error::Failed("session not started".to_owned()));
+        }
+        Ok(())
+    }
+
+    fn ensure_open(&self) -> fdo::Result<()> {
+        if self.stopped.load(Ordering::SeqCst) {
+            return Err(fdo::Error::Failed("session is stopped".to_owned()));
+        }
+        Ok(())
+    }
+
+    fn ensure_started_for_peer(&self, hdr: &Header<'_>) -> fdo::Result<()> {
+        self.check_permission(hdr)?;
+        self.ensure_started()
+    }
+
+    fn ensure_open_for_peer(&self, hdr: &Header<'_>) -> fdo::Result<()> {
+        self.check_permission(hdr)?;
+        self.ensure_open()
+    }
+
+    fn check_permission(&self, hdr: &Header<'_>) -> fdo::Result<()> {
+        let Some(sender) = hdr.sender() else {
+            return Err(fdo::Error::Failed(
+                "remote desktop request has no sender".to_owned(),
+            ));
+        };
+
+        if sender.as_str() != self.peer_name.as_str() {
+            return Err(fdo::Error::AccessDenied(
+                "remote desktop session belongs to another peer".to_owned(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+async fn recv_clipboard_reply(rx: async_channel::Receiver<Result<(), String>>) -> fdo::Result<()> {
+    rx.recv()
+        .await
+        .map_err(|_| fdo::Error::Failed("niri event loop is gone".to_owned()))?
+        .map_err(fdo::Error::Failed)
+}

--- a/src/dbus/mutter_screen_cast.rs
+++ b/src/dbus/mutter_screen_cast.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+// allow: SIZE_OK — Mutter ScreenCast's zbus object tree is kept together here; splitting the
+// existing interface file would be unrelated churn for the RemoteDesktop linkage patch.
 use std::mem;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -9,6 +10,9 @@ use zbus::object_server::{InterfaceRef, SignalEmitter};
 use zbus::zvariant::{DeserializeDict, OwnedObjectPath, SerializeDict, Type, Value};
 use zbus::{fdo, interface, ObjectServer};
 
+use super::mutter_remote_desktop::{
+    RemoteDesktopOutputStream, RemoteDesktopSessionRegistry, RemoteDesktopStream,
+};
 use super::Start;
 use crate::backend::IpcOutputMap;
 use crate::utils::{CastSessionId, CastStreamId};
@@ -17,6 +21,7 @@ use crate::utils::{CastSessionId, CastStreamId};
 pub struct ScreenCast {
     ipc_outputs: Arc<Mutex<IpcOutputMap>>,
     to_niri: calloop::channel::Sender<ScreenCastToNiri>,
+    remote_desktop_sessions: RemoteDesktopSessionRegistry,
     #[allow(clippy::type_complexity)]
     sessions: Arc<Mutex<Vec<(Session, InterfaceRef<Session>)>>>,
 }
@@ -26,6 +31,8 @@ pub struct Session {
     id: CastSessionId,
     ipc_outputs: Arc<Mutex<IpcOutputMap>>,
     to_niri: calloop::channel::Sender<ScreenCastToNiri>,
+    remote_desktop_session_id: Option<String>,
+    remote_desktop_sessions: RemoteDesktopSessionRegistry,
     #[allow(clippy::type_complexity)]
     streams: Arc<Mutex<Vec<(Stream, InterfaceRef<Stream>)>>>,
     stopped: Arc<AtomicBool>,
@@ -76,6 +83,15 @@ enum StreamTarget {
     Window { id: u64 },
 }
 
+#[derive(Debug, Default, DeserializeDict, Type)]
+#[zvariant(signature = "dict")]
+struct CreateSessionProperties {
+    #[zvariant(rename = "remote-desktop-session-id")]
+    remote_desktop_session_id: Option<String>,
+    #[zvariant(rename = "disable-animations")]
+    _disable_animations: Option<bool>,
+}
+
 #[derive(Debug, Clone)]
 pub enum StreamTargetId {
     Output { name: String },
@@ -109,29 +125,56 @@ impl ScreenCast {
     async fn create_session(
         &self,
         #[zbus(object_server)] server: &ObjectServer,
-        properties: HashMap<&str, Value<'_>>,
+        properties: CreateSessionProperties,
     ) -> fdo::Result<OwnedObjectPath> {
-        if properties.contains_key("remote-desktop-session-id") {
-            return Err(fdo::Error::Failed(
-                "there are no remote desktop sessions".to_owned(),
-            ));
-        }
-
         let session_id = CastSessionId::next();
         let path = format!("/org/gnome/Mutter/ScreenCast/Session/u{}", session_id.get());
-        let path = OwnedObjectPath::try_from(path).unwrap();
+        let path = object_path(path)?;
+        let remote_desktop_session_id = properties.remote_desktop_session_id;
 
-        let session = Session::new(session_id, self.ipc_outputs.clone(), self.to_niri.clone());
+        if let Some(remote_desktop_session_id) = &remote_desktop_session_id {
+            self.remote_desktop_sessions
+                .associate_screen_cast(remote_desktop_session_id, session_id)?;
+        }
+
+        let session = Session::new(
+            session_id,
+            self.ipc_outputs.clone(),
+            self.to_niri.clone(),
+            remote_desktop_session_id.clone(),
+            self.remote_desktop_sessions.clone(),
+        );
         match server.at(&path, session.clone()).await {
             Ok(true) => {
-                let iface = server.interface(&path).await.unwrap();
-                self.sessions.lock().unwrap().push((session, iface));
+                let iface = match server.interface(&path).await {
+                    Ok(iface) => iface,
+                    Err(err) => {
+                        self.remote_desktop_sessions.clear_screen_cast(session_id)?;
+                        return Err(fdo::Error::Failed(format!(
+                            "error retrieving session interface: {err:?}"
+                        )));
+                    }
+                };
+                let mut sessions = match self.sessions.lock() {
+                    Ok(sessions) => sessions,
+                    Err(_) => {
+                        self.remote_desktop_sessions.clear_screen_cast(session_id)?;
+                        return Err(fdo::Error::Failed(
+                            "screen cast session list is poisoned".to_owned(),
+                        ));
+                    }
+                };
+                sessions.push((session, iface));
             }
-            Ok(false) => return Err(fdo::Error::Failed("session path already exists".to_owned())),
+            Ok(false) => {
+                self.remote_desktop_sessions.clear_screen_cast(session_id)?;
+                return Err(fdo::Error::Failed("session path already exists".to_owned()));
+            }
             Err(err) => {
+                self.remote_desktop_sessions.clear_screen_cast(session_id)?;
                 return Err(fdo::Error::Failed(format!(
                     "error creating session object: {err:?}"
-                )))
+                )));
             }
         }
 
@@ -149,7 +192,15 @@ impl Session {
     async fn start(&self) {
         debug!("start");
 
-        for (stream, iface) in &*self.streams.lock().unwrap() {
+        let streams = match self.streams.lock() {
+            Ok(streams) => streams,
+            Err(_) => {
+                warn!("screen cast stream list is poisoned");
+                return;
+            }
+        };
+
+        for (stream, iface) in &*streams {
             stream.start(iface.signal_emitter().clone());
         }
     }
@@ -166,7 +217,13 @@ impl Session {
             return;
         }
 
-        Session::closed(&ctxt).await.unwrap();
+        if let Err(err) = self.remote_desktop_sessions.clear_screen_cast(self.id) {
+            warn!("error clearing remote desktop screen cast association: {err:?}");
+        }
+
+        if let Err(err) = Session::closed(&ctxt).await {
+            warn!("error emitting ScreenCast Closed signal: {err:?}");
+        }
 
         if let Err(err) = self.to_niri.send(ScreenCastToNiri::StopCast {
             session_id: self.id,
@@ -174,15 +231,26 @@ impl Session {
             warn!("error sending StopCast to niri: {err:?}");
         }
 
-        let streams = mem::take(&mut *self.streams.lock().unwrap());
+        let streams = match self.streams.lock() {
+            Ok(mut streams) => mem::take(&mut *streams),
+            Err(_) => {
+                warn!("screen cast stream list is poisoned");
+                Vec::new()
+            }
+        };
+
         for (_, iface) in streams.iter() {
-            server
+            if let Err(err) = server
                 .remove::<Stream, _>(iface.signal_emitter().path())
                 .await
-                .unwrap();
+            {
+                warn!("error removing stream object: {err:?}");
+            }
         }
 
-        server.remove::<Session, _>(ctxt.path()).await.unwrap();
+        if let Err(err) = server.remove::<Session, _>(ctxt.path()).await {
+            warn!("error removing screen cast session object: {err:?}");
+        }
     }
 
     async fn record_monitor(
@@ -194,20 +262,20 @@ impl Session {
         debug!(connector, ?properties, "record_monitor");
 
         let output = {
-            let ipc_outputs = self.ipc_outputs.lock().unwrap();
+            let ipc_outputs = self
+                .ipc_outputs
+                .lock()
+                .map_err(|_| fdo::Error::Failed("screen cast output map is poisoned".to_owned()))?;
             ipc_outputs.values().find(|o| o.name == connector).cloned()
         };
         let Some(output) = output else {
             return Err(fdo::Error::Failed("no such monitor".to_owned()));
         };
 
-        if output.logical.is_none() {
-            return Err(fdo::Error::Failed("monitor is disabled".to_owned()));
-        }
-
         let stream_id = CastStreamId::next();
+        let remote_stream = remote_desktop_output_stream(stream_id, &output)?;
         let path = format!("/org/gnome/Mutter/ScreenCast/Stream/u{}", stream_id.get());
-        let path = OwnedObjectPath::try_from(path).unwrap();
+        let path = object_path(path)?;
 
         let cursor_mode = properties.cursor_mode.unwrap_or_default();
 
@@ -221,8 +289,16 @@ impl Session {
         );
         match server.at(&path, stream.clone()).await {
             Ok(true) => {
-                let iface = server.interface(&path).await.unwrap();
-                self.streams.lock().unwrap().push((stream, iface));
+                let iface = server.interface(&path).await.map_err(|err| {
+                    fdo::Error::Failed(format!("error retrieving stream interface: {err:?}"))
+                })?;
+                self.register_remote_desktop_stream(&path, remote_stream)?;
+                self.streams
+                    .lock()
+                    .map_err(|_| {
+                        fdo::Error::Failed("screen cast stream list is poisoned".to_owned())
+                    })?
+                    .push((stream, iface));
             }
             Ok(false) => return Err(fdo::Error::Failed("stream path already exists".to_owned())),
             Err(err) => {
@@ -244,7 +320,7 @@ impl Session {
 
         let stream_id = CastStreamId::next();
         let path = format!("/org/gnome/Mutter/ScreenCast/Stream/u{}", stream_id.get());
-        let path = OwnedObjectPath::try_from(path).unwrap();
+        let path = object_path(path)?;
 
         let cursor_mode = properties.cursor_mode.unwrap_or_default();
 
@@ -260,8 +336,16 @@ impl Session {
         );
         match server.at(&path, stream.clone()).await {
             Ok(true) => {
-                let iface = server.interface(&path).await.unwrap();
-                self.streams.lock().unwrap().push((stream, iface));
+                let iface = server.interface(&path).await.map_err(|err| {
+                    fdo::Error::Failed(format!("error retrieving stream interface: {err:?}"))
+                })?;
+                self.register_remote_desktop_stream(&path, RemoteDesktopStream::window(stream_id))?;
+                self.streams
+                    .lock()
+                    .map_err(|_| {
+                        fdo::Error::Failed("screen cast stream list is poisoned".to_owned())
+                    })?
+                    .push((stream, iface));
             }
             Ok(false) => return Err(fdo::Error::Failed("stream path already exists".to_owned())),
             Err(err) => {
@@ -285,22 +369,16 @@ impl Stream {
         -> zbus::Result<()>;
 
     #[zbus(property)]
-    async fn parameters(&self) -> StreamParameters {
+    async fn parameters(&self) -> fdo::Result<StreamParameters> {
         match &self.target {
-            StreamTarget::Output(output) => {
-                let logical = output.logical.as_ref().unwrap();
-                StreamParameters {
-                    position: (logical.x, logical.y),
-                    size: (logical.width as i32, logical.height as i32),
-                }
-            }
-            StreamTarget::Window { .. } => {
+            StreamTarget::Output(output) => output_stream_parameters(output),
+            StreamTarget::Window { .. } => Ok(
                 // Does any consumer need this?
                 StreamParameters {
                     position: (0, 0),
                     size: (1, 1),
-                }
-            }
+                },
+            ),
         }
     }
 }
@@ -309,10 +387,12 @@ impl ScreenCast {
     pub fn new(
         ipc_outputs: Arc<Mutex<IpcOutputMap>>,
         to_niri: calloop::channel::Sender<ScreenCastToNiri>,
+        remote_desktop_sessions: RemoteDesktopSessionRegistry,
     ) -> Self {
         Self {
             ipc_outputs,
             to_niri,
+            remote_desktop_sessions,
             sessions: Arc::new(Mutex::new(vec![])),
         }
     }
@@ -338,19 +418,37 @@ impl Session {
         id: CastSessionId,
         ipc_outputs: Arc<Mutex<IpcOutputMap>>,
         to_niri: calloop::channel::Sender<ScreenCastToNiri>,
+        remote_desktop_session_id: Option<String>,
+        remote_desktop_sessions: RemoteDesktopSessionRegistry,
     ) -> Self {
         Self {
             id,
             ipc_outputs,
+            remote_desktop_session_id,
+            remote_desktop_sessions,
             streams: Arc::new(Mutex::new(vec![])),
             to_niri,
             stopped: Arc::new(AtomicBool::new(false)),
         }
     }
+
+    fn register_remote_desktop_stream(
+        &self,
+        path: &OwnedObjectPath,
+        stream: RemoteDesktopStream,
+    ) -> fdo::Result<()> {
+        if self.remote_desktop_session_id.is_none() {
+            return Ok(());
+        }
+
+        self.remote_desktop_sessions
+            .register_stream(self.id, path.as_str().to_owned(), stream)
+    }
 }
 
 impl Drop for Session {
     fn drop(&mut self) {
+        let _ = self.remote_desktop_sessions.clear_screen_cast(self.id);
         let _ = self.to_niri.send(ScreenCastToNiri::StopCast {
             session_id: self.id,
         });
@@ -403,4 +501,55 @@ impl StreamTarget {
             StreamTarget::Window { id } => StreamTargetId::Window { id: *id },
         }
     }
+}
+
+fn object_path(path: String) -> fdo::Result<OwnedObjectPath> {
+    OwnedObjectPath::try_from(path)
+        .map_err(|err| fdo::Error::Failed(format!("invalid object path: {err}")))
+}
+
+fn remote_desktop_output_stream(
+    stream_id: CastStreamId,
+    output: &niri_ipc::Output,
+) -> fdo::Result<RemoteDesktopStream> {
+    let logical = output
+        .logical
+        .as_ref()
+        .ok_or_else(|| fdo::Error::Failed("monitor is disabled".to_owned()))?;
+    let (width, height) = logical_size(logical)?;
+    Ok(RemoteDesktopStream::output(
+        stream_id,
+        RemoteDesktopOutputStream {
+            name: output.name.clone(),
+            x: logical.x,
+            y: logical.y,
+            width,
+            height,
+        },
+    ))
+}
+
+fn output_stream_parameters(output: &niri_ipc::Output) -> fdo::Result<StreamParameters> {
+    let logical = output
+        .logical
+        .as_ref()
+        .ok_or_else(|| fdo::Error::Failed("monitor is disabled".to_owned()))?;
+    Ok(StreamParameters {
+        position: (logical.x, logical.y),
+        size: logical_size(logical)?,
+    })
+}
+
+fn logical_size(logical: &niri_ipc::LogicalOutput) -> fdo::Result<(i32, i32)> {
+    if logical.width == 0 || logical.height == 0 {
+        return Err(fdo::Error::Failed(
+            "logical output size must be non-zero".to_owned(),
+        ));
+    }
+
+    let width = i32::try_from(logical.width)
+        .map_err(|_| fdo::Error::Failed("logical output width is too large".to_owned()))?;
+    let height = i32::try_from(logical.height)
+        .map_err(|_| fdo::Error::Failed("logical output height is too large".to_owned()))?;
+    Ok((width, height))
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -53,7 +53,7 @@ use smithay::wayland::selection::primary_selection::{
 use smithay::wayland::selection::wlr_data_control::{
     DataControlHandler as WlrDataControlHandler, DataControlState as WlrDataControlState,
 };
-use smithay::wayland::selection::{SelectionHandler, SelectionTarget};
+use smithay::wayland::selection::{SelectionHandler, SelectionSource, SelectionTarget};
 use smithay::wayland::session_lock::{
     LockSurface, SessionLockHandler, SessionLockManagerState, SessionLocker,
 };
@@ -283,29 +283,102 @@ delegate_keyboard_shortcuts_inhibit!(State);
 delegate_virtual_keyboard_manager!(State);
 
 impl SelectionHandler for State {
-    type SelectionUserData = Arc<[u8]>;
+    type SelectionUserData = SelectionData;
+
+    fn new_selection(
+        &mut self,
+        ty: SelectionTarget,
+        source: Option<SelectionSource>,
+        _seat: Seat<Self>,
+    ) {
+        if ty != SelectionTarget::Clipboard {
+            return;
+        }
+
+        #[cfg(feature = "xdp-gnome-screencast")]
+        if let Some(registry) = self
+            .niri
+            .dbus
+            .as_ref()
+            .and_then(|dbus| dbus.remote_desktop_sessions.as_ref())
+        {
+            registry.notify_clipboard_owner_changed(
+                None,
+                source.map(|source| source.mime_types()).unwrap_or_default(),
+            );
+        }
+    }
 
     fn send_selection(
         &mut self,
-        _ty: SelectionTarget,
-        _mime_type: String,
+        ty: SelectionTarget,
+        mime_type: String,
         fd: OwnedFd,
         _seat: Seat<Self>,
         user_data: &Self::SelectionUserData,
     ) {
         let _span = tracy_client::span!("send_selection");
 
-        let buf = user_data.clone();
-        thread::spawn(move || {
-            // Clear O_NONBLOCK, otherwise File::write_all() will stop halfway.
-            if let Err(err) = fcntl_setfl(&fd, OFlags::empty()) {
-                warn!("error clearing flags on selection target fd: {err:?}");
+        if ty != SelectionTarget::Clipboard {
+            return;
+        }
+
+        match user_data {
+            SelectionData::Bytes { data, .. } => {
+                if let Err(err) = write_selection_bytes(fd, data.clone()) {
+                    warn!("error sending selection: {err}");
+                }
             }
-            if let Err(err) = File::from(fd).write_all(&buf) {
-                warn!("error writing selection: {err:?}");
+            #[cfg(feature = "xdp-gnome-screencast")]
+            SelectionData::RemoteDesktop(selection) => {
+                if let Err(err) = selection.request_transfer(mime_type, fd) {
+                    warn!("error requesting remote desktop clipboard transfer: {err}");
+                }
             }
-        });
+        }
     }
+}
+
+#[derive(Clone, Debug)]
+pub enum SelectionData {
+    Bytes {
+        mime_types: Arc<[String]>,
+        data: Arc<[u8]>,
+    },
+    #[cfg(feature = "xdp-gnome-screencast")]
+    RemoteDesktop(crate::dbus::mutter_remote_desktop::RemoteDesktopClipboardSelection),
+}
+
+impl SelectionData {
+    pub fn bytes(mime_types: Vec<String>, data: Arc<[u8]>) -> Self {
+        Self::Bytes {
+            mime_types: mime_types.into(),
+            data,
+        }
+    }
+
+    pub fn contains_mime_type(&self, mime_type: &str) -> bool {
+        match self {
+            Self::Bytes { mime_types, .. } => {
+                mime_types.iter().any(|candidate| candidate == mime_type)
+            }
+            #[cfg(feature = "xdp-gnome-screencast")]
+            Self::RemoteDesktop(selection) => selection.contains_mime_type(mime_type),
+        }
+    }
+}
+
+pub fn write_selection_bytes(fd: OwnedFd, data: Arc<[u8]>) -> Result<(), String> {
+    thread::spawn(move || {
+        // Clear O_NONBLOCK, otherwise File::write_all() will stop halfway.
+        if let Err(err) = fcntl_setfl(&fd, OFlags::empty()) {
+            warn!("error clearing flags on selection target fd: {err:?}");
+        }
+        if let Err(err) = File::from(fd).write_all(&data) {
+            warn!("error writing selection: {err:?}");
+        }
+    });
+    Ok(())
 }
 
 impl DataDeviceHandler for State {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -128,7 +128,7 @@ use crate::dbus::gnome_shell_introspect::{self, IntrospectToNiri, NiriToIntrospe
 #[cfg(feature = "dbus")]
 use crate::dbus::gnome_shell_screenshot::{NiriToScreenshot, ScreenshotToNiri};
 use crate::frame_clock::FrameClock;
-use crate::handlers::{configure_lock_surface, XDG_ACTIVATION_TOKEN_TIMEOUT};
+use crate::handlers::{configure_lock_surface, SelectionData, XDG_ACTIVATION_TOKEN_TIMEOUT};
 use crate::input::pick_color_grab::PickColorGrab;
 use crate::input::scroll_swipe_gesture::ScrollSwipeGesture;
 use crate::input::scroll_tracker::ScrollTracker;
@@ -5685,7 +5685,7 @@ impl Niri {
                         &state.niri.display_handle,
                         &state.niri.seat,
                         vec![String::from("image/png")],
-                        buf.clone(),
+                        SelectionData::bytes(vec![String::from("image/png")], buf.clone()),
                     );
                 }
                 calloop::channel::Event::Closed => (),


### PR DESCRIPTION
Summary:
- Add the org.gnome.Mutter.RemoteDesktop service and session objects, including legacy input, keymap handling, ConnectToEIS, and clipboard/data-control bridging.
- Associate Mutter ScreenCast sessions with RemoteDesktop sessions via remote-desktop-session-id and expose output regions for absolute input.
- Add the optional reis dependency for the EIS server path.

Issue:
- Refs #390

Testing:
- cargo fmt --all -- --check
- cargo check --no-default-features --features dbus,xdp-gnome-screencast --message-format=short
- cargo check --message-format=short
- cargo test --no-default-features --features dbus,xdp-gnome-screencast --message-format=short mutter_remote_desktop
- cargo test --message-format=short mutter_remote_desktop
- cargo clippy --no-default-features --features dbus,xdp-gnome-screencast --message-format=short -- -A clippy::mutable_key_type -D warnings

Notes:
- This intentionally uses Refs rather than Fixes for #390. The implementation covers the Mutter DBus surface, EIS wiring, screencast association, and clipboard/data-control transfer paths, but live verification with a remote desktop client is still needed before calling the portal support complete.
- Plain clippy with -D warnings currently hits existing mutable_key_type diagnostics outside this patch, so the clippy command above allows that existing lint only.