### PR TITLE
Add write-to-clipboard=false for screenshot-screen and screenshot-window

### DIFF
--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -393,6 +393,17 @@ binds {
 }
 ```
 
+<sup>Since: next release</sup> You can keep the screenshot out of the clipboard with the `write-to-clipboard=false` property:
+
+```kdl
+binds {
+    Ctrl+Print { screenshot-screen write-to-clipboard=false; }
+    Alt+Print { screenshot-window write-to-clipboard=false; }
+}
+```
+
+This is also useful for scripted captures (`niri msg action screenshot-window --id … --path … --write-to-clipboard false`), for example generating window thumbnails without clobbering the clipboard.
+
 #### `toggle-keyboard-shortcuts-inhibit`
 
 <sup>Since: 25.02</sup>

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -131,12 +131,14 @@ pub enum Action {
     ScreenshotScreen(
         #[knuffel(property(name = "write-to-disk"), default = true)] bool,
         #[knuffel(property(name = "show-pointer"), default = true)] bool,
+        #[knuffel(property(name = "write-to-clipboard"), default = true)] bool,
         // Path; not settable from knuffel
         Option<String>,
     ),
     ScreenshotWindow(
         #[knuffel(property(name = "write-to-disk"), default = true)] bool,
         #[knuffel(property(name = "show-pointer"), default = false)] bool,
+        #[knuffel(property(name = "write-to-clipboard"), default = true)] bool,
         // Path; not settable from knuffel
         Option<String>,
     ),
@@ -145,6 +147,7 @@ pub enum Action {
         id: u64,
         write_to_disk: bool,
         show_pointer: bool,
+        write_to_clipboard: bool,
         path: Option<String>,
     },
     ToggleKeyboardShortcutsInhibit,
@@ -410,23 +413,27 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::ScreenshotScreen {
                 write_to_disk,
                 show_pointer,
+                write_to_clipboard,
                 path,
-            } => Self::ScreenshotScreen(write_to_disk, show_pointer, path),
+            } => Self::ScreenshotScreen(write_to_disk, show_pointer, write_to_clipboard, path),
             niri_ipc::Action::ScreenshotWindow {
                 id: None,
                 write_to_disk,
                 show_pointer,
+                write_to_clipboard,
                 path,
-            } => Self::ScreenshotWindow(write_to_disk, show_pointer, path),
+            } => Self::ScreenshotWindow(write_to_disk, show_pointer, write_to_clipboard, path),
             niri_ipc::Action::ScreenshotWindow {
                 id: Some(id),
                 write_to_disk,
                 show_pointer,
+                write_to_clipboard,
                 path,
             } => Self::ScreenshotWindowById {
                 id,
                 write_to_disk,
                 show_pointer,
+                write_to_clipboard,
                 path,
             },
             niri_ipc::Action::ToggleKeyboardShortcutsInhibit {} => {

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -183,6 +183,10 @@ pub struct PickedColor {
     pub rgb: [f64; 3],
 }
 
+fn default_true() -> bool {
+    true
+}
+
 /// Actions that niri can perform.
 // Variants in this enum should match the spelling of the ones in niri-config. Most, but not all,
 // variants from niri-config should be present here.
@@ -246,6 +250,11 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(short = 'p', long, action = clap::ArgAction::Set, default_value_t = true))]
         show_pointer: bool,
 
+        /// Whether to put the screenshot into your clipboard.
+        #[cfg_attr(feature = "clap", arg(short = 'c', long, action = clap::ArgAction::Set, default_value_t = true))]
+        #[serde(default = "default_true")]
+        write_to_clipboard: bool,
+
         /// Path to save the screenshot to.
         ///
         /// The path must be absolute, otherwise an error is returned.
@@ -274,6 +283,11 @@ pub enum Action {
         /// (usually this means the pointer is on top of the window).
         #[cfg_attr(feature = "clap", arg(short = 'p', long, action = clap::ArgAction::Set, default_value_t = false))]
         show_pointer: bool,
+
+        /// Whether to put the screenshot into your clipboard.
+        #[cfg_attr(feature = "clap", arg(short = 'c', long, action = clap::ArgAction::Set, default_value_t = true))]
+        #[serde(default = "default_true")]
+        write_to_clipboard: bool,
 
         /// Path to save the screenshot to.
         ///

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -732,7 +732,7 @@ impl State {
                     self.niri.do_screen_transition(renderer, delay_ms);
                 });
             }
-            Action::ScreenshotScreen(write_to_disk, show_pointer, path) => {
+            Action::ScreenshotScreen(write_to_disk, show_pointer, write_to_clipboard, path) => {
                 let active = self.niri.layout.active_output().cloned();
                 if let Some(active) = active {
                     self.backend.with_primary_renderer(|renderer| {
@@ -741,6 +741,7 @@ impl State {
                             &active,
                             write_to_disk,
                             show_pointer,
+                            write_to_clipboard,
                             path,
                         ) {
                             warn!("error taking screenshot: {err:?}");
@@ -770,7 +771,7 @@ impl State {
                 self.open_screenshot_ui(show_cursor, path);
                 self.niri.cancel_mru();
             }
-            Action::ScreenshotWindow(write_to_disk, show_pointer, path) => {
+            Action::ScreenshotWindow(write_to_disk, show_pointer, write_to_clipboard, path) => {
                 let focus = self.niri.layout.focus_with_output();
                 if let Some((mapped, output)) = focus {
                     self.backend.with_primary_renderer(|renderer| {
@@ -780,6 +781,7 @@ impl State {
                             mapped,
                             write_to_disk,
                             show_pointer,
+                            write_to_clipboard,
                             path,
                         ) {
                             warn!("error taking screenshot: {err:?}");
@@ -791,6 +793,7 @@ impl State {
                 id,
                 write_to_disk,
                 show_pointer,
+                write_to_clipboard,
                 path,
             } => {
                 let mut windows = self.niri.layout.windows();
@@ -804,6 +807,7 @@ impl State {
                             mapped,
                             write_to_disk,
                             show_pointer,
+                            write_to_clipboard,
                             path,
                         ) {
                             warn!("error taking screenshot: {err:?}");

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2035,7 +2035,10 @@ impl State {
         self.backend.with_primary_renderer(|renderer| {
             match self.niri.screenshot_ui.capture(renderer) {
                 Ok((size, pixels)) => {
-                    if let Err(err) = self.niri.save_screenshot(size, pixels, write_to_disk, path) {
+                    if let Err(err) =
+                        self.niri
+                            .save_screenshot(size, pixels, write_to_disk, true, path)
+                    {
                         warn!("error saving screenshot: {err:?}");
                     }
                 }
@@ -5554,6 +5557,7 @@ impl Niri {
         output: &Output,
         write_to_disk: bool,
         include_pointer: bool,
+        write_to_clipboard: bool,
         path: Option<String>,
     ) -> anyhow::Result<()> {
         let _span = tracy_client::span!("Niri::screenshot");
@@ -5581,7 +5585,7 @@ impl Niri {
             elements,
         )?;
 
-        self.save_screenshot(size, pixels, write_to_disk, path)
+        self.save_screenshot(size, pixels, write_to_disk, write_to_clipboard, path)
             .context("error saving screenshot")
     }
 
@@ -5592,6 +5596,7 @@ impl Niri {
         mapped: &Mapped,
         write_to_disk: bool,
         show_pointer: bool,
+        write_to_clipboard: bool,
         path: Option<String>,
     ) -> anyhow::Result<()> {
         let _span = tracy_client::span!("Niri::screenshot_window");
@@ -5649,7 +5654,7 @@ impl Niri {
             elements,
         )?;
 
-        self.save_screenshot(geo.size, pixels, write_to_disk, path)
+        self.save_screenshot(geo.size, pixels, write_to_disk, write_to_clipboard, path)
             .context("error saving screenshot")
     }
 
@@ -5658,6 +5663,7 @@ impl Niri {
         size: Size<i32, Physical>,
         pixels: Vec<u8>,
         write_to_disk: bool,
+        write_to_clipboard: bool,
         path_arg: Option<String>,
     ) -> anyhow::Result<()> {
         let path = write_to_disk
@@ -5677,20 +5683,23 @@ impl Niri {
 
         // Prepare to set the encoded image as our clipboard selection. This must be done from the
         // main thread.
-        let (tx, rx) = calloop::channel::sync_channel::<Arc<[u8]>>(1);
-        self.event_loop
-            .insert_source(rx, move |event, _, state| match event {
-                calloop::channel::Event::Msg(buf) => {
-                    set_data_device_selection(
-                        &state.niri.display_handle,
-                        &state.niri.seat,
-                        vec![String::from("image/png")],
-                        buf.clone(),
-                    );
-                }
-                calloop::channel::Event::Closed => (),
-            })
-            .unwrap();
+        let tx = write_to_clipboard.then(|| {
+            let (tx, rx) = calloop::channel::sync_channel::<Arc<[u8]>>(1);
+            self.event_loop
+                .insert_source(rx, move |event, _, state| match event {
+                    calloop::channel::Event::Msg(buf) => {
+                        set_data_device_selection(
+                            &state.niri.display_handle,
+                            &state.niri.seat,
+                            vec![String::from("image/png")],
+                            buf.clone(),
+                        );
+                    }
+                    calloop::channel::Event::Closed => (),
+                })
+                .unwrap();
+            tx
+        });
 
         // Prepare to send screenshot completion event back to main thread.
         let (event_tx, event_rx) = calloop::channel::sync_channel::<Option<String>>(1);
@@ -5714,7 +5723,9 @@ impl Niri {
             }
 
             let buf: Arc<[u8]> = Arc::from(buf.into_boxed_slice());
-            let _ = tx.send(buf.clone());
+            if let Some(tx) = tx {
+                let _ = tx.send(buf.clone());
+            }
 
             let mut image_path = None;
 


### PR DESCRIPTION
Scripted captures (like making window thumbnails with niri msg action screenshot-window) replace the user's clipboard on each shot; workaround is a wl-paste backup/restore dance racing with niri's async clipboard write.

The new property defaults to true, so nothing changes in behavior unless you ask it to. The IPC field has `#[serde(default)]` so older clients' requests will still de-serialize.