### PR TITLE
Relative Output Placement

### DIFF
--- a/docs/wiki/Configuration:-Outputs.md
+++ b/docs/wiki/Configuration:-Outputs.md
@@ -173,6 +173,9 @@ Set the position of the output in the global coordinate space.
 This affects directional monitor actions like `focus-monitor-left`, and cursor movement.
 The cursor can only move between directly adjacent outputs.
 
+
+#### Absolute Positioning
+
 > [!NOTE]
 > Output scale and rotation has to be taken into account for positioning: outputs are sized in logical, or scaled, pixels.
 > For example, a 3840×2160 output with scale 2.0 will have a logical size of 1920×1080, so to put another output directly adjacent to it on the right, set its x to 1920.
@@ -184,6 +187,41 @@ output "HDMI-A-1" {
 }
 ```
 
+#### Relative Positioning
+
+<sup>Since: TODO ADD VERSION HERE</sup>
+
+Instead of absolute coordinates, you can position an output relative to another output.
+Niri resolves this into absolute coordinates, so the layout keeps working when resolutions or scales change.
+
+Use exactly one direction property — `left-of`, `right-of`, `above`, or `below` — set to the name of the anchor output (matched the same way as the `output` name itself: by connector, or by `"make model serial"`).
+The absolute (`x`/`y`) and relative forms are mutually exclusive on a single output.
+
+```kdl
+output "eDP-1" {}
+
+output "HDMI-A-1" {
+    position left-of="eDP-1"
+}
+
+output "HDMI-A-2" {
+    position above="HDMI-A-1" align="center"
+}
+```
+
+The direction sets which edges touch: `left-of` puts this output's right edge against the anchor's left edge, `above` puts this output's bottom edge against the anchor's top edge, and so on.
+The optional `align` property — one of `beginning`, `center`, or `end` — controls how the output slides along that shared edge. It defaults to `beginning`.
+
+- `beginning` aligns the start of the shared edge: the top edges for `left-of`/`right-of`, or the left edges for `above`/`below`.
+- `center` aligns the midpoints of the shared edge.
+- `end` aligns the far end of the shared edge: the bottom edges for `left-of`/`right-of`, or the right edges for `above`/`below`.
+
+Relative positioning is best-effort:
+
+- Outputs can be chained — an output may be positioned relative to another output that is itself positioned relatively.
+- If the anchor is not connected, is unknown, or the references form a cycle, the output falls back to automatic placement (and niri prints a warning). Because outputs are repositioned on every hotplug, it will attach as soon as its anchor appears.
+- If the resolved position would overlap an already-placed output, the output is nudged outward along its direction until it no longer overlaps, without moving any already-placed output.
+
 #### Automatic Positioning
 
 Niri repositions outputs from scratch every time the output configuration changes (which includes monitors disconnecting and connecting).
@@ -191,8 +229,9 @@ The following algorithm is used for positioning outputs.
 
 1. Collect all connected monitors and their logical sizes.
 1. Sort them by their name. This makes it so the automatic positioning does not depend on the order the monitors are connected. This is important because the connection order is non-deterministic at compositor startup.
-1. Try to place every output with explicitly configured `position`, in order. If the output overlaps previously placed outputs, place it to the right of all previously placed outputs. In this case, niri will also print a warning.
-1. Place every output without explicitly configured `position` by putting it to the right of all previously placed outputs.
+1. Try to place every output with an absolute (`x`/`y`) `position`, in order. If the output overlaps previously placed outputs, place it to the right of all previously placed outputs. In this case, niri will also print a warning.
+1. Place every output without a configured `position` by putting it to the right of all previously placed outputs.
+1. Place every output with a relative `position` whose anchor is already placed, resolving it against the anchor's position. Repeat until no more can be placed (this resolves chains). Any output whose anchor is missing, unknown, or part of a cycle is placed to the right of all previously placed outputs, with a warning.
 
 ### `variable-refresh-rate`
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -54,7 +54,7 @@ pub use crate::input::{Input, ModKey, ScrollMethod, TrackLayout, WarpMouseToFocu
 pub use crate::layer_rule::LayerRule;
 pub use crate::layout::*;
 pub use crate::misc::*;
-pub use crate::output::{Output, OutputName, Outputs, Position, Vrr};
+pub use crate::output::{Align, Direction, Output, OutputName, Outputs, Position, Vrr};
 use crate::recent_windows::RecentWindowsPart;
 pub use crate::recent_windows::{MruDirection, MruFilter, MruPreviews, MruScope, RecentWindows};
 pub use crate::utils::FloatOrInt;
@@ -656,6 +656,65 @@ mod tests {
     }
 
     #[test]
+    fn parse_output_position() {
+        #[track_caller]
+        fn pos(node: &str) -> Position {
+            let text = format!("output \"X\" {{\n{node}\n}}");
+            do_parse(&text)
+                .outputs
+                .0
+                .into_iter()
+                .next()
+                .unwrap()
+                .position
+                .unwrap()
+        }
+        #[track_caller]
+        fn is_err(node: &str) -> bool {
+            let text = format!("output \"X\" {{\n{node}\n}}");
+            Config::parse_mem(&text).is_err()
+        }
+
+        // Absolute form still parses.
+        assert_eq!(pos("position x=10 y=20"), Position::Fixed { x: 10, y: 20 });
+
+        // Relative form; align defaults to Beginning.
+        assert_eq!(
+            pos(r#"position left-of="eDP-1""#),
+            Position::Relative {
+                relative_to: "eDP-1".to_owned(),
+                direction: Direction::LeftOf,
+                align: Align::Beginning,
+            }
+        );
+        assert_eq!(
+            pos(r#"position above="HDMI-A-1" align="center""#),
+            Position::Relative {
+                relative_to: "HDMI-A-1".to_owned(),
+                direction: Direction::Above,
+                align: Align::Center,
+            }
+        );
+        assert_eq!(
+            pos(r#"position below="DP-2" align="end""#),
+            Position::Relative {
+                relative_to: "DP-2".to_owned(),
+                direction: Direction::Below,
+                align: Align::End,
+            }
+        );
+
+        assert!(is_err(r#"position x=1 y=2 left-of="X""#)); // mixed absolute + relative
+        assert!(is_err("position x=1")); // missing y
+        assert!(is_err("position y=1")); // missing x
+        assert!(is_err(r#"position left-of="a" right-of="b""#)); // two directions
+        assert!(is_err(r#"position above="X" align="middle""#)); // bad align value
+        assert!(is_err(r#"position x=1 y=2 align="center""#)); // align on absolute
+        assert!(is_err("position")); // neither form
+        assert!(is_err(r#"position "left-of" "X""#)); // arguments not allowed
+    }
+
+    #[test]
     fn parse() {
         let parsed = do_parse(
             r##"
@@ -759,6 +818,7 @@ mod tests {
 
             output "eDP-2" {
                 mode custom=true "1920x1080@144"
+                position above="eDP-1" align="center"
             }
 
             output "eDP-3" {
@@ -1156,7 +1216,7 @@ mod tests {
                         ),
                         transform: Flipped90,
                         position: Some(
-                            Position {
+                            Fixed {
                                 x: 10,
                                 y: 20,
                             },
@@ -1210,7 +1270,13 @@ mod tests {
                         name: "eDP-2",
                         scale: None,
                         transform: Normal,
-                        position: None,
+                        position: Some(
+                            Relative {
+                                relative_to: "eDP-1",
+                                direction: Above,
+                                align: Center,
+                            },
+                        ),
                         max_bpc: None,
                         mode: Some(
                             Mode {

--- a/niri-config/src/output.rs
+++ b/niri-config/src/output.rs
@@ -131,7 +131,10 @@ pub struct OutputName {
 /// The two forms are mutually exclusive.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Position {
-    Fixed { x: i32, y: i32 },
+    Fixed {
+        x: i32,
+        y: i32,
+    },
     Relative {
         /// Name of the anchor output.
         relative_to: String,

--- a/niri-config/src/output.rs
+++ b/niri-config/src/output.rs
@@ -123,12 +123,46 @@ pub struct OutputName {
     pub serial: Option<String>,
 }
 
-#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Position {
-    #[knuffel(property)]
-    pub x: i32,
-    #[knuffel(property)]
-    pub y: i32,
+/// Configured position of an output.
+///
+/// One of:
+///  - an absolute position (logical)
+///  - a position relative to another output
+/// The two forms are mutually exclusive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Position {
+    Fixed { x: i32, y: i32 },
+    Relative {
+        /// Name of the anchor output.
+        relative_to: String,
+        /// Which side to attach to.
+        direction: Direction,
+        /// Alignment along the shared edge.
+        align: Align,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    LeftOf,
+    RightOf,
+    Above,
+    Below,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Align {
+    /// Align to:
+    /// - top for a vertical edge
+    /// - left for a horizontal one.
+    #[default]
+    Beginning,
+    /// Align the midpoints of the shared edge.
+    Center,
+    /// Align to:
+    ///  - bottom for a vertical edge
+    ///  - right for a horizontal one.
+    End,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -532,6 +566,120 @@ impl<S: ErrorSpan> Decode<S> for Modeline {
             hsync_polarity,
             vsync_polarity,
         })
+    }
+}
+
+impl<S: ErrorSpan> Decode<S> for Position {
+    fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+        if let Some(type_name) = &node.type_name {
+            ctx.emit_error(DecodeError::unexpected(
+                type_name,
+                "type name",
+                "no type name expected for this node",
+            ));
+        }
+
+        for child in node.children() {
+            ctx.emit_error(DecodeError::unexpected(
+                child,
+                "node",
+                format!("unexpected node `{}`", child.node_name.escape_default()),
+            ));
+        }
+
+        for arg in &node.arguments {
+            ctx.emit_error(DecodeError::unexpected(
+                &arg.literal,
+                "argument",
+                "the position node takes no arguments; use properties like `x=` and `y=`, \
+                 or `left-of=`/`right-of=`/`above=`/`below=`",
+            ));
+        }
+
+        let mut x: Option<i32> = None;
+        let mut y: Option<i32> = None;
+        let mut direction: Option<(Direction, String)> = None;
+        let mut align: Option<Align> = None;
+
+        for (name, val) in &node.properties {
+            match &***name {
+                "x" => x = Some(knuffel::traits::DecodeScalar::decode(val, ctx)?),
+                "y" => y = Some(knuffel::traits::DecodeScalar::decode(val, ctx)?),
+                "align" => {
+                    let value: String = knuffel::traits::DecodeScalar::decode(val, ctx)?;
+                    align = Some(match value.as_str() {
+                        "beginning" => Align::Beginning,
+                        "center" => Align::Center,
+                        "end" => Align::End,
+                        _ => {
+                            ctx.emit_error(DecodeError::conversion(
+                                &val.literal,
+                                "expected `beginning`, `center`, or `end`",
+                            ));
+                            Align::Beginning
+                        }
+                    });
+                }
+                dir @ ("left-of" | "right-of" | "above" | "below") => {
+                    let parsed = match dir {
+                        "left-of" => Direction::LeftOf,
+                        "right-of" => Direction::RightOf,
+                        "above" => Direction::Above,
+                        _ => Direction::Below,
+                    };
+                    let anchor: String = knuffel::traits::DecodeScalar::decode(val, ctx)?;
+                    if direction.is_some() {
+                        ctx.emit_error(DecodeError::unexpected(
+                            name,
+                            "property",
+                            "only one direction may be given \
+                             (left-of, right-of, above, or below)",
+                        ));
+                    } else {
+                        direction = Some((parsed, anchor));
+                    }
+                }
+                name_str => ctx.emit_error(DecodeError::unexpected(
+                    name,
+                    "property",
+                    format!("unexpected property `{}`", name_str.escape_default()),
+                )),
+            }
+        }
+
+        match (x, y, direction) {
+            (Some(x), Some(y), None) if align.is_none() => Ok(Position::Fixed { x, y }),
+            (Some(_), Some(_), None) => Err(DecodeError::unexpected(
+                node,
+                "property",
+                "`align` is only valid together with a direction \
+                 (left-of/right-of/above/below)",
+            )),
+            (None, None, Some((direction, relative_to))) => Ok(Position::Relative {
+                relative_to,
+                direction,
+                align: align.unwrap_or_default(),
+            }),
+            (_, _, Some(_)) => Err(DecodeError::unexpected(
+                node,
+                "property",
+                "position cannot combine absolute coordinates (x/y) with a direction \
+                 (left-of/right-of/above/below)",
+            )),
+            (None, None, None) => Err(DecodeError::missing(
+                node,
+                "position requires either `x` and `y`, or a direction \
+                 (left-of/right-of/above/below)",
+            )),
+            // Exactly one of `x`/`y` given, with no direction.
+            (x, _, None) => {
+                let missing = if x.is_none() { "x" } else { "y" };
+                Err(DecodeError::missing(
+                    node,
+                    format!("absolute position requires both `x` and `y`; missing `{missing}`"),
+                ))
+            }
+        }
     }
 }
 

--- a/niri-config/src/output.rs
+++ b/niri-config/src/output.rs
@@ -6,6 +6,7 @@ use knuffel::errors::DecodeError;
 use knuffel::traits::ErrorSpan;
 use knuffel::Decode;
 use niri_ipc::{ConfiguredMode, HSyncPolarity, Transform, VSyncPolarity};
+pub use niri_ipc::Align;
 
 use crate::gestures::HotCorners;
 use crate::{Color, FloatOrInt, LayoutPart};
@@ -151,21 +152,6 @@ pub enum Direction {
     RightOf,
     Above,
     Below,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum Align {
-    /// Align to:
-    /// - top for a vertical edge
-    /// - left for a horizontal one.
-    #[default]
-    Beginning,
-    /// Align the midpoints of the shared edge.
-    Center,
-    /// Align to:
-    ///  - bottom for a vertical edge
-    ///  - right for a horizontal one.
-    End,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1158,7 +1158,7 @@ pub enum ScaleToSet {
 }
 
 /// Output position to set.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "clap", derive(clap::Subcommand))]
 #[cfg_attr(feature = "clap", command(subcommand_value_name = "POSITION"))]
 #[cfg_attr(feature = "clap", command(subcommand_help_heading = "Position Values"))]
@@ -1170,6 +1170,18 @@ pub enum PositionToSet {
     /// Set a specific position.
     #[cfg_attr(feature = "clap", command(name = "set"))]
     Specific(ConfiguredPosition),
+    /// Position the output to the left of another output.
+    #[cfg_attr(feature = "clap", command(name = "left-of"))]
+    LeftOf(RelativeTo),
+    /// Position the output to the right of another output.
+    #[cfg_attr(feature = "clap", command(name = "right-of"))]
+    RightOf(RelativeTo),
+    /// Position the output above another output.
+    #[cfg_attr(feature = "clap", command(name = "above"))]
+    Above(RelativeTo),
+    /// Position the output below another output.
+    #[cfg_attr(feature = "clap", command(name = "below"))]
+    Below(RelativeTo),
 }
 
 /// Output position as set in the config file.
@@ -1181,6 +1193,32 @@ pub struct ConfiguredPosition {
     pub x: i32,
     /// Logical Y position.
     pub y: i32,
+}
+
+/// Anchor output for a position relative to another output.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct RelativeTo {
+    /// Anchor output: connector name or "make model serial".
+    pub output: String,
+    /// Alignment along the edge shared with the anchor.
+    #[cfg_attr(feature = "clap", arg(long, default_value = "beginning"))]
+    pub align: Align,
+}
+
+/// Alignment of a relatively-positioned output along the edge shared with its anchor.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub enum Align {
+    /// Align the start of the shared edge: top for a vertical edge, left for a horizontal one.
+    #[default]
+    Beginning,
+    /// Align the midpoints of the shared edge.
+    Center,
+    /// Align the end of the shared edge: bottom for a vertical edge, right for a horizontal one.
+    End,
 }
 
 /// Output VRR to set.

--- a/src/dbus/mutter_display_config.rs
+++ b/src/dbus/mutter_display_config.rs
@@ -213,7 +213,7 @@ impl DisplayConfig {
                                 )))
                             }
                         },
-                        position: Some(niri_config::Position {
+                        position: Some(niri_config::Position::Fixed {
                             x: requested_config.x,
                             y: requested_config.y,
                         }),

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -16,8 +16,8 @@ use calloop::futures::Scheduler;
 use niri_config::debug::PreviewRender;
 use niri_config::output::MaxBpc;
 use niri_config::{
-    Config, FloatOrInt, Key, Modifiers, OutputName, TrackLayout, WarpMouseToFocusMode,
-    WorkspaceReference, Xkb,
+    Align, Config, Direction, FloatOrInt, Key, Modifiers, OutputName, Position, TrackLayout,
+    WarpMouseToFocusMode, WorkspaceReference, Xkb,
 };
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::input::Keycode;
@@ -1920,10 +1920,12 @@ impl State {
             niri_ipc::OutputAction::Position { position } => {
                 config.position = match position {
                     niri_ipc::PositionToSet::Automatic => None,
-                    niri_ipc::PositionToSet::Specific(position) => Some(niri_config::Position::Fixed {
-                        x: position.x,
-                        y: position.y,
-                    }),
+                    niri_ipc::PositionToSet::Specific(position) => {
+                        Some(niri_config::Position::Fixed {
+                            x: position.x,
+                            y: position.y,
+                        })
+                    }
                 }
             }
             niri_ipc::OutputAction::Vrr { vrr } => {
@@ -2745,63 +2747,23 @@ impl Niri {
             .map(|Data { output, .. }| output.clone())
             .collect();
 
-        for data in outputs.into_iter() {
+        let to_place: Vec<OutputToPlace> = outputs
+            .iter()
+            .map(|d| OutputToPlace {
+                name: d.name.clone(),
+                size: output_size(&d.output).to_i32_round(),
+                config: d.config.clone(),
+            })
+            .collect();
+        let new_positions = resolve_output_positions(&to_place);
+
+        for (data, new_position) in outputs.into_iter().zip(new_positions) {
             let Data {
                 output,
                 name,
                 position,
-                config,
+                ..
             } = data;
-
-            let size = output_size(&output).to_i32_round();
-
-            let new_position = config
-                .and_then(|pos| match pos {
-                    niri_config::Position::Fixed { x, y } => Some(Point::from((x, y))),
-                    niri_config::Position::Relative { .. } => None,
-                })
-                .filter(|pos| {
-                    // Ensure that the requested position does not overlap any existing output.
-                    let target_geom = Rectangle::new(*pos, size);
-
-                    let overlap = self
-                        .global_space
-                        .outputs()
-                        .map(|output| self.global_space.output_geometry(output).unwrap())
-                        .find(|geom| geom.overlaps(target_geom));
-
-                    if let Some(overlap) = overlap {
-                        warn!(
-                            "output {} at x={} y={} sized {}x{} \
-                             overlaps an existing output at x={} y={} sized {}x{}, \
-                             falling back to automatic placement",
-                            name.connector,
-                            pos.x,
-                            pos.y,
-                            size.w,
-                            size.h,
-                            overlap.loc.x,
-                            overlap.loc.y,
-                            overlap.size.w,
-                            overlap.size.h,
-                        );
-
-                        false
-                    } else {
-                        true
-                    }
-                })
-                .unwrap_or_else(|| {
-                    let x = self
-                        .global_space
-                        .outputs()
-                        .map(|output| self.global_space.output_geometry(output).unwrap())
-                        .map(|geom| geom.loc.x + geom.size.w)
-                        .max()
-                        .unwrap_or(0);
-
-                    Point::from((x, 0))
-                });
 
             self.global_space.map_output(&output, new_position);
 
@@ -6542,5 +6504,324 @@ niri_render_elements! {
         Texture = PrimaryGpuTextureRenderElement,
         // Used for the CPU-rendered panels.
         RelocatedMemoryBuffer = RelocateRenderElement<MemoryRenderBufferRenderElement<R>>,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct OutputToPlace {
+    name: OutputName,
+    size: Size<i32, Logical>,
+    config: Option<Position>,
+}
+
+/// Resolves the "absolute" position of every output, returned in the same order.
+///
+/// The caller is expected to pass `outputs` in a stable order (niri sorts by output name);
+/// the resolver needs to process outputs in the same order each time, so the result
+/// is deterministic.
+///
+/// Placement derived in phases, keeping the original behavior for the absolute and automatic
+/// cases and adding relative on top:
+///
+/// 1. Outputs with an absolute [`Position::Fixed`] are placed first. Same as before.
+/// 2. Outputs without explicit configuration are placed automatically. Same as before.
+/// 3. Outputs with a [`Position::Relative`] config are placed in dependency order using repeated
+///    passes: in each pass, any not-yet-placed relative output whose anchor is already placed is
+///    resolved. Repeats until nothing is placed, Thus resolving chains (`A <- B <- C`).
+/// 4. Any relative output that could not be resolved (unknown/missing anchor name, self-reference,
+///    or a cycle) falls back to automatic placement. On every hotplug, such outputs are resolved
+///    if their anchor is present.
+fn resolve_output_positions(outputs: &[OutputToPlace]) -> Vec<Point<i32, Logical>> {
+    let mut result: Vec<Option<Point<i32, Logical>>> = vec![None; outputs.len()];
+    let mut placed: Vec<Rectangle<i32, Logical>> = Vec::new();
+
+    let place = |result: &mut Vec<Option<Point<i32, Logical>>>,
+                 placed: &mut Vec<Rectangle<i32, Logical>>,
+                 index: usize,
+                 size: Size<i32, Logical>,
+                 pos: Point<i32, Logical>| {
+        result[index] = Some(pos);
+        placed.push(Rectangle::new(pos, size));
+    };
+
+    // Phase 1: absolute positions, preserving the far-right fallback on overlap.
+    for (i, output) in outputs.iter().enumerate() {
+        if let Some(Position::Fixed { x, y }) = output.config {
+            let requested = Point::from((x, y));
+            let overlap = placed
+                .iter()
+                .find(|p| p.overlaps(Rectangle::new(requested, output.size)));
+            let pos = if let Some(overlap) = overlap {
+                warn!(
+                    "output {} at x={} y={} sized {}x{} \
+                     overlaps an existing output at x={} y={} sized {}x{}, \
+                     falling back to automatic placement",
+                    output.name.connector,
+                    requested.x,
+                    requested.y,
+                    output.size.w,
+                    output.size.h,
+                    overlap.loc.x,
+                    overlap.loc.y,
+                    overlap.size.w,
+                    overlap.size.h,
+                );
+                auto_position(&placed)
+            } else {
+                requested
+            };
+            place(&mut result, &mut placed, i, output.size, pos);
+        }
+    }
+
+    // Phase 2: unconfigured outputs.
+    for (i, output) in outputs.iter().enumerate() {
+        if output.config.is_none() {
+            let pos = auto_position(&placed);
+            place(&mut result, &mut placed, i, output.size, pos);
+        }
+    }
+
+    // Phase 3: relative outputs.
+    // Probably not the most efficient way to do this, but it's simple and works.
+    // And famous last words: "I doubt someone will ever have 100s of outputs!"
+    loop {
+        let mut resolved_something = false;
+        for (i, output) in outputs.iter().enumerate() {
+            if result[i].is_some() {
+                continue;
+            }
+            let Some(Position::Relative {
+                relative_to,
+                direction,
+                align,
+            }) = &output.config
+            else {
+                continue;
+            };
+
+            let anchor = outputs
+                .iter()
+                .enumerate()
+                .find(|(j, cand)| result[*j].is_some() && cand.name.matches(relative_to));
+            let Some((j, _)) = anchor else {
+                continue;
+            };
+
+            let anchor_rect = Rectangle::new(result[j].unwrap(), outputs[j].size);
+            let requested = resolve_relative(anchor_rect, output.size, *direction, *align);
+            let pos = nudge_out(requested, output.size, *direction, &placed);
+            place(&mut result, &mut placed, i, output.size, pos);
+            resolved_something = true;
+        }
+        if !resolved_something {
+            break;
+        }
+    }
+
+    // Phase 4: unresolved relative outputs fall back to automatic placement.
+    for (i, output) in outputs.iter().enumerate() {
+        if result[i].is_none() {
+            if let Some(Position::Relative { relative_to, .. }) = &output.config {
+                warn!(
+                    "output {} could not be placed relative to `{}` \
+                     (missing, unknown, or cyclic reference), falling back to automatic placement",
+                    output.name.connector, relative_to,
+                );
+            }
+            let pos = auto_position(&placed);
+            place(&mut result, &mut placed, i, output.size, pos);
+        }
+    }
+
+    result.into_iter().map(Option::unwrap).collect()
+}
+
+fn auto_position(placed: &[Rectangle<i32, Logical>]) -> Point<i32, Logical> {
+    let x = placed
+        .iter()
+        .map(|geom| geom.loc.x + geom.size.w)
+        .max()
+        .unwrap_or(0);
+    Point::from((x, 0))
+}
+
+fn resolve_relative(
+    anchor: Rectangle<i32, Logical>,
+    size: Size<i32, Logical>,
+    direction: Direction,
+    align: Align,
+) -> Point<i32, Logical> {
+    let (ox, oy) = (anchor.loc.x, anchor.loc.y);
+    let (ow, oh) = (anchor.size.w, anchor.size.h);
+    let (mw, mh) = (size.w, size.h);
+
+    match direction {
+        // Horizontal neighbors: fixed x, aligned along y.
+        Direction::LeftOf => Point::from((ox - mw, align_along(oy, oh, mh, align))),
+        Direction::RightOf => Point::from((ox + ow, align_along(oy, oh, mh, align))),
+        // Vertical neighbors: fixed y, aligned along x.
+        Direction::Above => Point::from((align_along(ox, ow, mw, align), oy - mh)),
+        Direction::Below => Point::from((align_along(ox, ow, mw, align), oy + oh)),
+    }
+}
+
+fn align_along(anchor_start: i32, anchor_len: i32, our_len: i32, align: Align) -> i32 {
+    match align {
+        Align::Beginning => anchor_start,
+        Align::Center => anchor_start + (anchor_len - our_len) / 2,
+        Align::End => anchor_start + anchor_len - our_len,
+    }
+}
+
+/// Shifts `pos` outward along the direction axis by the minimal amount needed to clear every
+/// already-placed output, without moving any of them. Only true overlaps trigger a shift.
+/// Touching edges are allowed
+fn nudge_out(
+    mut pos: Point<i32, Logical>,
+    size: Size<i32, Logical>,
+    direction: Direction,
+    placed: &[Rectangle<i32, Logical>],
+) -> Point<i32, Logical> {
+    while let Some(obstacle) = placed
+        .iter()
+        .find(|p| p.overlaps(Rectangle::new(pos, size)))
+    {
+        match direction {
+            Direction::LeftOf => pos.x = obstacle.loc.x - size.w,
+            Direction::RightOf => pos.x = obstacle.loc.x + obstacle.size.w,
+            Direction::Above => pos.y = obstacle.loc.y - size.h,
+            Direction::Below => pos.y = obstacle.loc.y + obstacle.size.h,
+        }
+    }
+    pos
+}
+
+#[cfg(test)]
+mod output_positioning_tests {
+    use super::*;
+
+    fn name(connector: &str) -> OutputName {
+        OutputName {
+            connector: connector.to_owned(),
+            make: None,
+            model: None,
+            serial: None,
+        }
+    }
+
+    fn out(connector: &str, size: (i32, i32), config: Option<Position>) -> OutputToPlace {
+        OutputToPlace {
+            name: name(connector),
+            size: Size::from(size),
+            config,
+        }
+    }
+
+    fn relative(to: &str, direction: Direction, align: Align) -> Option<Position> {
+        Some(Position::Relative {
+            relative_to: to.to_owned(),
+            direction,
+            align,
+        })
+    }
+
+    fn resolve(outputs: &[OutputToPlace]) -> Vec<(i32, i32)> {
+        resolve_output_positions(outputs)
+            .into_iter()
+            .map(|p| (p.x, p.y))
+            .collect()
+    }
+
+    #[test]
+    fn absolute_and_auto() {
+        let outputs = [
+            out("A", (1000, 1000), Some(Position::Fixed { x: 0, y: 0 })),
+            out("B", (1000, 1000), None),
+            out("C", (500, 500), Some(Position::Fixed { x: 3000, y: 100 })),
+        ];
+        assert_eq!(resolve(&outputs), vec![(0, 0), (3500, 0), (3000, 100)]);
+    }
+
+    #[test]
+    fn absolute_overlap_falls_back_to_auto() {
+        let outputs = [
+            out("A", (1000, 1000), Some(Position::Fixed { x: 0, y: 0 })),
+            out("B", (1000, 1000), Some(Position::Fixed { x: 500, y: 0 })),
+        ];
+        assert_eq!(resolve(&outputs), vec![(0, 0), (1000, 0)]);
+    }
+
+    #[test]
+    fn all_directions_and_alignments() {
+        let anchor = || out("A", (1000, 1000), Some(Position::Fixed { x: 0, y: 0 }));
+        let check = |direction, align, expected| {
+            let outputs = [anchor(), out("B", (200, 400), relative("A", direction, align))];
+            assert_eq!(resolve(&outputs)[1], expected, "{direction:?} {align:?}");
+        };
+
+        use Align::*;
+        use Direction::*;
+        // left-of: x = -200; y aligned within [0, 1000] for height 400.
+        check(LeftOf, Beginning, (-200, 0));
+        check(LeftOf, Center, (-200, 300));
+        check(LeftOf, End, (-200, 600));
+        // right-of: x = 1000.
+        check(RightOf, Beginning, (1000, 0));
+        check(RightOf, Center, (1000, 300));
+        check(RightOf, End, (1000, 600));
+        // above: y = -400; x aligned within [0, 1000] for width 200.
+        check(Above, Beginning, (0, -400));
+        check(Above, Center, (400, -400));
+        check(Above, End, (800, -400));
+        // below: y = 1000.
+        check(Below, Beginning, (0, 1000));
+        check(Below, Center, (400, 1000));
+        check(Below, End, (800, 1000));
+    }
+
+    #[test]
+    fn relative_chain_resolves_across_passes() {
+        let outputs = [
+            out("C", (200, 200), relative("B", Direction::Above, Align::Beginning)),
+            out("B", (200, 1000), relative("A", Direction::LeftOf, Align::Beginning)),
+            out("A", (1000, 1000), None),
+        ];
+        // A -> (0,0); B left of A -> (-200, 0); C above B -> (-200, -200).
+        assert_eq!(resolve(&outputs), vec![(-200, -200), (-200, 0), (0, 0)]);
+    }
+
+    #[test]
+    fn cycle_falls_back_to_auto() {
+        // B and C reference each other; neither can be resolved -> both auto-placed.
+        let outputs = [
+            out("B", (100, 100), relative("C", Direction::LeftOf, Align::Beginning)),
+            out("C", (100, 100), relative("B", Direction::RightOf, Align::Beginning)),
+        ];
+        // No panic / no hang; both fall back to automatic side-by-side placement.
+        assert_eq!(resolve(&outputs), vec![(0, 0), (100, 0)]);
+    }
+
+    #[test]
+    fn missing_anchor_falls_back_to_auto() {
+        let outputs = [
+            out("A", (1000, 1000), None),
+            out("B", (500, 500), relative("DOES-NOT-EXIST", Direction::Above, Align::Beginning)),
+        ];
+        // A auto at origin; B's anchor is unknown -> auto to the right of A.
+        assert_eq!(resolve(&outputs), vec![(0, 0), (1000, 0)]);
+    }
+
+    #[test]
+    fn relative_overlap_nudges_outward() {
+        // A and D sit side by side, both fixed. E wants to be left-of D, but the requested spot
+        // overlaps A, so it is nudged further left until it clears A (touching A's left edge).
+        let outputs = [
+            out("A", (1000, 1000), Some(Position::Fixed { x: 0, y: 0 })),
+            out("D", (1000, 1000), Some(Position::Fixed { x: 1000, y: 0 })),
+            out("E", (500, 1000), relative("D", Direction::LeftOf, Align::Beginning)),
+        ];
+        // Requested E.x = 1000 - 500 = 500 overlaps A [0,1000); nudged to x = -500 (right edge at 0).
+        assert_eq!(resolve(&outputs)[2], (-500, 0));
     }
 }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1918,6 +1918,13 @@ impl State {
             }
             niri_ipc::OutputAction::Transform { transform } => config.transform = transform,
             niri_ipc::OutputAction::Position { position } => {
+                let relative = |direction, to: niri_ipc::RelativeTo| {
+                    Some(niri_config::Position::Relative {
+                        relative_to: to.output,
+                        direction,
+                        align: to.align,
+                    })
+                };
                 config.position = match position {
                     niri_ipc::PositionToSet::Automatic => None,
                     niri_ipc::PositionToSet::Specific(position) => {
@@ -1926,6 +1933,10 @@ impl State {
                             y: position.y,
                         })
                     }
+                    niri_ipc::PositionToSet::LeftOf(to) => relative(Direction::LeftOf, to),
+                    niri_ipc::PositionToSet::RightOf(to) => relative(Direction::RightOf, to),
+                    niri_ipc::PositionToSet::Above(to) => relative(Direction::Above, to),
+                    niri_ipc::PositionToSet::Below(to) => relative(Direction::Below, to),
                 }
             }
             niri_ipc::OutputAction::Vrr { vrr } => {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -6529,8 +6529,8 @@ struct OutputToPlace {
 ///    passes: in each pass, any not-yet-placed relative output whose anchor is already placed is
 ///    resolved. Repeats until nothing is placed, Thus resolving chains (`A <- B <- C`).
 /// 4. Any relative output that could not be resolved (unknown/missing anchor name, self-reference,
-///    or a cycle) falls back to automatic placement. On every hotplug, such outputs are resolved
-///    if their anchor is present.
+///    or a cycle) falls back to automatic placement. On every hotplug, such outputs are resolved if
+///    their anchor is present.
 fn resolve_output_positions(outputs: &[OutputToPlace]) -> Vec<Point<i32, Logical>> {
     let mut result: Vec<Option<Point<i32, Logical>>> = vec![None; outputs.len()];
     let mut placed: Vec<Rectangle<i32, Logical>> = Vec::new();
@@ -6756,7 +6756,10 @@ mod output_positioning_tests {
     fn all_directions_and_alignments() {
         let anchor = || out("A", (1000, 1000), Some(Position::Fixed { x: 0, y: 0 }));
         let check = |direction, align, expected| {
-            let outputs = [anchor(), out("B", (200, 400), relative("A", direction, align))];
+            let outputs = [
+                anchor(),
+                out("B", (200, 400), relative("A", direction, align)),
+            ];
             assert_eq!(resolve(&outputs)[1], expected, "{direction:?} {align:?}");
         };
 
@@ -6783,8 +6786,16 @@ mod output_positioning_tests {
     #[test]
     fn relative_chain_resolves_across_passes() {
         let outputs = [
-            out("C", (200, 200), relative("B", Direction::Above, Align::Beginning)),
-            out("B", (200, 1000), relative("A", Direction::LeftOf, Align::Beginning)),
+            out(
+                "C",
+                (200, 200),
+                relative("B", Direction::Above, Align::Beginning),
+            ),
+            out(
+                "B",
+                (200, 1000),
+                relative("A", Direction::LeftOf, Align::Beginning),
+            ),
             out("A", (1000, 1000), None),
         ];
         // A -> (0,0); B left of A -> (-200, 0); C above B -> (-200, -200).
@@ -6795,8 +6806,16 @@ mod output_positioning_tests {
     fn cycle_falls_back_to_auto() {
         // B and C reference each other; neither can be resolved -> both auto-placed.
         let outputs = [
-            out("B", (100, 100), relative("C", Direction::LeftOf, Align::Beginning)),
-            out("C", (100, 100), relative("B", Direction::RightOf, Align::Beginning)),
+            out(
+                "B",
+                (100, 100),
+                relative("C", Direction::LeftOf, Align::Beginning),
+            ),
+            out(
+                "C",
+                (100, 100),
+                relative("B", Direction::RightOf, Align::Beginning),
+            ),
         ];
         // No panic / no hang; both fall back to automatic side-by-side placement.
         assert_eq!(resolve(&outputs), vec![(0, 0), (100, 0)]);
@@ -6806,7 +6825,11 @@ mod output_positioning_tests {
     fn missing_anchor_falls_back_to_auto() {
         let outputs = [
             out("A", (1000, 1000), None),
-            out("B", (500, 500), relative("DOES-NOT-EXIST", Direction::Above, Align::Beginning)),
+            out(
+                "B",
+                (500, 500),
+                relative("DOES-NOT-EXIST", Direction::Above, Align::Beginning),
+            ),
         ];
         // A auto at origin; B's anchor is unknown -> auto to the right of A.
         assert_eq!(resolve(&outputs), vec![(0, 0), (1000, 0)]);
@@ -6819,9 +6842,14 @@ mod output_positioning_tests {
         let outputs = [
             out("A", (1000, 1000), Some(Position::Fixed { x: 0, y: 0 })),
             out("D", (1000, 1000), Some(Position::Fixed { x: 1000, y: 0 })),
-            out("E", (500, 1000), relative("D", Direction::LeftOf, Align::Beginning)),
+            out(
+                "E",
+                (500, 1000),
+                relative("D", Direction::LeftOf, Align::Beginning),
+            ),
         ];
-        // Requested E.x = 1000 - 500 = 500 overlaps A [0,1000); nudged to x = -500 (right edge at 0).
+        // Requested E.x = 1000 - 500 = 500 overlaps A [0,1000); nudged to x = -500 (right edge at
+        // 0).
         assert_eq!(resolve(&outputs)[2], (-500, 0));
     }
 }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1920,7 +1920,7 @@ impl State {
             niri_ipc::OutputAction::Position { position } => {
                 config.position = match position {
                     niri_ipc::PositionToSet::Automatic => None,
-                    niri_ipc::PositionToSet::Specific(position) => Some(niri_config::Position {
+                    niri_ipc::PositionToSet::Specific(position) => Some(niri_config::Position::Fixed {
                         x: position.x,
                         y: position.y,
                     }),
@@ -2709,7 +2709,7 @@ impl Niri {
         for output in self.global_space.outputs().chain(new_output) {
             let name = output.user_data().get::<OutputName>().unwrap();
             let position = self.global_space.output_geometry(output).map(|geo| geo.loc);
-            let config = config.outputs.find(name).and_then(|c| c.position);
+            let config = config.outputs.find(name).and_then(|c| c.position.clone());
 
             outputs.push(Data {
                 output: output.clone(),
@@ -2756,7 +2756,10 @@ impl Niri {
             let size = output_size(&output).to_i32_round();
 
             let new_position = config
-                .map(|pos| Point::from((pos.x, pos.y)))
+                .and_then(|pos| match pos {
+                    niri_config::Position::Fixed { x, y } => Some(Point::from((x, y))),
+                    niri_config::Position::Relative { .. } => None,
+                })
                 .filter(|pos| {
                     // Ensure that the requested position does not overlap any existing output.
                     let target_geom = Rectangle::new(*pos, size);

--- a/src/protocols/output_management.rs
+++ b/src/protocols/output_management.rs
@@ -687,7 +687,7 @@ where
                 new_config.modeline = None;
             }
             zwlr_output_configuration_head_v1::Request::SetPosition { x, y } => {
-                new_config.position = Some(niri_config::Position { x, y });
+                new_config.position = Some(niri_config::Position::Fixed { x, y });
             }
             zwlr_output_configuration_head_v1::Request::SetTransform { transform } => {
                 let transform = match transform {

--- a/src/tests/remove_output.rs
+++ b/src/tests/remove_output.rs
@@ -32,3 +32,45 @@ fn set_fullscreen_on_removed_output_does_not_panic() {
     window.set_fullscreen(Some(&wl_output));
     f.double_roundtrip(id);
 }
+
+#[test]
+fn relative_output_position_is_applied_at_runtime() {
+    use niri_config::{
+        Align, Config, Direction, Output as OutputConfig, OutputName, Outputs, Position,
+    };
+
+    let mut config = Config::default();
+    config.outputs = Outputs(vec![OutputConfig {
+        name: "headless-2".to_owned(),
+        position: Some(Position::Relative {
+            relative_to: "headless-1".to_owned(),
+            direction: Direction::LeftOf,
+            align: Align::Beginning,
+        }),
+        ..Default::default()
+    }]);
+
+    let mut f = Fixture::with_config(config);
+    f.add_output(1, (1920, 1080));
+    f.add_output(2, (1280, 720));
+
+    let niri = f.niri();
+    let mut g1 = None;
+    let mut g2 = None;
+    for output in niri.global_space.outputs() {
+        let connector = output.user_data().get::<OutputName>().unwrap().connector.clone();
+        let geo = niri.global_space.output_geometry(output).unwrap();
+        match connector.as_str() {
+            "headless-1" => g1 = Some(geo),
+            "headless-2" => g2 = Some(geo),
+            _ => {}
+        }
+    }
+    let g1 = g1.expect("headless-1 not placed");
+    let g2 = g2.expect("headless-2 not placed");
+
+    // headless-2 is left-of headless-1: its right edge touches headless-1's left edge, top-aligned.
+    // If relative positioning were ignored, headless-2 would auto-place to the RIGHT instead.
+    assert_eq!(g2.loc.x + g2.size.w, g1.loc.x, "right edge should touch anchor's left edge");
+    assert_eq!(g2.loc.y, g1.loc.y, "should be top-aligned");
+}


### PR DESCRIPTION
Implements #3793

I know this suggestion didn't get a lot of traction, but I implemented it for my own use and decided to put it here for posterity. Anyway.

### This PR adds support for relative output positioning. 

#### Configuration

```kdl
output "eDP-1" {}

output "HDMI-A-1" {
    position left-of="eDP-1"
}

output "HDMI-A-2" {
    position above="HDMI-A-1" align="center"
}
```

Supported relations are `above=`, `below=`, `left-of=` and `right-of=`. These are self explanatory I hope

Supported alignments are `beginning` which is the default, `center` and `end`. The code has more about these. And in general this might need some work because the results may not be what the user expects. I would really want to discuss this if someone is interested.

The change keeps the current behaviour and just add the relative resolution on top of it. Outputs that have a missing anchor fall back to the missing position resolving. And are resolved to the right position when the anchor output is plugged in. 

I hope the commits are at the proper granularity.... I had to recreate them to follow the guidelines.