### PR TITLE
input: ignore power key presses immediately after resume

### DIFF
--- a/src/dbus/freedesktop_login1.rs
+++ b/src/dbus/freedesktop_login1.rs
@@ -4,6 +4,17 @@ use zbus::names::InterfaceName;
 
 pub enum Login1ToNiri {
     LidClosedChanged(bool),
+    PrepareForSleep(bool),
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.login1.Manager",
+    default_service = "org.freedesktop.login1",
+    default_path = "/org/freedesktop/login1"
+)]
+trait Login1Manager {
+    #[zbus(signal)]
+    fn prepare_for_sleep(start: bool) -> zbus::Result<()>;
 }
 
 pub fn start(
@@ -35,6 +46,24 @@ pub fn start(
             }
         };
 
+        let login1 = Login1ManagerProxy::new(&async_conn).await;
+        let login1 = match login1 {
+            Ok(x) => x,
+            Err(err) => {
+                warn!("error creating login1 manager proxy: {err:?}");
+                return;
+            }
+        };
+
+        let prepare_for_sleep = login1.receive_prepare_for_sleep().await;
+        let mut prepare_for_sleep = match prepare_for_sleep {
+            Ok(x) => x,
+            Err(err) => {
+                warn!("error subscribing to PrepareForSleep: {err:?}");
+                return;
+            }
+        };
+
         let props = proxy
             .get_all(InterfaceName::try_from("org.freedesktop.login1.Manager").unwrap())
             .await;
@@ -58,40 +87,62 @@ pub fn start(
             return;
         };
 
-        while let Some(signal) = props_changed.next().await {
-            let args = match signal.args() {
-                Ok(args) => args,
-                Err(err) => {
-                    warn!("error parsing PropertiesChanged args: {err:?}");
-                    return;
+        loop {
+            futures_util::select! {
+                signal = props_changed.next() => {
+                    let Some(signal) = signal else {
+                        return;
+                    };
+
+                    let args = match signal.args() {
+                        Ok(args) => args,
+                        Err(err) => {
+                            warn!("error parsing PropertiesChanged args: {err:?}");
+                            return;
+                        }
+                    };
+
+                    let mut new_lid_closed = lid_closed;
+                    let mut changed = false;
+                    for (name, value) in args.changed_properties() {
+                        trace!("changed property: {name} => {value:?}");
+                        if *name != "LidClosed" {
+                            continue;
+                        }
+
+                        new_lid_closed = bool::try_from(value).unwrap_or(new_lid_closed);
+                        changed = true;
+                    }
+
+                    if !changed || new_lid_closed == lid_closed {
+                        continue;
+                    }
+
+                    lid_closed = new_lid_closed;
+                    if let Err(err) = to_niri.send(Login1ToNiri::LidClosedChanged(lid_closed)) {
+                        warn!("error sending message to niri: {err:?}");
+                        return;
+                    };
                 }
-            };
+                signal = prepare_for_sleep.next() => {
+                    let Some(signal) = signal else {
+                        return;
+                    };
 
-            let mut new_lid_closed = lid_closed;
-            let mut changed = false;
-            for (name, value) in args.changed_properties() {
-                trace!("changed property: {name} => {value:?}");
-                if *name != "LidClosed" {
-                    continue;
+                    let args = match signal.args() {
+                        Ok(args) => args,
+                        Err(err) => {
+                            warn!("error parsing PrepareForSleep args: {err:?}");
+                            return;
+                        }
+                    };
+
+                    if let Err(err) = to_niri.send(Login1ToNiri::PrepareForSleep(args.start)) {
+                        warn!("error sending message to niri: {err:?}");
+                        return;
+                    };
                 }
-
-                new_lid_closed = bool::try_from(value).unwrap_or(new_lid_closed);
-                changed = true;
             }
-
-            if !changed {
-                continue;
-            }
-
-            if new_lid_closed == lid_closed {
-                continue;
-            }
-
-            lid_closed = new_lid_closed;
-            if let Err(err) = to_niri.send(Login1ToNiri::LidClosedChanged(lid_closed)) {
-                warn!("error sending message to niri: {err:?}");
-                return;
-            };
         }
     };
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use calloop::timer::{TimeoutAction, Timer};
 use input::event::gesture::GestureEventCoordinates as _;
@@ -532,6 +532,19 @@ impl State {
 
                 if let Some(Keysym::space) = raw {
                     this.niri.screenshot_ui.set_space_down(pressed);
+                }
+
+                if pressed && modified.raw() == Keysym::XF86_PowerOff.raw() {
+                    if this
+                        .niri
+                        .ignore_power_key_until
+                        .is_some_and(|until| Instant::now() < until)
+                    {
+                        this.niri.suppressed_keys.insert(key_code);
+                        return FilterResult::Intercept(None);
+                    }
+
+                    this.niri.ignore_power_key_until = None;
                 }
 
                 let res = {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -191,6 +191,7 @@ const CLEAR_COLOR_LOCKED: [f32; 4] = [0.3, 0.1, 0.1, 1.];
 // second, so with the worst timing the maximum interval between two frame callbacks for a surface
 // should be ~1.995 seconds.
 const FRAME_CALLBACK_THROTTLE: Option<Duration> = Some(Duration::from_millis(995));
+const POST_RESUME_POWER_KEY_IGNORE: Duration = Duration::from_secs(2);
 
 pub struct Niri {
     pub config: Rc<RefCell<Config>>,
@@ -266,6 +267,9 @@ pub struct Niri {
     /// Libinput guarantees that the lid switch starts in open state, and if it was closed during
     /// startup, libinput will immediately send a closed event.
     pub is_lid_closed: bool,
+
+    /// Until this instant, ignore power-key presses that may be left over from waking up.
+    pub ignore_power_key_until: Option<Instant>,
 
     pub devices: HashSet<input::Device>,
     pub tablets: HashMap<input::Device, TabletData>,
@@ -2206,10 +2210,20 @@ impl State {
 
     #[cfg(feature = "dbus")]
     pub fn on_login1_msg(&mut self, msg: Login1ToNiri) {
-        let Login1ToNiri::LidClosedChanged(is_closed) = msg;
-
-        trace!("login1 lid {}", if is_closed { "closed" } else { "opened" });
-        self.set_lid_closed(is_closed);
+        match msg {
+            Login1ToNiri::LidClosedChanged(is_closed) => {
+                trace!("login1 lid {}", if is_closed { "closed" } else { "opened" });
+                self.set_lid_closed(is_closed);
+            }
+            Login1ToNiri::PrepareForSleep(true) => {
+                trace!("login1 preparing for sleep");
+            }
+            Login1ToNiri::PrepareForSleep(false) => {
+                trace!("login1 resumed from sleep");
+                self.niri.ignore_power_key_until =
+                    Some(Instant::now() + POST_RESUME_POWER_KEY_IGNORE);
+            }
+        }
     }
 
     #[cfg(feature = "dbus")]
@@ -2522,6 +2536,7 @@ impl Niri {
             blocker_cleared_rx,
             monitors_active: true,
             is_lid_closed: false,
+            ignore_power_key_until: None,
 
             devices: HashSet::new(),
             tablets: HashMap::new(),


### PR DESCRIPTION
When niri handles the power key itself, the key press used to wake a suspended
system can be delivered after resume and interpreted as a fresh suspend request.
This can make the system immediately suspend again after waking up.

The observed journal sequence is:

```text
Lid opened
Power key pressed short
System returned from sleep operation 'suspend'
suspend requested from client ... ('niri')
The system will suspend now
```

This change listens for login1's `PrepareForSleep` signal. After
`PrepareForSleep(false)`, niri opens a short post-resume window and swallows
`XF86_PowerOff` presses during that window.

This preserves the normal behavior where pressing the power key while the
session is already awake suspends the system, while avoiding a suspend loop
caused by a wake-up key event.

Tested:

```text
cargo check --features dbus
```

I could not run `cargo +nightly fmt --all` on this machine because the installed
Cargo is not rustup-managed. I ran `cargo fmt --all`; it completed, but ignored
nightly-only rustfmt options.
