### PR TITLE
Normalize full-height windows after manual resizing

### DIFF
--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4957,6 +4957,7 @@ impl<W: LayoutElement> Column<W> {
                 tile.window_height_for_tile_height(tile_height)
             }
         };
+        let is_resizing_up = window_height > current_window_px;
 
         // Clamp the height according to other windows' min sizes, or simply to working area height.
         let min_height_taken = if self.display_mode == ColumnDisplay::Tabbed {
@@ -4985,7 +4986,18 @@ impl<W: LayoutElement> Column<W> {
             window_height = f64::max(window_height, f64::from(min_h));
         }
 
-        self.data[tile_idx].height = WindowHeight::Fixed(window_height.clamp(1., MAX_PX));
+        // Window sizes are ultimately rounded to integer logical pixels, so compare rounded
+        // values to avoid missing the limit due to floating-point imprecision.
+        let height = if self.tiles.len() == 1
+            && is_resizing_up
+            && window_height.round() == height_left.round()
+        {
+            WindowHeight::auto_1()
+        } else {
+            WindowHeight::Fixed(window_height.clamp(1., MAX_PX))
+        };
+
+        self.data[tile_idx].height = height;
         self.is_pending_maximized = false;
         self.update_tile_sizes(animate);
     }

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -2467,6 +2467,46 @@ fn set_window_height_recomputes_to_auto() {
 }
 
 #[test]
+fn set_window_height_to_max_recomputes_to_auto() {
+    for scale in [1., 1.5] {
+        let ops = [
+            Op::AddScaledOutput {
+                id: 1,
+                scale,
+                layout_config: None,
+            },
+            Op::AddWindow {
+                params: TestWindowParams::new(0),
+            },
+            Op::Communicate(0),
+            Op::AddWindow {
+                params: TestWindowParams::new(1),
+            },
+            Op::Communicate(1),
+            Op::FocusColumnLeft,
+            Op::SetWindowHeight {
+                id: None,
+                change: SizeChange::AdjustProportion(-10.),
+            },
+            Op::Communicate(0),
+            Op::SetWindowHeight {
+                id: None,
+                change: SizeChange::AdjustProportion(10.),
+            },
+            Op::Communicate(0),
+            Op::ConsumeWindowIntoColumn,
+        ];
+
+        let layout = check_ops(ops);
+        let mut windows = layout.windows().map(|(_, win)| win);
+        let first = windows.next().unwrap().requested_size().unwrap();
+        let second = windows.next().unwrap().requested_size().unwrap();
+
+        assert_eq!(first.h, second.h, "scale: {scale}");
+    }
+}
+
+#[test]
 fn one_window_in_column_becomes_weight_1() {
     let ops = [
         Op::AddOutput(1),


### PR DESCRIPTION
Fixes #1811.

When the only window in a column is manually resized back up to the maximum height, store it as auto-height rather than fixed-height. This makes a later `consume-window-into-column` split the available space (which is intuitive) instead of leaving the consumed window at its minimum height (confusing from a user perspective).

The conversion only happens while resizing upward in a single-window column, preserving fixed heights that are merely clamped by output changes. The comparison uses rounded logical-pixel heights to avoid fractional-scale precision issues.

## Manual validation

Both captures use identical nested niri sessions and the following steps:

1. Spawn two terminals in separate columns.
2. Focus the left terminal.
3. `set-window-height -10%`
4. `set-window-height +10%`
5. `consume-window-into-column`

### Before
The image shows the resulting state, meaning there are actually two terminals here:
<img width="1264" height="1387" alt="before" src="https://github.com/user-attachments/assets/698060f4-7571-46b3-abbc-d883e6981b13" />
The consumed window collapses to one pixel.

### After
Now the terminal is auto resized, so it is actually visible:
<img width="1264" height="1387" alt="after" src="https://github.com/user-attachments/assets/7ec26390-c24d-4b5c-a9e5-797da83dff07" />
The windows split the column evenly.

A regression test covers the same sequence at output scales 1.0 and 1.5.

Tested with:

- `cargo test --all --exclude niri-visual-tests`
- `cargo clippy --all --all-targets`
- `cargo +nightly fmt --all -- --check`
- Matched nested niri reproduction before and after the fix using real Wayland Alacritty clients