### PR TITLE
fix: color format for copy in multigpu setup

### DIFF
--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -70,10 +70,10 @@ use crate::render_helpers::renderer::AsGlesRenderer;
 use crate::render_helpers::{resources, shaders, RenderCtx, RenderTarget};
 use crate::utils::{get_monotonic_time, is_laptop_panel, logical_output, PanelOrientation};
 
-const SUPPORTED_COLOR_FORMATS: [Fourcc; 8] = [
-    Fourcc::Xrgb2101010,
+// specific 10-bit formats for multigpu setup,
+// i.e. copying from rendering Nvidia dGPU to target iGPU.
+const SUPPORTED_COLOR_FORMATS: [Fourcc; 6] = [
     Fourcc::Xbgr2101010,
-    Fourcc::Argb2101010,
     Fourcc::Abgr2101010,
     Fourcc::Xrgb8888,
     Fourcc::Xbgr8888,


### PR DESCRIPTION
This fixes https://github.com/niri-wm/niri/issues/4113 where copying from a rendering Nvidia GPU to a target iGPU fails because the latter has chosen a color format the former does not support. The `nvidia-drm` proprietary driver only supports XB30 and AB30, not XR30/AR30. Therefore, the first two color formats are used.