### PR TITLE
screencast: report window stream dimensions

### DIFF
--- a/src/dbus/mutter_screen_cast.rs
+++ b/src/dbus/mutter_screen_cast.rs
@@ -73,7 +73,10 @@ pub struct Stream {
 enum StreamTarget {
     // FIXME: update on scale changes and whatnot.
     Output(niri_ipc::Output),
-    Window { id: u64 },
+    Window {
+        id: u64,
+        parameters: StreamParameters,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -82,16 +85,18 @@ pub enum StreamTargetId {
     Window { id: u64 },
 }
 
-#[derive(Debug, SerializeDict, Type, Value)]
+#[derive(Debug, Clone, SerializeDict, Type, Value)]
 #[zvariant(signature = "dict")]
-struct StreamParameters {
-    /// Position of the stream in logical coordinates.
-    position: (i32, i32),
-    /// Size of the stream in logical coordinates.
-    size: (i32, i32),
+pub struct StreamParameters {
+    pub(crate) position: (i32, i32),
+    pub(crate) size: (i32, i32),
 }
 
 pub enum ScreenCastToNiri {
+    GetWindowParameters {
+        window_id: u64,
+        reply: async_channel::Sender<Option<StreamParameters>>,
+    },
     StartCast {
         session_id: CastSessionId,
         stream_id: CastStreamId,
@@ -246,10 +251,32 @@ impl Session {
         let path = format!("/org/gnome/Mutter/ScreenCast/Stream/u{}", stream_id.get());
         let path = OwnedObjectPath::try_from(path).unwrap();
 
+        let (tx, rx) = async_channel::bounded(1);
+        if let Err(err) = self.to_niri.send(ScreenCastToNiri::GetWindowParameters {
+            window_id: properties.window_id,
+            reply: tx,
+        }) {
+            warn!("error querying window geometry: {err:?}");
+            return Err(fdo::Error::Failed("internal error".to_owned()));
+        }
+        let parameters = match rx.recv().await {
+            Ok(Some(parameters)) => parameters,
+            Ok(None) => {
+                return Err(fdo::Error::Failed(
+                    "could not resolve window geometry".to_owned(),
+                ));
+            }
+            Err(err) => {
+                warn!("error receiving window geometry: {err:?}");
+                return Err(fdo::Error::Failed("internal error".to_owned()));
+            }
+        };
+
         let cursor_mode = properties.cursor_mode.unwrap_or_default();
 
         let target = StreamTarget::Window {
             id: properties.window_id,
+            parameters,
         };
         let stream = Stream::new(
             stream_id,
@@ -294,13 +321,7 @@ impl Stream {
                     size: (logical.width as i32, logical.height as i32),
                 }
             }
-            StreamTarget::Window { .. } => {
-                // Does any consumer need this?
-                StreamParameters {
-                    position: (0, 0),
-                    size: (1, 1),
-                }
-            }
+            StreamTarget::Window { parameters, .. } => parameters.clone(),
         }
     }
 }
@@ -400,7 +421,7 @@ impl StreamTarget {
             StreamTarget::Output(output) => StreamTargetId::Output {
                 name: output.name.clone(),
             },
-            StreamTarget::Window { id } => StreamTargetId::Window { id: *id },
+            StreamTarget::Window { id, .. } => StreamTargetId::Window { id: *id },
         }
     }
 }

--- a/src/screencasting/mod.rs
+++ b/src/screencasting/mod.rs
@@ -16,7 +16,9 @@ use smithay::reexports::gbm::Modifier;
 use smithay::utils::{Physical, Point, Scale, Size};
 use zbus::object_server::SignalEmitter;
 
-use crate::dbus::mutter_screen_cast::{self, CursorMode, ScreenCastToNiri, StreamTargetId};
+use crate::dbus::mutter_screen_cast::{
+    self, CursorMode, ScreenCastToNiri, StreamParameters, StreamTargetId,
+};
 use crate::niri::{CastTarget, Niri, OutputRenderElements, PointerRenderElements, State};
 use crate::niri_render_elements;
 use crate::render_helpers::{RenderCtx, RenderTarget};
@@ -385,6 +387,24 @@ impl State {
 
     pub fn on_screen_cast_msg(&mut self, msg: ScreenCastToNiri) {
         match msg {
+            ScreenCastToNiri::GetWindowParameters { window_id, reply } => {
+                let parameters = if window_id == self.niri.casting.dynamic_cast_id_for_portal.get()
+                {
+                    // The dynamic target has no fixed geometry until it is assigned.
+                    Some(StreamParameters {
+                        position: (0, 0),
+                        size: (1, 1),
+                    })
+                } else {
+                    self.niri
+                        .cast_params_for_window(window_id)
+                        .map(|(size, _)| StreamParameters {
+                            position: (0, 0),
+                            size: (size.w, size.h),
+                        })
+                };
+                let _ = reply.send_blocking(parameters);
+            }
             ScreenCastToNiri::StartCast {
                 session_id,
                 stream_id,


### PR DESCRIPTION
## Problem

The Mutter-compatible `Parameters` property reports a fixed `1x1` size for every window stream. Consumers that use this property to initialize window capture get the wrong geometry, including when the selected window is on an inactive workspace.

## Change

Query the compositor state asynchronously during `RecordWindow` and store the window's actual physical stream size. Window stream position remains `(0, 0)` because the stream is isolated from the global output.

The existing `1x1` value is kept for Niri's dynamic target pseudo-window, which has no fixed geometry until a target is assigned.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo check --offline`
- `cargo test --offline` (195 passed)
- Nested Niri with a private D-Bus session:
  - moved an Alacritty window to an inactive workspace without following focus
  - `RecordWindow` returned a stream with `size: (525, 1038)`
  - the dynamic target still returned `size: (1, 1)`
