### PR TITLE
Add scope property to focus-window-previous

### DIFF
--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -393,6 +393,28 @@ binds {
 }
 ```
 
+#### `focus-window-previous`
+
+<sup>Since: 25.01</sup>
+
+Focus the previously focused window.
+
+```kdl
+binds {
+    Mod+Grave { focus-window-previous; }
+}
+```
+
+<sup>Since: next release</sup> You can restrict the action to the current output or workspace with the `scope` property.
+It takes the same values as the [recent windows switcher scope](./Configuration:-Recent-Windows.md): `all` (the default), `output`, `workspace`.
+
+```kdl
+binds {
+    // Focus the previously focused window on the current workspace.
+    Mod+Grave { focus-window-previous scope="workspace"; }
+}
+```
+
 #### `toggle-keyboard-shortcuts-inhibit`
 
 <sup>Since: 25.02</sup>

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -160,7 +160,7 @@ pub enum Action {
     #[knuffel(skip)]
     FocusWindow(u64),
     FocusWindowInColumn(#[knuffel(argument)] u8),
-    FocusWindowPrevious,
+    FocusWindowPrevious(#[knuffel(property(name = "scope"), default)] MruScope),
     FocusColumnLeft,
     #[knuffel(skip)]
     FocusColumnLeftUnderMouse,
@@ -444,7 +444,7 @@ impl From<niri_ipc::Action> for Action {
             }
             niri_ipc::Action::FocusWindow { id } => Self::FocusWindow(id),
             niri_ipc::Action::FocusWindowInColumn { index } => Self::FocusWindowInColumn(index),
-            niri_ipc::Action::FocusWindowPrevious {} => Self::FocusWindowPrevious,
+            niri_ipc::Action::FocusWindowPrevious {} => Self::FocusWindowPrevious(MruScope::All),
             niri_ipc::Action::FocusColumnLeft {} => Self::FocusColumnLeft,
             niri_ipc::Action::FocusColumnRight {} => Self::FocusColumnRight,
             niri_ipc::Action::FocusColumnFirst {} => Self::FocusColumnFirst,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 use calloop::timer::{TimeoutAction, Timer};
 use input::event::gesture::GestureEventCoordinates as _;
 use niri_config::{
-    Action, Bind, Binds, Config, Key, ModKey, Modifiers, MruDirection, SwitchBinds, Trigger,
+    Action, Bind, Binds, Config, Key, ModKey, Modifiers, MruDirection, MruScope, SwitchBinds,
+    Trigger,
 };
 use niri_ipc::LayoutSwitchTarget;
 use smithay::backend::input::{
@@ -883,17 +884,32 @@ impl State {
                 // FIXME: granular
                 self.niri.queue_redraw_all();
             }
-            Action::FocusWindowPrevious => {
+            Action::FocusWindowPrevious(scope) => {
                 let current = self.niri.layout.focus().map(|win| win.id());
-                if let Some(window) = self
+                let active_output = self.niri.layout.active_output();
+
+                // Restrict the candidate windows to the requested scope. `Workspace` and `Output`
+                // only make sense relative to an active output; without one, fall back to nothing.
+                let window = self
                     .niri
                     .layout
-                    .windows()
-                    .map(|(_, win)| win)
+                    .workspaces()
+                    .filter(|(mon, ws_idx, _)| match scope {
+                        MruScope::All => true,
+                        MruScope::Output => {
+                            mon.is_some_and(|mon| Some(mon.output()) == active_output)
+                        }
+                        MruScope::Workspace => mon.is_some_and(|mon| {
+                            Some(mon.output()) == active_output
+                                && mon.active_workspace_idx() == *ws_idx
+                        }),
+                    })
+                    .flat_map(|(_, _, ws)| ws.windows())
                     .filter(|win| Some(win.id()) != current)
                     .max_by_key(|win| win.get_focus_timestamp())
-                    .map(|win| win.window.clone())
-                {
+                    .map(|win| win.window.clone());
+
+                if let Some(window) = window {
                     // Commit current focus so repeated focus-window-previous works as expected.
                     self.niri.mru_apply_keyboard_commit();
 


### PR DESCRIPTION
Adds a `scope` property to the `focus-window-previous` bind:

```kdl
binds {
    Mod+Grave { focus-window-previous scope="workspace"; }
}
```

It takes the same values as the recent windows switcher scope: `all` (default, current behavior), `output`, `workspace`.

Motivation: alternating between two windows on the current workspace or monitor (e.g. editor and terminal) without the action jumping to a more recently used window on another workspace/monitor, and without opening the switcher UI.

The IPC action is unchanged and behaves like `scope="all"`; it could grow an optional scope argument in a follow-up if that's wanted.

Tested with `cargo test`, `cargo +nightly fmt --check`, and `niri validate` on a config using all three values. Wiki page updated with a `Since: next release` annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)