### PR TITLE
Feature: Allow keyboard input to pass to window while in Overview Mode (If user sets flag in config)

### DIFF
--- a/niri-config/src/misc.rs
+++ b/niri-config/src/misc.rs
@@ -123,6 +123,7 @@ pub struct Overview {
     pub zoom: f64,
     pub backdrop_color: Color,
     pub workspace_shadow: WorkspaceShadow,
+    pub allow_overview_throughput_keyboard: bool,
 }
 
 impl Default for Overview {
@@ -131,6 +132,7 @@ impl Default for Overview {
             zoom: 0.5,
             backdrop_color: DEFAULT_BACKDROP_COLOR,
             workspace_shadow: WorkspaceShadow::default(),
+            allow_overview_throughput_keyboard: false,
         }
     }
 }
@@ -143,11 +145,18 @@ pub struct OverviewPart {
     pub backdrop_color: Option<Color>,
     #[knuffel(child)]
     pub workspace_shadow: Option<WorkspaceShadowPart>,
+    #[knuffel(child)]
+    pub allow_overview_throughput_keyboard: Option<Flag>,
 }
 
 impl MergeWith<OverviewPart> for Overview {
     fn merge_with(&mut self, part: &OverviewPart) {
-        merge!((self, part), zoom, workspace_shadow);
+        merge!(
+            (self, part),
+            zoom,
+            workspace_shadow,
+            allow_overview_throughput_keyboard
+        );
         merge_clone!((self, part), backdrop_color);
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -556,7 +556,15 @@ impl State {
 
                 if matches!(res, FilterResult::Forward) {
                     // If we didn't find any bind, try other hardcoded keys.
-                    if this.niri.keyboard_focus.is_overview() && pressed {
+                    if this.niri.keyboard_focus.is_overview()
+                        && pressed
+                        && !this
+                            .niri
+                            .config
+                            .borrow()
+                            .overview
+                            .allow_overview_throughput_keyboard
+                    {
                         if let Some(bind) = raw.and_then(|raw| hardcoded_overview_bind(raw, *mods))
                         {
                             this.niri.suppressed_keys.insert(key_code);

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1212,6 +1212,12 @@ impl State {
                 |layer| excl_focus_on_layer(layer).or_else(|| on_d_focus_on_layer(layer));
 
             let is_overview_open = self.niri.layout.is_overview_open();
+            let allow_keyboard_throughput = self
+                .niri
+                .config
+                .borrow()
+                .overview
+                .allow_overview_throughput_keyboard;
 
             let mut surface = grab_on_layer(Layer::Overlay);
             // FIXME: we shouldn't prioritize the top layer grabs over regular overlay input or a
@@ -1219,7 +1225,7 @@ impl State {
             // in the first place. Or a better way to structure this code.
             surface = surface.or_else(|| grab_on_layer(Layer::Top));
 
-            if !is_overview_open {
+            if !is_overview_open || allow_keyboard_throughput {
                 surface = surface.or_else(|| grab_on_layer(Layer::Bottom));
                 surface = surface.or_else(|| grab_on_layer(Layer::Background));
             }
@@ -1234,7 +1240,7 @@ impl State {
             } else {
                 surface = surface.or_else(|| focus_on_layer(Layer::Top));
 
-                if is_overview_open {
+                if is_overview_open && !allow_keyboard_throughput {
                     surface = Some(surface.unwrap_or(KeyboardFocus::Overview));
                 }
 


### PR DESCRIPTION
### Issue Summary
---
When in Overview mode there is no way for user to push keyboard input into the focused window
If a user needs to input into a window they will need to exit Overview mode, then go back into Overview mode to continue rearranging.

### Proposed change
---
Allow user to set a flag allow_overview_throughput_keyboard in niri's config which tells niri *"don't block keyboard input from reaching focus window in overview mode"*

### Rationale for change
---
I find myself reflexively trying to type into newly spawned applications when in Overview mode. 
This happens when I am setting up multiple terminals for projects and arranging them, I keep going back and forth between overview mode and normal.
This change enables people like me to reap the benefits of overview mode without having to juggle overview state.
 
### Implementation
---
- Updated  ```Overview``` struct, ```OverviewPart```, and ```MergeWith<OverviewPart> for Overview``` with ```allow_overview_throughput_keyboard```, which is false by default **(used  ```disable_power_key_handling``` in niri-config/src/input.rs for an example)**
- Check Flag in ```update_keyboard_focus()``` and skip Overview mode specific logic so inputs can go to defaults which is the focused window
- Check Flag in ```on_keyboard()``` from src/input/mod.rs and skip Overview logic again, so no hardcoded overview commands intercept our our keyboard inputs (escape, arrow keys, enter)

### Testing
---
- Go into Overview mode -> spawn a new terminal -> type a command -> press enter 
- for change on line 1228, I have not found a way to test because I can't find any apps that live on Bottom or Background layer to request focus. But this should behave the exact same way. If you know of an app that could help test this behavior please let me know and I will test and update this bullet
- All cargo tests pass

###Demo

https://github.com/user-attachments/assets/475afcb5-6737-4be9-a594-2a3129379543

