### PR TITLE
Specify gnome portal as the choice for ScreenCast xdg-desktop-portal endpoint

### DIFF
--- a/resources/niri-portals.conf
+++ b/resources/niri-portals.conf
@@ -3,3 +3,4 @@ default=gnome;gtk;
 org.freedesktop.impl.portal.Access=gtk;
 org.freedesktop.impl.portal.Notification=gtk;
 org.freedesktop.impl.portal.Secret=gnome-keyring;
+org.freedesktop.impl.portal.ScreenCast=gnome;


### PR DESCRIPTION
I was having difficulty getting screencasting to work, and this change eventually made it work.

Because gnome is already required for this to work, I think this change makes sense and just allows niri to work better with systems where multiple portals are already set up.