### PR TITLE
screencast: use BGRA instead of BGRx for non-alpha casts

### DIFF
--- a/src/screencasting/pw_utils.rs
+++ b/src/screencasting/pw_utils.rs
@@ -1255,7 +1255,7 @@ fn make_video_params(
     let format = if alpha {
         VideoFormat::BGRA
     } else {
-        VideoFormat::BGRx
+        VideoFormat::BGRA
     };
 
     let fourcc = if alpha {


### PR DESCRIPTION
gstreamer's pipewiresrc element (used by gnome-network-displays among others) doesnt accept BGRx during PipeWire format negotiation. It enumerates BGRA, NV12, RGB etc as accepted formats but BGRx is missing. niri currently offers BGRx for non-alpha screencasts so the format lists never intersect and negotiation fails with "no more input formats".

This came up while debugging gnome-network-displays for Miracast streaming (#4301). I was pointed to #1791 which adds SHM sharing. The SHM fallback helps with buffer type but the video format mismatch is separate. Even with SHM, BGRx doesnt match pipewiresrc's accepted formats. With this change both issues are addressed.

One line change:  ->  for the non-alpha path. BGRA is already what gstreamer pipewiresrc accepts and what niri uses for the alpha path. Functionally BGRA and BGRx are the same since the alpha channel gets ignored anyway.

Tested working with gnome-network-displays 0.99.0 streaming to a TV over Miracast, using niri 26.04.

### Niri offered formats with the build:
`
Id 12       (Spa:Enum:VideoFormat:BGRA)
    Prop: key Spa:Pod:Object:Param:Format:Video:modifier (131074), flags 00000008
      Id 12       (Spa:Enum:VideoFormat:BGRA)
`
### Negotiated format
`
Object: size 264, type Spa:Pod:Object:Param:Format (262147), id Spa:Enum:ParamId:Format (4)
    Prop: key Spa:Pod:Object:Param:Format:mediaType (1), flags 00000000
      Choice: type Spa:Enum:Choice:None, flags 00000000 20 4
        Id 2        (Spa:Enum:MediaType:video)
    Prop: key Spa:Pod:Object:Param:Format:mediaSubtype (2), flags 00000000
      Choice: type Spa:Enum:Choice:None, flags 00000000 20 4
        Id 1        (Spa:Enum:MediaSubtype:raw)
    Prop: key Spa:Pod:Object:Param:Format:Video:format (131073), flags 00000000
      Choice: type Spa:Enum:Choice:None, flags 00000000 20 4
        Id 12       (Spa:Enum:VideoFormat:BGRA)
    Prop: key Spa:Pod:Object:Param:Format:Video:size (131075), flags 00000000
      Choice: type Spa:Enum:Choice:None, flags 00000000 24 8
        Rectangle 1920x1080
    Prop: key Spa:Pod:Object:Param:Format:Video:framerate (131076), flags 00000000
      Choice: type Spa:Enum:Choice:None, flags 00000000 24 8
        Fraction 0/1
    Prop: key Spa:Pod:Object:Param:Format:Video:maxFramerate (131077), flags 00000000
      Choice: type Spa:Enum:Choice:None, flags 00000000 40 8
        Fraction 60031/1000
        Fraction 1/1
`

### Link state
`
niri-shm:output_1
  |-> gnome-network-displays:input_1
gnome-network-displays:input_1
  |<- niri-shm:output_1
`