### PR TITLE
fix 32bit build: use portable-atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,7 @@ dependencies = [
  "pipewire",
  "pkg-config",
  "png",
+ "portable-atomic",
  "profiling",
  "proptest",
  "proptest-derive",
@@ -2889,6 +2890,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ pango = { version = "0.21.5", features = ["v1_44"] }
 pangocairo = "0.21.5"
 pipewire = { version = "0.10.0", optional = true, features = ["v0_3_33"] }
 png = "0.18.1"
+portable-atomic = "1"
 profiling = "1.0.17"
 sd-notify = "0.5.0"
 serde.workspace = true

--- a/src/utils/id.rs
+++ b/src/utils/id.rs
@@ -1,4 +1,6 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
+
+use portable_atomic::AtomicU64;
 
 /// Counter that returns unique IDs.
 pub struct IdCounter {


### PR DESCRIPTION
building on 32bit fails with error:
```no `AtomicU64` in `sync::atomic```

add portable-atomic to use native types when available and emulate them when not.

Bugs: #4331

Please also consider adding a 32bit CI to prevent regressions!