### PR TITLE
feat: don't expel tile from column on maximize/fullscreen

### DIFF
--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -9,6 +9,7 @@ use niri_ipc::{ColumnDisplay, SizeChange, WindowLayout};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Serial, Size};
+use wayland_backend::smallvec::SmallVec;
 
 use super::closing_window::{ClosingWindow, ClosingWindowRenderElement};
 use super::monitor::InsertPosition;
@@ -5062,8 +5063,30 @@ impl<W: LayoutElement> Column<W> {
             return;
         }
 
-        self.is_pending_fullscreen = is_fullscreen;
-        self.update_tile_sizes(true);
+        let from_sizing_mode = self.sizing_mode();
+        let to_sizing_mode = match from_sizing_mode {
+            SizingMode::Normal => SizingMode::Fullscreen,
+            SizingMode::Maximized => SizingMode::Fullscreen,
+            SizingMode::Fullscreen => {
+                if self.is_pending_maximized() {
+                    SizingMode::Maximized
+                } else {
+                    SizingMode::Normal
+                }
+            }
+        };
+
+        if from_sizing_mode == SizingMode::Normal {
+            self.is_pending_fullscreen = is_fullscreen;
+            self.update_tile_sizes(true);
+
+            self.animate_fullscreen_or_maximize(from_sizing_mode, to_sizing_mode);
+        } else {
+            self.animate_fullscreen_or_maximize(from_sizing_mode, to_sizing_mode);
+
+            self.is_pending_fullscreen = is_fullscreen;
+            self.update_tile_sizes(true);
+        }
     }
 
     fn set_maximized(&mut self, maximize: bool) {
@@ -5071,8 +5094,62 @@ impl<W: LayoutElement> Column<W> {
             return;
         }
 
-        self.is_pending_maximized = maximize;
-        self.update_tile_sizes(true);
+        let from_sizing_mode = self.sizing_mode();
+        let to_sizing_mode = match from_sizing_mode {
+            SizingMode::Normal => SizingMode::Maximized,
+            SizingMode::Maximized => SizingMode::Normal,
+            SizingMode::Fullscreen => SizingMode::Fullscreen,
+        };
+
+        if from_sizing_mode == SizingMode::Normal {
+            self.is_pending_maximized = maximize;
+            self.update_tile_sizes(true);
+
+            self.animate_fullscreen_or_maximize(from_sizing_mode, to_sizing_mode);
+        } else {
+            self.animate_fullscreen_or_maximize(from_sizing_mode, to_sizing_mode);
+
+            self.is_pending_maximized = maximize;
+            self.update_tile_sizes(true);
+        }
+    }
+
+    fn animate_fullscreen_or_maximize(
+        &mut self,
+        from_sizing_mode: SizingMode,
+        to_sizing_mode: SizingMode,
+    ) {
+        let from_offset = self
+            .tile_offsets_ext(self.display_mode, from_sizing_mode)
+            .nth(self.active_tile_idx)
+            .unwrap();
+        let to_offset = self
+            .tile_offsets_ext(self.display_mode, to_sizing_mode)
+            .nth(self.active_tile_idx)
+            .unwrap();
+        let to_top_offset = self
+            .tile_offsets_ext(self.display_mode, to_sizing_mode)
+            .nth(0)
+            .unwrap();
+        warn!(
+            "diff = {:?} - {:?} \t= {:?}",
+            from_offset,
+            to_offset,
+            from_offset - to_offset
+        );
+        for tile in self.tiles.iter_mut() {
+            if from_sizing_mode == SizingMode::Normal {
+                tile.animate_move_from_with_config(
+                    from_offset + from_offset - to_offset - to_top_offset,
+                    self.options.animations.window_movement.0,
+                );
+            } else {
+                tile.animate_move_from_with_config(
+                    from_offset - to_offset,
+                    self.options.animations.window_movement.0,
+                );
+            }
+        }
     }
 
     fn set_column_display(&mut self, display: ColumnDisplay) {
@@ -5156,10 +5233,10 @@ impl<W: LayoutElement> Column<W> {
         origin
     }
 
-    // HACK: pass a self.data iterator in manually as a workaround for the lack of method partial
-    // borrowing. Note that this method's return value does not borrow the entire &Self!
-    fn tile_offsets_iter(
+    fn tile_offsets_iter_ext(
         &self,
+        display_mode: ColumnDisplay,
+        pending_sizing_mode: SizingMode,
         data: impl Iterator<Item = TileData>,
     ) -> impl Iterator<Item = Point<f64, Logical>> {
         // FIXME: this should take into account always-center-single-column, which means that
@@ -5167,8 +5244,8 @@ impl<W: LayoutElement> Column<W> {
         // the workspace or some other reason.
         let center = self.options.layout.center_focused_column == CenterFocusedColumn::Always;
         let gaps = self.options.layout.gaps;
-        let is_stacked = self.display_mode == ColumnDisplay::Normal
-            && self.pending_sizing_mode() == SizingMode::Normal;
+        let is_stacked =
+            display_mode == ColumnDisplay::Normal && pending_sizing_mode == SizingMode::Normal;
 
         // Does not include extra size from the tab indicator.
         let tiles_width = self
@@ -5189,25 +5266,56 @@ impl<W: LayoutElement> Column<W> {
         };
         let data = data.chain(iter::once(dummy));
 
-        data.map(move |data| {
-            let mut pos = origin;
+        // FIXME: allocates if the column contains more than 16 (arbitrarily chosen number) tiles
+        let positions: SmallVec<[Point<f64, Logical>; 16]> = data
+            .map(move |data| {
+                let mut pos = origin;
 
-            if center {
-                pos.x += (tiles_width - data.size.w) / 2.;
-            } else if data.interactively_resizing_by_left_edge {
-                pos.x += tiles_width - data.size.w;
-            }
+                if center {
+                    pos.x += (tiles_width - data.size.w) / 2.;
+                } else if data.interactively_resizing_by_left_edge {
+                    pos.x += tiles_width - data.size.w;
+                }
 
+                if display_mode == ColumnDisplay::Normal {
+                    origin.y += data.size.h + gaps;
+                }
+
+                pos
+            })
+            .collect();
+
+        let active_position = positions[self.active_tile_idx];
+
+        let origin = self.tiles_origin();
+        positions.into_iter().map(move |pos| {
             if is_stacked {
-                origin.y += data.size.h + gaps;
+                pos
+            } else {
+                origin + pos - active_position
             }
-
-            pos
         })
+    }
+
+    // HACK: pass a self.data iterator in manually as a workaround for the lack of method partial
+    // borrowing. Note that this method's return value does not borrow the entire &Self!
+    fn tile_offsets_iter(
+        &self,
+        data: impl Iterator<Item = TileData>,
+    ) -> impl Iterator<Item = Point<f64, Logical>> {
+        self.tile_offsets_iter_ext(self.display_mode, self.pending_sizing_mode(), data)
     }
 
     fn tile_offsets(&self) -> impl Iterator<Item = Point<f64, Logical>> + '_ {
         self.tile_offsets_iter(self.data.iter().copied())
+    }
+
+    fn tile_offsets_ext(
+        &self,
+        display_mode: ColumnDisplay,
+        pending_sizing_mode: SizingMode,
+    ) -> impl Iterator<Item = Point<f64, Logical>> + '_ {
+        self.tile_offsets_iter_ext(display_mode, pending_sizing_mode, self.data.iter().copied())
     }
 
     fn tile_offset(&self, tile_idx: usize) -> Point<f64, Logical> {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2187,13 +2187,6 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         // With place_within_column, the tab indicator changes the column size immediately.
         self.data[self.active_column_idx].update(col);
         col.update_tile_sizes(true);
-
-        // Disable fullscreen if needed.
-        if col.display_mode != ColumnDisplay::Tabbed && col.tiles.len() > 1 {
-            let window = col.tiles[col.active_tile_idx].window().id().clone();
-            self.set_fullscreen(&window, false);
-            self.set_maximized(&window, false);
-        }
     }
 
     pub fn center_column(&mut self) {
@@ -2822,7 +2815,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     }
 
     pub fn set_fullscreen(&mut self, window: &W::Id, is_fullscreen: bool) -> bool {
-        let mut col_idx = self
+        let col_idx = self
             .columns
             .iter()
             .position(|col| col.contains(window))
@@ -2832,17 +2825,9 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return false;
         }
 
-        let mut col = &mut self.columns[col_idx];
-        let is_tabbed = col.display_mode == ColumnDisplay::Tabbed;
+        let col = &mut self.columns[col_idx];
 
         cancel_resize_for_column(&mut self.interactive_resize, col);
-
-        if is_fullscreen && (col.tiles.len() > 1 && !is_tabbed) {
-            // This wasn't the only window in its column; extract it into a separate column.
-            self.consume_or_expel_window_right(Some(window));
-            col_idx += 1;
-            col = &mut self.columns[col_idx];
-        }
 
         col.set_fullscreen(is_fullscreen);
 
@@ -2853,7 +2838,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     }
 
     pub fn set_maximized(&mut self, window: &W::Id, maximize: bool) -> bool {
-        let mut col_idx = self
+        let col_idx = self
             .columns
             .iter()
             .position(|col| col.contains(window))
@@ -2863,18 +2848,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             return false;
         }
 
-        let mut col = &mut self.columns[col_idx];
-        let is_tabbed = col.display_mode == ColumnDisplay::Tabbed;
-
+        let col = &mut self.columns[col_idx];
         cancel_resize_for_column(&mut self.interactive_resize, col);
-
-        if maximize && (col.tiles.len() > 1 && !is_tabbed) {
-            // This wasn't the only window in its column; extract it into a separate column.
-            self.consume_or_expel_window_right(Some(window));
-            col_idx += 1;
-            col = &mut self.columns[col_idx];
-        }
-
         col.set_maximized(maximize);
 
         // With place_within_column, the tab indicator changes the column size immediately.
@@ -5087,10 +5062,6 @@ impl<W: LayoutElement> Column<W> {
             return;
         }
 
-        if is_fullscreen {
-            assert!(self.tiles.len() == 1 || self.display_mode == ColumnDisplay::Tabbed);
-        }
-
         self.is_pending_fullscreen = is_fullscreen;
         self.update_tile_sizes(true);
     }
@@ -5098,10 +5069,6 @@ impl<W: LayoutElement> Column<W> {
     fn set_maximized(&mut self, maximize: bool) {
         if self.is_pending_maximized == maximize {
             return;
-        }
-
-        if maximize {
-            assert!(self.tiles.len() == 1 || self.display_mode == ColumnDisplay::Tabbed);
         }
 
         self.is_pending_maximized = maximize;
@@ -5200,7 +5167,8 @@ impl<W: LayoutElement> Column<W> {
         // the workspace or some other reason.
         let center = self.options.layout.center_focused_column == CenterFocusedColumn::Always;
         let gaps = self.options.layout.gaps;
-        let tabbed = self.display_mode == ColumnDisplay::Tabbed;
+        let is_stacked = self.display_mode == ColumnDisplay::Normal
+            && self.pending_sizing_mode() == SizingMode::Normal;
 
         // Does not include extra size from the tab indicator.
         let tiles_width = self
@@ -5230,7 +5198,7 @@ impl<W: LayoutElement> Column<W> {
                 pos.x += tiles_width - data.size.w;
             }
 
-            if !tabbed {
+            if is_stacked {
                 origin.y += data.size.h + gaps;
             }
 
@@ -5279,7 +5247,11 @@ impl<W: LayoutElement> Column<W> {
 
         let active = active.iter().map(|tile| (tile, true));
 
-        let rest_visible = self.display_mode != ColumnDisplay::Tabbed;
+        let rest_visible = self.display_mode != ColumnDisplay::Tabbed
+            || matches!(
+                self.pending_sizing_mode(),
+                SizingMode::Fullscreen | SizingMode::Maximized
+            );
         let rest = first.iter().chain(rest);
         let rest = rest.map(move |tile| (tile, rest_visible));
 

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -577,6 +577,15 @@ impl<W: LayoutElement> Tile<W> {
         self.animate_move_y_from(from.y);
     }
 
+    pub fn animate_move_from_with_config(
+        &mut self,
+        from: Point<f64, Logical>,
+        config: niri_config::Animation,
+    ) {
+        self.animate_move_x_from_with_config(from.x, config);
+        self.animate_move_y_from_with_config(from.y, config);
+    }
+
     pub fn animate_move_x_from(&mut self, from: f64) {
         self.animate_move_x_from_with_config(from, self.options.animations.window_movement.0);
     }


### PR DESCRIPTION
Superseded by https://github.com/niri-wm/niri/pull/4384

Outstanding issues
- [ ] janky fullscreening animation when fullscreening tiles of a column other than the first tile
- [ ] unit tests are not adjusted
- [ ] the new behaviour should be made optional to not break existing workflows