### PR TITLE
layout: refill the view from the left after closing a column

### DIFF
--- a/src/layout/closing_window.rs
+++ b/src/layout/closing_window.rs
@@ -47,6 +47,9 @@ pub struct ClosingWindow {
     /// Position in the workspace.
     pos: Point<f64, Logical>,
 
+    /// Horizontal movement synchronized with a layout change.
+    move_x: Option<Animation>,
+
     /// How much the texture should be offset.
     buffer_offset: Point<f64, Logical>,
 
@@ -149,6 +152,7 @@ impl ClosingWindow {
             block_out_from: snapshot.block_out_from,
             geo_size,
             pos,
+            move_x: None,
             buffer_offset,
             buffer_with_blocked_out_bg_offset,
             blocked_out_buffer_offset,
@@ -174,6 +178,17 @@ impl ClosingWindow {
             AnimationState::Waiting { .. } => true,
             AnimationState::Animating(anim) => !anim.is_done(),
         }
+    }
+
+    pub(super) fn set_move_x_animation(&mut self, animation: Animation) {
+        self.move_x = Some(animation);
+    }
+
+    pub(super) fn position_in_view(&self, view_x: f64) -> Point<f64, Logical> {
+        let mut pos = self.pos;
+        pos.x += self.move_x.as_ref().map_or(0., Animation::value);
+        pos.x -= view_x;
+        pos
     }
 
     pub fn render(
@@ -207,8 +222,7 @@ impl ClosingWindow {
                 let elem = PrimaryGpuTextureRenderElement(elem);
                 let elem = RescaleRenderElement::from_element(elem, Point::from((0, 0)), 1.);
 
-                let mut location = self.pos + offset;
-                location.x -= view_rect.loc.x;
+                let location = self.position_in_view(view_rect.loc.x) + offset;
                 let elem = RelocateRenderElement::from_element(
                     elem,
                     location.to_physical_precise_round(scale),
@@ -232,7 +246,7 @@ impl ClosingWindow {
 
             // Round to physical pixels relative to the view position. This is similar to what
             // happens when rendering normal windows.
-            let relative = self.pos - view_rect.loc;
+            let relative = self.position_in_view(view_rect.loc.x);
             let pos = view_rect.loc + relative.to_physical_precise_round(scale).to_logical(scale);
 
             let geo_loc = Vec2::new(pos.x as f32, pos.y as f32);
@@ -289,8 +303,7 @@ impl ClosingWindow {
             ((1. - clamped_progress) / 5. + 0.8).max(0.),
         );
 
-        let mut location = self.pos + offset;
-        location.x -= view_rect.loc.x;
+        let location = self.position_in_view(view_rect.loc.x) + offset;
         let elem = RelocateRenderElement::from_element(
             elem,
             location.to_physical_precise_round(scale),

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1164,23 +1164,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         column_idx: usize,
         anim_config: Option<niri_config::Animation>,
     ) -> Column<W> {
-        let focus_left_refill = anim_config.is_none()
-            && !self.view_offset.is_gesture()
-            && self.columns[column_idx].sizing_mode().is_normal()
-            && column_idx == self.active_column_idx
-            && 0 < column_idx
-            && column_idx + 1 < self.columns.len()
-            && {
-                let view_x = self.target_view_pos();
-                let area = self.working_area;
-                let visible_width = |idx| {
-                    let left = self.column_x(idx) - view_x;
-                    let right = left + self.data[idx].width;
-                    (right.min(area.loc.x + area.size.w) - left.max(area.loc.x)).max(0.)
-                };
-
-                visible_width(column_idx - 1) < visible_width(column_idx + 1)
-            };
+        let focus_left_refill = anim_config.is_none() && self.should_focus_left_refill(column_idx);
 
         // Animate movement of the other columns.
         let movement_config = anim_config.unwrap_or(self.options.animations.window_movement.0);
@@ -1264,6 +1248,26 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         column
+    }
+
+    fn should_focus_left_refill(&self, column_idx: usize) -> bool {
+        !self.view_offset.is_gesture()
+            && self.columns[column_idx].sizing_mode().is_normal()
+            && column_idx == self.active_column_idx
+            && self.activate_prev_column_on_removal.is_none()
+            && 0 < column_idx
+            && column_idx + 1 < self.columns.len()
+            && {
+                let view_x = self.target_view_pos();
+                let area = self.working_area;
+                let visible_width = |idx| {
+                    let left = self.column_x(idx) - view_x;
+                    let right = left + self.data[idx].width;
+                    (right.min(area.loc.x + area.size.w) - left.max(area.loc.x)).max(0.)
+                };
+
+                visible_width(column_idx - 1) < visible_width(column_idx + 1)
+            }
     }
 
     pub fn update_window(&mut self, window: &W::Id, serial: Option<Serial>) {
@@ -1497,6 +1501,15 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let col = &self.columns[col_idx];
         let removing_last = col.tiles.len() == 1;
+        let move_x = (removing_last && self.should_focus_left_refill(col_idx)).then(|| {
+            Animation::new(
+                self.clock.clone(),
+                0.,
+                self.column_x(col_idx - 1) - self.column_x(col_idx),
+                0.,
+                self.options.animations.window_movement.0,
+            )
+        });
 
         // Skip closing animation for invisible tiles in a tabbed column.
         if col.display_mode == ColumnDisplay::Tabbed && tile_idx != col.active_tile_idx {
@@ -1524,7 +1537,9 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             tile_pos.x -= offset;
         }
 
-        self.start_close_animation_for_tile(renderer, snapshot, tile_size, tile_pos, blocker);
+        self.start_close_animation_for_tile(
+            renderer, snapshot, tile_size, tile_pos, blocker, move_x,
+        );
     }
 
     fn start_close_animation_for_tile(
@@ -1534,6 +1549,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         tile_size: Size<f64, Logical>,
         tile_pos: Point<f64, Logical>,
         blocker: TransactionBlocker,
+        move_x: Option<Animation>,
     ) {
         let anim = Animation::new(
             self.clock.clone(),
@@ -1554,7 +1570,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             renderer, snapshot, scale, tile_size, tile_pos, blocker, anim,
         );
         match res {
-            Ok(closing) => {
+            Ok(mut closing) => {
+                if let Some(animation) = move_x {
+                    closing.set_move_x_animation(animation);
+                }
                 self.closing_windows.push(closing);
             }
             Err(err) => {
@@ -3762,6 +3781,16 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     #[cfg(test)]
     pub(super) fn view_offset(&self) -> &ViewOffset {
         &self.view_offset
+    }
+
+    #[cfg(test)]
+    pub fn closing_window_render_positions(
+        &self,
+    ) -> impl Iterator<Item = Point<f64, Logical>> + '_ {
+        let view_x = self.view_pos();
+        self.closing_windows
+            .iter()
+            .map(move |closing| closing.position_in_view(view_x))
     }
 
     #[cfg(test)]

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1164,6 +1164,24 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         column_idx: usize,
         anim_config: Option<niri_config::Animation>,
     ) -> Column<W> {
+        let focus_left_refill = anim_config.is_none()
+            && !self.view_offset.is_gesture()
+            && self.columns[column_idx].sizing_mode().is_normal()
+            && column_idx == self.active_column_idx
+            && 0 < column_idx
+            && column_idx + 1 < self.columns.len()
+            && {
+                let view_x = self.target_view_pos();
+                let area = self.working_area;
+                let visible_width = |idx| {
+                    let left = self.column_x(idx) - view_x;
+                    let right = left + self.data[idx].width;
+                    (right.min(area.loc.x + area.size.w) - left.max(area.loc.x)).max(0.)
+                };
+
+                visible_width(column_idx - 1) < visible_width(column_idx + 1)
+            };
+
         // Animate movement of the other columns.
         let movement_config = anim_config.unwrap_or(self.options.animations.window_movement.0);
         let offset = self.column_x(column_idx + 1) - self.column_x(column_idx);
@@ -1236,10 +1254,13 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 );
             }
         } else {
-            self.activate_column_with_anim_config(
-                min(self.active_column_idx, self.columns.len() - 1),
-                view_config,
-            );
+            let target_idx = min(self.active_column_idx, self.columns.len() - 1);
+            if focus_left_refill {
+                // Reveal the left neighbor on the same timeline as the columns closing the gap.
+                self.activate_column_with_anim_config(target_idx - 1, movement_config);
+            } else {
+                self.activate_column_with_anim_config(target_idx, view_config);
+            }
         }
 
         column
@@ -2086,7 +2107,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             source_column_idx,
             source_tile_idx,
             transaction.clone(),
-            None,
+            Some(self.options.animations.window_movement.0),
         );
 
         {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -1654,6 +1654,57 @@ fn check_ops_with_options(
     layout
 }
 
+fn three_wide_columns() -> Layout<TestWindow> {
+    let wide_window = |id| {
+        let mut params = TestWindowParams::new(id);
+        params.bbox = Rectangle::from_size(Size::from((625, 200)));
+        params
+    };
+
+    check_ops([
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: wide_window(1),
+        },
+        Op::Communicate(1),
+        Op::AddWindow {
+            params: wide_window(2),
+        },
+        Op::Communicate(2),
+        Op::AddWindow {
+            params: wide_window(3),
+        },
+        Op::Communicate(3),
+    ])
+}
+
+#[test]
+fn removing_active_column_focuses_refill_side() {
+    let mut layout = three_wide_columns();
+    check_ops_on_layout(
+        &mut layout,
+        [
+            Op::FocusWindow(2),
+            Op::CompleteAnimations,
+            Op::CloseWindow(2),
+        ],
+    );
+    assert_eq!(layout.focus().map(|window| *window.id()), Some(1));
+
+    let mut layout = three_wide_columns();
+    check_ops_on_layout(
+        &mut layout,
+        [
+            Op::FocusWindow(1),
+            Op::CompleteAnimations,
+            Op::FocusWindow(2),
+            Op::CompleteAnimations,
+            Op::CloseWindow(2),
+        ],
+    );
+    assert_eq!(layout.focus().map(|window| *window.id()), Some(3));
+}
+
 #[test]
 fn operations_dont_panic() {
     if std::env::var_os("RUN_SLOW_TESTS").is_none() {

--- a/src/tests/animations.rs
+++ b/src/tests/animations.rs
@@ -188,3 +188,89 @@ fn egl_clientside_height_change_doesnt_animate() {
     200 × 200 at x:  0 y: 50
     ");
 }
+
+#[test]
+fn closing_window_stays_in_place_during_left_refill() {
+    const MOVEMENT: Kind = Kind::Easing(EasingParams {
+        duration_ms: 1000,
+        curve: Curve::Linear,
+    });
+    const CLOSE: Kind = Kind::Easing(EasingParams {
+        duration_ms: 2000,
+        curve: Curve::Linear,
+    });
+
+    let mut config = Config::default();
+    config.layout.gaps = 0.;
+    config.animations.window_movement.0.kind = MOVEMENT;
+    config.animations.window_close.anim.kind = CLOSE;
+    config.debug.disable_transactions = true;
+
+    let mut f = Fixture::with_config(config);
+    f.niri_state().backend.headless().add_renderer().unwrap();
+    f.add_output(1, (1280, 720));
+
+    let id = f.add_client();
+    let _surface1 = create_window(&mut f, id, 640, 720);
+    let surface2 = create_window(&mut f, id, 640, 720);
+    let _surface3 = create_window(&mut f, id, 640, 720);
+    f.double_roundtrip(id);
+
+    f.niri().layout.focus_left();
+    set_time(f.niri(), Duration::ZERO);
+    f.niri_complete_animations();
+    set_time(f.niri(), Duration::ZERO);
+
+    let window = f.client(id).window(&surface2);
+    window.attach_null();
+    window.commit();
+    f.roundtrip(id);
+
+    let closing_position = |niri: &Niri| {
+        niri.layout
+            .active_workspace()
+            .unwrap()
+            .scrolling()
+            .closing_window_render_positions()
+            .next()
+            .unwrap()
+    };
+
+    assert_eq!(closing_position(f.niri()), Point::from((0., 0.)));
+    assert_snapshot!(format_tiles(f.niri()), @r"
+    640 × 720 at x:-640 y:  0
+    640 × 720 at x:640 y:  0
+    ");
+
+    set_time(f.niri(), Duration::from_millis(500));
+    f.niri().advance_animations();
+
+    assert_eq!(closing_position(f.niri()), Point::from((0., 0.)));
+    assert_snapshot!(format_tiles(f.niri()), @r"
+    640 × 720 at x:-320 y:  0
+    640 × 720 at x:640 y:  0
+    ");
+
+    set_time(f.niri(), Duration::from_millis(1000));
+    f.niri().advance_animations();
+
+    assert_eq!(closing_position(f.niri()), Point::from((0., 0.)));
+    assert_snapshot!(format_tiles(f.niri()), @r"
+    640 × 720 at x:  0 y:  0
+    640 × 720 at x:640 y:  0
+    ");
+
+    set_time(f.niri(), Duration::from_millis(2000));
+    f.niri().advance_animations();
+
+    assert_eq!(
+        f.niri()
+            .layout
+            .active_workspace()
+            .unwrap()
+            .scrolling()
+            .closing_window_render_positions()
+            .count(),
+        0
+    );
+}


### PR DESCRIPTION
## Description

Niri's scrolling layout commonly shows two half-width columns side by side. Consider three such columns. The dotted lines below mark the view.

When columns 1 and 2 are visible, closing the column 2 keeps column 1 in place while column 3 enters from the right:

```text
before:

..............
[  1  ][  2  ] [  3  ]
..............


after closing column 2:

..............
[  1  ][  3  ]
..............
```

Column 1 remains in the left half of the screen.
In the mirror case, columns 2 and 3 are visible and column 1 is outside the view on the left:

```
before:

        ..............
[  1  ] [  2  ][  3  ]
        ..............
```

Currently, closing column 2 moves column 3 from the right half of the screen to the left, while column 1 remains outside the view:

```
current:

       ..............
[  1  ][  3  ]
       ..............
```

This PR changes the mirror case by moving the view to the left and activating column 1:

```
with this PR:

..............
[  1  ][  3  ]
..............
```

Column 1 enters from the left, while column 3 remains in the right half of the screen.

This introduces additional view movement, but that movement compensates for the layout change caused by removing column 2. As a result, the neighboring column that was already visible remains stable in screen space, making the two mirror cases behave consistently.

## Before


https://github.com/user-attachments/assets/925b8c73-63d0-41b5-8a9b-d2af5852e161


## After


https://github.com/user-attachments/assets/e4ddb6f7-0de0-4322-b288-e2673ce7d60b


## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo test --all`
- `RUN_SLOW_TESTS=1 cargo test --all`
- Manually tested both left-side and right-side refills in a nested niri session
