### PR TITLE
feat(backend/tty): dynamically suspend idle secondary GPUs

### DIFF
--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -81,7 +81,7 @@ nav:
     - Layer‐Shell Components: Layer‐Shell-Components.md
     - IPC, niri msg: IPC.md
     - Application-Specific Issues: Application-Issues.md
-    - Nvidia: Nvidia.md
+    - GPUs: GPUs.md
     - Xwayland: Xwayland.md
     - Gestures: Gestures.md
     - Fullscreen and Maximize: Fullscreen-and-Maximize.md

--- a/docs/wiki/Configuration:-Debug-Options.md
+++ b/docs/wiki/Configuration:-Debug-Options.md
@@ -33,6 +33,7 @@ debug {
     honor-xdg-activation-with-invalid-serial
     skip-cursor-only-updates-during-vrr
     deactivate-unfocused-windows
+    disable-idle-drm-device-suspend
 }
 
 binds {
@@ -323,6 +324,21 @@ debug {
     deactivate-unfocused-windows
 }
 ```
+
+### `disable-idle-drm-device-suspend`
+
+Turns off automatic suspend of idle secondary GPUs.
+
+By default, niri suspends secondary GPUs (dGPUs, eGPUs) that aren't driving any outputs or leases. Saves power, and on some systems gets the device into ACPI `D3cold`.
+
+Use this flag if suspend breaks hotplug, wakeup, or rendering for you.
+
+```kdl
+debug {
+    disable-idle-drm-device-suspend
+}
+```
+
 
 ### Key Bindings
 

--- a/docs/wiki/Configuration:-Debug-Options.md
+++ b/docs/wiki/Configuration:-Debug-Options.md
@@ -34,6 +34,7 @@ debug {
     skip-cursor-only-updates-during-vrr
     deactivate-unfocused-windows
     disable-10bit-output
+    disable-idle-drm-device-suspend
 }
 
 binds {
@@ -342,6 +343,19 @@ debug {
 }
 ```
 
+### `disable-idle-drm-device-suspend`
+
+Turns off automatic suspend of idle secondary GPUs.
+
+By default, niri suspends secondary GPUs (dGPUs, eGPUs) that aren't driving any outputs or leases. Saves power, and on some systems gets the device into ACPI `D3cold`.
+
+Use this flag if suspend breaks hotplug, wakeup, or rendering for you.
+
+```kdl
+debug {
+    disable-idle-drm-device-suspend
+}
+```
 ### Key Bindings
 
 These are not debug options, but rather key bindings.

--- a/docs/wiki/GPUs.md
+++ b/docs/wiki/GPUs.md
@@ -1,3 +1,7 @@
+This page covers NVIDIA quirks and multi-GPU setups, including NVIDIA Optimus and eGPU docks.
+
+## NVIDIA
+
 ### High VRAM usage fix
 
 Presently, there is a quirk in the NVIDIA drivers that affects niri's VRAM usage (the driver does not properly release VRAM back into the pool). Niri *should* use on the order of 100 MiB of VRAM (as checked in [nvtop](https://github.com/Syllo/nvtop)); if you see anywhere close to 1 GiB of VRAM in use, you are likely hitting this issue (heap not returning freed buffers to the driver).
@@ -6,7 +10,7 @@ Luckily, you can mitigate this by configuring the NVIDIA drivers with a per-proc
 
 * `sudo mkdir -p /etc/nvidia/nvidia-application-profiles-rc.d` to make the config dir if it does not exist (it most likely does not if you are reading this)
 * write the following JSON blob to set the `GLVidHeapReuseRatio` config value for the `niri` process into the file `/etc/nvidia/nvidia-application-profiles-rc.d/50-limit-free-buffer-pool-in-wayland-compositors.json`:
-    
+
     ```json
     {
         "rules": [
@@ -31,14 +35,14 @@ Luckily, you can mitigate this by configuring the NVIDIA drivers with a per-proc
         ]
     }
     ```
-    
+
     (The file in `/etc/nvidia/nvidia-application-profiles-rc.d/` can be named anything, and does not actually need an extension).
 
 Restart niri after writing the config file to apply the change.
 
 The upstream issue that this solution was pulled from is [here](https://github.com/NVIDIA/egl-wayland/issues/126#issuecomment-2379945259). There is a (slim) chance that NVIDIA updates their built-in application profiles to apply this to niri automatically; it is unlikely that the underlying heuristic will see a proper fix.
 
-The fix shipped in the driver at the time of writing uses a value of 0, while the initial config posted by an Nvidia engineer approximately a year prior used a value of 1. 
+The fix shipped in the driver at the time of writing uses a value of 0, while the initial config posted by an Nvidia engineer approximately a year prior used a value of 1.
 
 ### Screencast flickering fix
 
@@ -53,3 +57,25 @@ debug {
 ```
 
 This debug flag has since been removed because the problem was properly fixed in niri.
+
+## Secondary GPUs (Optimus, eGPU)
+
+### Power management
+
+When nothing is using a secondary GPU (dGPU, eGPU) for outputs or leases, niri suspends it. Saves power, and on some systems the device drops into ACPI `D3cold`.
+
+On hotplug, niri wakes the GPU in the background (up to 10 seconds), so slow PCIe links don't stall the compositor.
+
+If suspend gives you trouble, turn it off:
+
+```kdl
+debug {
+    disable-idle-drm-device-suspend
+}
+```
+
+On NVIDIA, suspend is skipped unless video memory preservation is on — without it, suspending can kill the EGL context.
+
+### eGPU connection latency
+
+Some eGPUs are slow to come back after hotplug. Niri opens the render node from a background thread, so a slow PCIe resume doesn't block the compositor.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -67,7 +67,7 @@ Some desktop environments and shells work with niri and can give a more out-of-t
 ### NVIDIA
 
 The NVIDIA drivers currently have an issue with high VRAM usage due to a heap reuse quirk.
-You're recommended to apply a manual fix documented [here](./Nvidia.md) if you run niri on an NVIDIA GPU.
+You're recommended to apply a manual fix documented [here](./GPUs.md) if you run niri on an NVIDIA GPU.
 
 NVIDIA GPUs can have problems running niri (for example, the screen remains black upon starting from a TTY).
 Sometimes, the problems can be fixed.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -10,7 +10,7 @@
 * [Layer‐Shell Components](./Layer%E2%80%90Shell-Components.md)
 * [IPC, `niri msg`](./IPC.md)
 * [Application-Specific Issues](./Application-Issues.md)
-* [Nvidia](./Nvidia.md)
+* [GPUs](./GPUs.md)
 * [Xwayland](./Xwayland.md)
 * [Gestures](./Gestures.md)
 * [Fullscreen and Maximize](./Fullscreen-and-Maximize.md)

--- a/niri-config/src/debug.rs
+++ b/niri-config/src/debug.rs
@@ -24,6 +24,7 @@ pub struct Debug {
     pub honor_xdg_activation_with_invalid_serial: bool,
     pub deactivate_unfocused_windows: bool,
     pub skip_cursor_only_updates_during_vrr: bool,
+    pub disable_idle_drm_device_suspend: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
@@ -68,6 +69,8 @@ pub struct DebugPart {
     pub deactivate_unfocused_windows: Option<Flag>,
     #[knuffel(child)]
     pub skip_cursor_only_updates_during_vrr: Option<Flag>,
+    #[knuffel(child)]
+    pub disable_idle_drm_device_suspend: Option<Flag>,
 }
 
 impl MergeWith<DebugPart> for Debug {
@@ -91,6 +94,7 @@ impl MergeWith<DebugPart> for Debug {
             honor_xdg_activation_with_invalid_serial,
             deactivate_unfocused_windows,
             skip_cursor_only_updates_during_vrr,
+            disable_idle_drm_device_suspend,
         );
 
         merge_clone_opt!((self, part), preview_render, render_drm_device);

--- a/niri-config/src/debug.rs
+++ b/niri-config/src/debug.rs
@@ -25,6 +25,7 @@ pub struct Debug {
     pub deactivate_unfocused_windows: bool,
     pub skip_cursor_only_updates_during_vrr: bool,
     pub disable_10bit_output: bool,
+    pub disable_idle_drm_device_suspend: bool,
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
@@ -71,6 +72,8 @@ pub struct DebugPart {
     pub skip_cursor_only_updates_during_vrr: Option<Flag>,
     #[knuffel(child)]
     pub disable_10bit_output: Option<Flag>,
+    #[knuffel(child)]
+    pub disable_idle_drm_device_suspend: Option<Flag>,
 }
 
 impl MergeWith<DebugPart> for Debug {
@@ -95,6 +98,7 @@ impl MergeWith<DebugPart> for Debug {
             deactivate_unfocused_windows,
             skip_cursor_only_updates_during_vrr,
             disable_10bit_output,
+            disable_idle_drm_device_suspend,
         );
 
         merge_clone_opt!((self, part), preview_render, render_drm_device);

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2271,6 +2271,7 @@ mod tests {
                 honor_xdg_activation_with_invalid_serial: false,
                 deactivate_unfocused_windows: false,
                 skip_cursor_only_updates_during_vrr: false,
+                disable_idle_drm_device_suspend: false,
             },
             workspaces: [
                 Workspace {

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2300,6 +2300,7 @@ mod tests {
                 deactivate_unfocused_windows: false,
                 skip_cursor_only_updates_during_vrr: false,
                 disable_10bit_output: false,
+                disable_idle_drm_device_suspend: false,
             },
             workspaces: [
                 Workspace {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -201,6 +201,12 @@ impl Backend {
         }
     }
 
+    pub fn on_prepare_for_sleep(&mut self, niri: &mut Niri, start: bool) {
+        if let Backend::Tty(tty) = self {
+            tty.on_prepare_for_sleep(niri, start);
+        }
+    }
+
     pub fn tty_checked(&mut self) -> Option<&mut Tty> {
         if let Self::Tty(v) = self {
             Some(v)

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -4,9 +4,10 @@ use std::fmt::Write;
 use std::iter::zip;
 use std::num::NonZeroU64;
 use std::os::fd::{AsFd, OwnedFd};
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 use std::{io, mem};
 
@@ -81,6 +82,172 @@ const SUPPORTED_COLOR_FORMATS: [Fourcc; 6] = [
     Fourcc::Abgr8888,
 ];
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemPmState {
+    Running,
+    Quiescing,
+    Suspended,
+    ResumePending,
+}
+
+struct GpuGateState {
+    open_allowed: bool,
+    active_leases: usize,
+    generation: u64,
+}
+
+struct GpuGateShared {
+    state: Mutex<GpuGateState>,
+    cvar: Condvar,
+}
+
+#[derive(Clone)]
+pub struct GpuGate {
+    shared: Arc<GpuGateShared>,
+}
+
+pub struct GpuLease {
+    shared: Arc<GpuGateShared>,
+}
+
+impl Drop for GpuLease {
+    fn drop(&mut self) {
+        let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        state.active_leases = state.active_leases.saturating_sub(1);
+        if state.active_leases == 0 {
+            self.shared.cvar.notify_all();
+        }
+    }
+}
+
+impl Default for GpuGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GpuGate {
+    pub fn new() -> Self {
+        Self {
+            shared: Arc::new(GpuGateShared {
+                state: Mutex::new(GpuGateState {
+                    open_allowed: true,
+                    active_leases: 0,
+                    generation: 0,
+                }),
+                cvar: Condvar::new(),
+            }),
+        }
+    }
+
+    pub fn acquire_lease(&self, expected_generation: u64) -> Option<GpuLease> {
+        let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        if !state.open_allowed || state.generation != expected_generation {
+            return None;
+        }
+
+        state.active_leases = state.active_leases.saturating_add(1);
+
+        Some(GpuLease {
+            shared: self.shared.clone(),
+        })
+    }
+
+    pub fn set_open_allowed(&self, allowed: bool, generation: u64) {
+        let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        state.open_allowed = allowed;
+        state.generation = generation;
+    }
+
+    pub fn active_lease_count(&self) -> usize {
+        let state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.active_leases
+    }
+
+    pub fn wait_for_drain(&self, timeout: Duration) -> bool {
+        let state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        let (state, _) = self
+            .shared
+            .cvar
+            .wait_timeout_while(state, timeout, |state| state.active_leases != 0)
+            .unwrap_or_else(|e| e.into_inner());
+
+        state.active_leases == 0
+    }
+}
+
+fn is_pci_device_ready(node: DrmNode) -> bool {
+    let Some(path) = node.dev_path() else {
+        return true;
+    };
+    let Some(filename) = path.file_name().and_then(|s| s.to_str()) else {
+        return true;
+    };
+    let sysfs_path = format!("/sys/class/drm/{filename}/device/power/runtime_status");
+    if let Ok(content) = std::fs::read_to_string(&sysfs_path) {
+        let status = content.trim();
+        if status == "suspended" || status == "suspending" || status == "resuming" {
+            return false;
+        }
+    }
+    true
+}
+
+#[derive(Debug)]
+enum WakeupState {
+    Pending,
+    Woken {
+        // Held open so the kernel doesn't autosuspend the GPU mid-init.
+        #[allow(dead_code)]
+        file: std::fs::File,
+        generation: u64,
+    },
+    WokenNoFd {
+        generation: u64,
+    },
+    Failed,
+    Cancelled,
+}
+
+struct PendingDeviceInit {
+    attempts: usize,
+    generation: u64,
+    timer_token: Option<RegistrationToken>,
+    wakeup_state: Arc<Mutex<WakeupState>>,
+}
+
+struct GpuPowerState {
+    suspended: bool,
+    waking_up: bool,
+    wakeup_failed: bool,
+    resume_attempts: usize,
+    wakeup_generation: u64,
+    wakeup_state: Arc<Mutex<WakeupState>>,
+    suspend_timer: Option<RegistrationToken>,
+    wakeup_timer: Option<RegistrationToken>,
+    disable_suspend_due_to_nvidia_vram: bool,
+}
+
+impl GpuPowerState {
+    fn new(disable_suspend_due_to_nvidia_vram: bool) -> Self {
+        Self {
+            suspended: false,
+            waking_up: false,
+            wakeup_failed: false,
+            resume_attempts: 0,
+            wakeup_generation: 0,
+            wakeup_state: Arc::new(Mutex::new(WakeupState::Pending)),
+            suspend_timer: None,
+            wakeup_timer: None,
+            disable_suspend_due_to_nvidia_vram,
+        }
+    }
+}
+
 pub struct Tty {
     config: Rc<RefCell<Config>>,
     session: LibSeatSession,
@@ -96,6 +263,15 @@ pub struct Tty {
     ignored_nodes: HashSet<DrmNode>,
     // Devices indexed by DRM node (not necessarily the render node).
     devices: HashMap<DrmNode, OutputDevice>,
+    // PCIe wakeup can take seconds; poll from a thread instead of blocking the event loop.
+    pending_device_inits: HashMap<DrmNode, PendingDeviceInit>,
+    next_pending_init_generation: u64,
+    // Track suspend state across udev churn.
+    gpu_power: HashMap<DrmNode, GpuPowerState>,
+    system_pm: SystemPmState,
+    gpu_gate: GpuGate,
+    pm_generation: u64,
+    inhibitor_fd: Option<OwnedFd>,
     // The dma-buf global corresponds to the output device (the primary GPU). It is only `Some()`
     // if we have a device corresponding to the primary GPU.
     dmabuf_global: Option<DmabufGlobal>,
@@ -413,7 +589,635 @@ struct ConnectorProperties<'a> {
     requests: AtomicModeReq,
 }
 
+// Check if a secondary GPU is completely idle and has no active display attachments.
+//
+// NOTE on render offload (PRIME):
+// Applications doing direct render offload (e.g., via DRI3/Vulkan) open the secondary
+// GPU's render node directly. This access automatically wakes up the hardware at the
+// kernel driver level, independent of the compositor.
+// The compositor imports the resulting dmabufs on the primary GPU's renderer. Thus,
+// removing the secondary render node from GpuManager does not break offloaded clients,
+// as the compositor does not need the secondary renderer registered for presentation.
+fn is_device_idle_and_last(tty: &Tty, node: DrmNode) -> bool {
+    let Some(device) = tty.devices.get(&node) else {
+        return false;
+    };
+    let Some(render_node) = device.render_node else {
+        return false;
+    };
+    let key = tty.gpu_power_key(node);
+    let Some(power) = tty.gpu_power.get(&key) else {
+        return false;
+    };
+
+    if tty.config.borrow().debug.disable_idle_drm_device_suspend
+        || power.disable_suspend_due_to_nvidia_vram
+        || !device.surfaces.is_empty()
+        || !device.active_leases.is_empty()
+    {
+        return false;
+    }
+
+    !tty.devices.iter().any(|(other_node, other)| {
+        let other_is_suspended = tty
+            .gpu_power
+            .get(&tty.gpu_power_key(*other_node))
+            .map(|power| power.suspended)
+            .unwrap_or(false);
+
+        *other_node != node
+            && other.render_node == Some(render_node)
+            && !other_is_suspended
+            && (!other.surfaces.is_empty() || !other.active_leases.is_empty())
+    })
+}
+
+// Checks if VRAM allocations preservation is enabled for NVIDIA GPUs.
+// Returns Some(true) if active, Some(false) if disabled or unreadable, and None if not an NVIDIA
+// card.
+fn check_nvidia_preserve_memory(node: DrmNode) -> Option<bool> {
+    let has_nvidia_driver = std::path::Path::new("/sys/module/nvidia").exists()
+        || std::path::Path::new("/proc/driver/nvidia").exists();
+
+    let try_get_driver_name = || -> Option<std::ffi::OsString> {
+        let path = node.dev_path()?;
+        let name = path.file_name()?;
+        let sys_path = format!("/sys/class/drm/{}/device/driver", name.to_string_lossy());
+        let driver_path = std::fs::read_link(sys_path).ok()?;
+        let driver_name = driver_path.file_name()?;
+        Some(driver_name.to_owned())
+    };
+
+    match try_get_driver_name() {
+        Some(driver_name) => {
+            if driver_name != "nvidia" {
+                return None;
+            }
+        }
+        None => {
+            if has_nvidia_driver {
+                return Some(false);
+            } else {
+                return None;
+            }
+        }
+    }
+
+    if let Ok(content) =
+        std::fs::read_to_string("/sys/module/nvidia/parameters/PreserveVideoMemoryAllocations")
+    {
+        return Some(matches!(content.trim(), "Y" | "1"));
+    }
+
+    if let Ok(content) = std::fs::read_to_string("/proc/driver/nvidia/params") {
+        let val = content
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find(|(key, _)| key.trim() == "PreserveVideoMemoryAllocations")
+            .map(|(_, value)| value.trim() == "1")
+            .unwrap_or(false);
+        return Some(val);
+    }
+
+    Some(false)
+}
+
+fn return_device_fd(session: &mut LibSeatSession, device_fd: DrmDeviceFd, raw_device_fd: DeviceFd) {
+    drop(device_fd);
+    match TryInto::<OwnedFd>::try_into(raw_device_fd) {
+        Ok(fd) => {
+            if let Err(err) = session.close(fd) {
+                warn!("error closing DRM device fd: {err:?}");
+            }
+        }
+        Err(_) => warn!("could not close DRM device fd: unexpected Arc references"),
+    }
+}
+
+fn spawn_gpu_wakeup_thread(
+    render_path: std::path::PathBuf,
+    expected_dev_id: u64,
+    generation: u64,
+    pm_generation: u64,
+    wakeup_state: Arc<Mutex<WakeupState>>,
+    gpu_gate: GpuGate,
+) {
+    std::thread::spawn(move || {
+        for _ in 0..WAKEUP_ATTEMPTS {
+            {
+                let lock = wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+                if let WakeupState::Cancelled = *lock {
+                    return;
+                }
+            }
+
+            let file_opt = {
+                let Some(_lease) = gpu_gate.acquire_lease(pm_generation) else {
+                    debug!(
+                        "gpu gate is closed or stale generation for {render_path:?}, cancelling wakeup"
+                    );
+                    let mut lock = wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+                    if let WakeupState::Pending = *lock {
+                        *lock = WakeupState::Cancelled;
+                    }
+                    return;
+                };
+
+                std::fs::OpenOptions::new().read(true).open(&render_path)
+            };
+
+            if let Ok(file) = file_opt {
+                match file.metadata() {
+                    Ok(meta) => {
+                        if meta.rdev() == expected_dev_id {
+                            let mut lock = wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+                            if let WakeupState::Pending = *lock {
+                                *lock = WakeupState::Woken { file, generation };
+                            }
+                            return;
+                        } else {
+                            let mut lock = wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+                            if let WakeupState::Pending = *lock {
+                                *lock = WakeupState::Failed;
+                            }
+                            return;
+                        }
+                    }
+                    Err(err) => {
+                        warn!("failed to read metadata for {render_path:?}: {err:?}");
+                    }
+                }
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(WAKEUP_DELAY_MS));
+        }
+
+        let mut lock = wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+        if let WakeupState::Pending = *lock {
+            warn!(
+                "failed to open GPU render node at {render_path:?} for wakeup after \
+                 {WAKEUP_ATTEMPTS} attempts"
+            );
+            *lock = WakeupState::Failed;
+        }
+    });
+}
+
+// Avoid power-cycling the GPU during brief connector churn.
+pub(crate) const SUSPEND_TIMEOUT_SECS: u64 = 10;
+// Slow eGPU links need time before the render node comes back.
+pub(crate) const WAKEUP_ATTEMPTS: usize = 40;
+pub(crate) const WAKEUP_DELAY_MS: u64 = 250;
+
+fn wakeup_retry_delay() -> std::time::Duration {
+    std::time::Duration::from_millis(WAKEUP_DELAY_MS)
+}
+
 impl Tty {
+    pub(crate) fn update_dmabuf_feedbacks(&mut self, niri: &mut Niri) {
+        if let Ok(primary_renderer) = self.gpu_manager.single_renderer(&self.primary_render_node) {
+            let primary_formats = primary_renderer.dmabuf_formats();
+
+            if let Some(dmabuf_global) = self.dmabuf_global.as_mut() {
+                if let Ok(default_feedback) = DmabufFeedbackBuilder::new(
+                    self.primary_render_node.dev_id(),
+                    primary_formats.clone(),
+                )
+                .build()
+                {
+                    niri.dmabuf_state
+                        .set_default_feedback(dmabuf_global, &default_feedback);
+                }
+            }
+
+            for (node, device) in self.devices.iter_mut() {
+                for surface in device.surfaces.values_mut() {
+                    match surface_dmabuf_feedback(
+                        &surface.compositor,
+                        primary_formats.clone(),
+                        self.primary_render_node,
+                        device.render_node,
+                        *node,
+                    ) {
+                        Ok(feedback) => {
+                            surface.dmabuf_feedback = Some(feedback);
+                        }
+                        Err(err) => warn!("error building dmabuf feedback: {err:?}"),
+                    }
+                }
+            }
+
+            niri.queue_redraw_all();
+        }
+    }
+
+    fn gpu_power_key(&self, node: DrmNode) -> DrmNode {
+        if let Some(device) = self.devices.get(&node) {
+            return device.render_node.unwrap_or(node);
+        }
+        if node.ty() == NodeType::Render {
+            node
+        } else {
+            node.node_with_type(NodeType::Render)
+                .and_then(Result::ok)
+                .unwrap_or(node)
+        }
+    }
+
+    fn find_active_primary_for_key(&self, key: DrmNode) -> Option<DrmNode> {
+        self.devices.iter().find_map(|(node, device)| {
+            if device.render_node == Some(key) || (device.render_node.is_none() && *node == key) {
+                Some(*node)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn sync_gpu_manager_devices(&mut self) {
+        // Smithay may keep old Arc refs around until devices() runs.
+        // Touch it so stale GPU state gets dropped before fd cleanup.
+        // Otherwise closing or reusing the fd can trip on extra refs.
+        let _ = self.gpu_manager.devices();
+    }
+
+    fn prime_gpu_power_state(&mut self, node: DrmNode, render_node: Option<DrmNode>) {
+        let key = render_node.unwrap_or(node);
+        if self.gpu_power.contains_key(&key) {
+            return;
+        }
+
+        let disable_suspend_due_to_nvidia_vram =
+            node != self.primary_node && check_nvidia_preserve_memory(node) == Some(false);
+
+        if disable_suspend_due_to_nvidia_vram {
+            warn!(
+                "NVIDIA GPU {node:?}: PreserveVideoMemoryAllocations off or unreadable, not suspending. \
+                 Boot with nvidia.NVreg_PreserveVideoMemoryAllocations=1 to fix."
+            );
+        }
+
+        self.gpu_power
+            .insert(key, GpuPowerState::new(disable_suspend_due_to_nvidia_vram));
+    }
+}
+
+fn should_start_gpu_wakeup(power: &GpuPowerState, is_retry: bool) -> bool {
+    let block = (power.waking_up || power.wakeup_failed) && !is_retry;
+    !block
+}
+
+fn migrate_gpu_power_state_map<K: std::hash::Hash + std::cmp::Eq + Copy + std::fmt::Debug>(
+    gpu_power: &mut std::collections::HashMap<K, GpuPowerState>,
+    early_key: K,
+    actual_key: K,
+) -> Vec<calloop::RegistrationToken> {
+    let mut tokens_to_cancel = Vec::new();
+    if early_key != actual_key {
+        if let Some(power) = gpu_power.get_mut(&early_key) {
+            if let Some(token) = power.suspend_timer.take() {
+                tokens_to_cancel.push(token);
+            }
+            if let Some(token) = power.wakeup_timer.take() {
+                tokens_to_cancel.push(token);
+            }
+        }
+
+        if gpu_power.contains_key(&actual_key) {
+            if let Some(power) = gpu_power.remove(&early_key) {
+                *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                    WakeupState::Cancelled;
+            }
+        } else if let Some(power) = gpu_power.remove(&early_key) {
+            gpu_power.insert(actual_key, power);
+            debug!(
+                "migrated GPU power state from early key {early_key:?} to actual key {actual_key:?}"
+            );
+        }
+    }
+    tokens_to_cancel
+}
+
+impl Tty {
+    fn migrate_and_prepare_gpu_power_state(
+        &mut self,
+        niri: &mut Niri,
+        node: DrmNode,
+        render_node: Option<DrmNode>,
+    ) -> &mut GpuPowerState {
+        let early_key = node
+            .node_with_type(NodeType::Render)
+            .and_then(Result::ok)
+            .unwrap_or(node);
+        let actual_key = render_node.unwrap_or(node);
+
+        let tokens = migrate_gpu_power_state_map(&mut self.gpu_power, early_key, actual_key);
+        for token in tokens {
+            niri.event_loop.remove(token);
+        }
+
+        self.prime_gpu_power_state(node, render_node);
+        self.cancel_gpu_power_timer_by_key(niri, actual_key);
+        let power = self
+            .gpu_power
+            .entry(actual_key)
+            .or_insert_with(|| GpuPowerState::new(false));
+        *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+        power.suspended = false;
+        power.waking_up = false;
+        power.wakeup_failed = false;
+        power.resume_attempts = 0;
+        power
+    }
+
+    fn gpu_power_state_mut(&mut self, node: DrmNode) -> &mut GpuPowerState {
+        let key = self.gpu_power_key(node);
+        if !self.gpu_power.contains_key(&key) {
+            let render_node = if node.ty() == NodeType::Render {
+                Some(node)
+            } else {
+                node.node_with_type(NodeType::Render).and_then(Result::ok)
+            };
+            self.prime_gpu_power_state(node, render_node);
+        }
+        self.gpu_power
+            .get_mut(&key)
+            .expect("gpu_power state must exist after priming")
+    }
+
+    fn cancel_gpu_power_timer_by_key(&mut self, niri: &mut Niri, key: DrmNode) {
+        if let Some(power) = self.gpu_power.get_mut(&key) {
+            if let Some(token) = power.suspend_timer.take() {
+                niri.event_loop.remove(token);
+            }
+
+            if let Some(token) = power.wakeup_timer.take() {
+                niri.event_loop.remove(token);
+            }
+        }
+    }
+
+    fn reset_wakeup_state_by_key(&mut self, niri: &mut Niri, key: DrmNode, failed: bool) {
+        self.cancel_gpu_power_timer_by_key(niri, key);
+
+        if let Some(power) = self.gpu_power.get_mut(&key) {
+            power.waking_up = false;
+            power.resume_attempts = 0;
+            if failed {
+                power.wakeup_failed = true;
+            }
+            *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+        }
+    }
+
+    fn reset_wakeup_state(&mut self, niri: &mut Niri, node: DrmNode) {
+        let key = self.gpu_power_key(node);
+        self.reset_wakeup_state_by_key(niri, key, false);
+    }
+
+    fn remove_pending_device_init(&mut self, niri: &mut Niri, node: &DrmNode) {
+        if let Some(pending) = self.pending_device_inits.remove(node) {
+            *pending
+                .wakeup_state
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+            if let Some(token) = pending.timer_token {
+                niri.event_loop.remove(token);
+            }
+        }
+    }
+
+    fn start_gpu_wakeup(&mut self, niri: &mut Niri, node: DrmNode) -> Result<(), ()> {
+        if !self.gpu_access_allowed() {
+            return Err(());
+        }
+
+        let render_node = self
+            .devices
+            .get(&node)
+            .and_then(|device| device.render_node);
+        let render_target =
+            render_node.and_then(|rn| rn.dev_path().map(|path| (path, rn.dev_id())));
+
+        let key = self.gpu_power_key(node);
+        self.cancel_gpu_power_timer_by_key(niri, key);
+
+        let wakeup_state = Arc::new(Mutex::new(WakeupState::Pending));
+        let generation = {
+            let power = self.gpu_power_state_mut(node);
+            // Keep generation > 0 so Cancelled (generation 0) is never matched.
+            power.wakeup_generation = power.wakeup_generation.wrapping_add(1).max(1);
+            *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+
+            power.wakeup_state = wakeup_state.clone();
+            power.waking_up = true;
+            power.resume_attempts = 1;
+
+            power.wakeup_generation
+        };
+
+        if let Some((render_path, expected_dev_id)) = render_target {
+            debug!("waking GPU {node:?} in background thread");
+            spawn_gpu_wakeup_thread(
+                render_path,
+                expected_dev_id,
+                generation,
+                self.pm_generation,
+                wakeup_state,
+                self.gpu_gate.clone(),
+            );
+        } else {
+            *wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                WakeupState::WokenNoFd { generation };
+        }
+
+        if self.schedule_wakeup_retry(niri, key).is_err() {
+            self.reset_wakeup_state(niri, node);
+            return Err(());
+        }
+        Ok(())
+    }
+
+    fn schedule_wakeup_retry(&mut self, niri: &mut Niri, key: DrmNode) -> Result<(), ()> {
+        let token = niri
+            .event_loop
+            .insert_source(
+                Timer::from_duration(wakeup_retry_delay()),
+                move |_, _, state| {
+                    if let Some(tty) = state.backend.tty_checked() {
+                        tty.check_async_device_resume(key, &mut state.niri);
+                    }
+
+                    TimeoutAction::Drop
+                },
+            )
+            .map_err(|err| {
+                error!("couldn't set wakeup check timer for GPU {key:?}: {err:?}");
+            })?;
+
+        if let Some(power) = self.gpu_power.get_mut(&key) {
+            if let Some(old_token) = power.wakeup_timer.take() {
+                niri.event_loop.remove(old_token);
+            }
+            power.wakeup_timer = Some(token);
+        }
+
+        Ok(())
+    }
+
+    fn check_async_device_init(&mut self, device_id: dev_t, path: &Path, niri: &mut Niri) {
+        if !self.session.is_active() {
+            let Ok(node) = DrmNode::from_dev_id(device_id) else {
+                return;
+            };
+            self.remove_pending_device_init(niri, &node);
+            return;
+        }
+
+        let Ok(node) = DrmNode::from_dev_id(device_id) else {
+            return;
+        };
+
+        let Some(pending) = self.pending_device_inits.get_mut(&node) else {
+            debug!("pending GPU init check cancelled because device was removed: {node:?}");
+            return;
+        };
+
+        let status = {
+            let lock = pending
+                .wakeup_state
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            match &*lock {
+                WakeupState::Woken { generation, .. } if *generation == pending.generation => {
+                    Some(Ok(()))
+                }
+                WakeupState::WokenNoFd { generation } if *generation == pending.generation => {
+                    Some(Ok(()))
+                }
+                WakeupState::Failed => Some(Err(())),
+                _ => None,
+            }
+        };
+
+        if let Some(result) = status {
+            if result.is_ok() {
+                debug!("GPU {node:?} is back, adding device");
+                let add_res = self.device_added(device_id, path, niri, true);
+                self.remove_pending_device_init(niri, &node);
+                if let Err(err) = add_res {
+                    error!("async GPU init failed: {err:?}");
+                }
+            } else {
+                self.remove_pending_device_init(niri, &node);
+                error!("GPU {node:?} failed to wake up, giving up");
+            }
+            return;
+        }
+
+        pending.attempts += 1;
+        if pending.attempts >= WAKEUP_ATTEMPTS {
+            error!("gave up waking GPU {node:?}, marking it failed");
+            self.remove_pending_device_init(niri, &node);
+            return;
+        }
+
+        let dev_id = node.dev_id();
+        let path = path.to_owned();
+
+        match niri.event_loop.insert_source(
+            Timer::from_duration(wakeup_retry_delay()),
+            move |_, _, state| {
+                if let Some(tty) = state.backend.tty_checked() {
+                    tty.check_async_device_init(dev_id, &path, &mut state.niri);
+                }
+
+                TimeoutAction::Drop
+            },
+        ) {
+            Ok(token) => {
+                if let Some(pending) = self.pending_device_inits.get_mut(&node) {
+                    pending.timer_token = Some(token);
+                }
+            }
+            Err(err) => {
+                error!("failed to schedule async GPU init check for {node:?}: {err:?}");
+                self.remove_pending_device_init(niri, &node);
+            }
+        }
+    }
+
+    fn check_async_device_resume(&mut self, key: DrmNode, niri: &mut Niri) {
+        if !self.session.is_active() {
+            self.reset_wakeup_state_by_key(niri, key, false);
+            return;
+        }
+
+        let Some(power) = self.gpu_power.get_mut(&key) else {
+            return;
+        };
+
+        if !power.waking_up {
+            return;
+        }
+
+        power.wakeup_timer = None;
+
+        let status = {
+            let lock = power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+            match &*lock {
+                WakeupState::Woken { generation, .. } if *generation == power.wakeup_generation => {
+                    Some(Ok(()))
+                }
+                WakeupState::WokenNoFd { generation } if *generation == power.wakeup_generation => {
+                    Some(Ok(()))
+                }
+                WakeupState::Failed => Some(Err(())),
+                _ => None,
+            }
+        };
+
+        if let Some(result) = status {
+            if result.is_ok() {
+                debug!("GPU {key:?} is back, resuming");
+                if let Some(node) = self.find_active_primary_for_key(key) {
+                    match self.resume_device(niri, node, true) {
+                        Ok(gpu_topology_changed) => {
+                            if gpu_topology_changed {
+                                self.update_dmabuf_feedbacks(niri);
+                            }
+                            self.device_changed(node.dev_id(), niri, true);
+                        }
+                        Err(()) => {
+                            error!("GPU {key:?} failed to resume after wakeup");
+                            self.reset_wakeup_state_by_key(niri, key, true);
+                        }
+                    }
+                } else {
+                    debug!("GPU {key:?} woke up but no active primary devices share this render node; resetting state");
+                    self.reset_wakeup_state_by_key(niri, key, false);
+                }
+            } else {
+                error!("GPU {key:?} failed to resume: wakeup failed");
+                self.reset_wakeup_state_by_key(niri, key, true);
+            }
+            return;
+        }
+
+        let attempts = power.resume_attempts;
+        if attempts >= WAKEUP_ATTEMPTS {
+            error!("gave up waking GPU {key:?}, marking it failed");
+            self.reset_wakeup_state_by_key(niri, key, true);
+            return;
+        }
+
+        power.resume_attempts += 1;
+
+        if self.schedule_wakeup_retry(niri, key).is_err() {
+            self.reset_wakeup_state_by_key(niri, key, true);
+        }
+    }
+
     pub fn new(
         config: Rc<RefCell<Config>>,
         event_loop: LoopHandle<'static, State>,
@@ -508,6 +1312,13 @@ impl Tty {
             primary_render_node,
             ignored_nodes: HashSet::new(),
             devices: HashMap::new(),
+            pending_device_inits: HashMap::new(),
+            next_pending_init_generation: 0,
+            gpu_power: HashMap::new(),
+            system_pm: SystemPmState::Running,
+            gpu_gate: GpuGate::new(),
+            pm_generation: 0,
+            inhibitor_fd: None,
             dmabuf_global: None,
             update_output_config_on_resume: false,
             debug_tint: false,
@@ -515,7 +1326,103 @@ impl Tty {
         })
     }
 
+    pub fn gpu_access_allowed(&self) -> bool {
+        self.system_pm == SystemPmState::Running && self.session.is_active()
+    }
+
+    pub fn on_prepare_for_sleep(&mut self, niri: &mut Niri, start: bool) {
+        if start {
+            info!("system PM: prepare for sleep (start=true)");
+            self.system_pm = SystemPmState::Quiescing;
+            self.pm_generation = self.pm_generation.wrapping_add(1);
+
+            // Disallow new leases from being acquired and record new generation.
+            self.gpu_gate.set_open_allowed(false, self.pm_generation);
+
+            // Cancel all pending timers and background inits.
+            for power in self.gpu_power.values_mut() {
+                if let Some(token) = power.suspend_timer.take() {
+                    niri.event_loop.remove(token);
+                }
+                if let Some(token) = power.wakeup_timer.take() {
+                    niri.event_loop.remove(token);
+                }
+                power.waking_up = false;
+                *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                    WakeupState::Cancelled;
+            }
+
+            for pending in self.pending_device_inits.drain().map(|(_, v)| v) {
+                if let Some(token) = pending.timer_token {
+                    niri.event_loop.remove(token);
+                }
+                *pending
+                    .wakeup_state
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+            }
+
+            let gate = self.gpu_gate.clone();
+            let inhibitor = self.inhibitor_fd.take();
+
+            self.system_pm = SystemPmState::Quiescing;
+
+            // Keep the event loop responsive while pending GPU work stops.
+            if let Err(e) = std::thread::Builder::new()
+                .name("niri-gpu-quiesce".into())
+                .spawn(move || {
+                    if gate.wait_for_drain(Duration::from_secs(4)) {
+                        debug!("dGPU leases drained successfully before sleep");
+                    } else {
+                        warn!("dGPU lease drain timed out during quiesce");
+                    }
+
+                    // logind may sleep after GPU access has stopped or timed out.
+                    drop(inhibitor);
+                })
+            {
+                warn!("failed to spawn GPU quiesce thread: {e}");
+            }
+        } else {
+            info!("system PM: prepare for sleep (start=false, resume)");
+            self.system_pm = SystemPmState::ResumePending;
+            self.pm_generation = self.pm_generation.wrapping_add(1);
+
+            // Clear failed wakeup state on secondary GPUs so they retry on resume.
+            let primary_key = self.gpu_power_key(self.primary_node);
+            let nodes: Vec<_> = self.devices.keys().copied().collect();
+            for node in nodes {
+                if self.gpu_power_key(node) != primary_key && !is_pci_device_ready(node) {
+                    debug!("secondary GPU {node:?} is not active in sysfs yet on resume");
+                }
+            }
+            for power in self.gpu_power.values_mut() {
+                power.wakeup_failed = false;
+            }
+
+            // Re-acquire the sleep inhibitor for the next sleep cycle.
+            #[cfg(feature = "dbus")]
+            {
+                self.inhibitor_fd = crate::dbus::freedesktop_login1::take_sleep_inhibitor_system();
+            }
+
+            // Allow GPU leases again and go back to Running.
+            self.gpu_gate.set_open_allowed(true, self.pm_generation);
+            self.system_pm = SystemPmState::Running;
+
+            if self.update_output_config_on_resume {
+                self.update_output_config_on_resume = false;
+                self.on_output_config_changed(niri);
+            }
+        }
+    }
+
     pub fn init(&mut self, niri: &mut Niri) {
+        #[cfg(feature = "dbus")]
+        {
+            self.inhibitor_fd = crate::dbus::freedesktop_login1::take_sleep_inhibitor_system();
+        }
+
         // If the session is inactive, skip initialization because we won't be able to do much with
         // the devices anyway. We'll get ActivateSession and add the devices there instead.
         //
@@ -536,7 +1443,8 @@ impl Tty {
             .device_list()
             .find(|&(device_id, _)| device_id == self.primary_node.dev_id())
         {
-            if let Err(err) = self.device_added(primary_device_id, primary_device_path, niri) {
+            if let Err(err) = self.device_added(primary_device_id, primary_device_path, niri, false)
+            {
                 warn!(
                     "error adding primary node device, display-only devices may not work: {err:?}"
                 );
@@ -550,7 +1458,7 @@ impl Tty {
                 continue;
             }
 
-            if let Err(err) = self.device_added(device_id, path, niri) {
+            if let Err(err) = self.device_added(device_id, path, niri, false) {
                 warn!("error adding device: {err:?}");
             }
         }
@@ -570,7 +1478,7 @@ impl Tty {
                 // new underlying device IDs.
                 self.ignored_nodes = self.compute_ignored_nodes();
 
-                if let Err(err) = self.device_added(device_id, &path, niri) {
+                if let Err(err) = self.device_added(device_id, &path, niri, false) {
                     warn!("error adding device: {err:?}");
                 }
             }
@@ -600,6 +1508,7 @@ impl Tty {
             SessionEvent::PauseSession => {
                 debug!("pausing session");
 
+                self.gpu_gate.set_open_allowed(false, self.pm_generation);
                 self.libinput.suspend();
 
                 for device in self.devices.values_mut() {
@@ -612,6 +1521,10 @@ impl Tty {
             }
             SessionEvent::ActivateSession => {
                 debug!("resuming session");
+
+                if self.system_pm == SystemPmState::Running {
+                    self.gpu_gate.set_open_allowed(true, self.pm_generation);
+                }
 
                 if self.libinput.resume().is_err() {
                     warn!("error resuming libinput");
@@ -657,6 +1570,11 @@ impl Tty {
                 // Update remained devices.
                 for node in remained_devices {
                     device_list.remove(&node.dev_id());
+
+                    let key = self.gpu_power_key(node);
+                    if let Some(power) = self.gpu_power.get_mut(&key) {
+                        power.wakeup_failed = false;
+                    }
 
                     // It hasn't been removed, update its state as usual.
                     let device = self.devices.get_mut(&node).unwrap();
@@ -723,7 +1641,7 @@ impl Tty {
                 let primary = primary_device_path.map(|path| (primary_device_id, path));
 
                 for (device_id, path) in primary.into_iter().chain(device_list) {
-                    if let Err(err) = self.device_added(device_id, &path, niri) {
+                    if let Err(err) = self.device_added(device_id, &path, niri, false) {
                         warn!("error adding device: {err:?}");
                     }
                 }
@@ -747,17 +1665,12 @@ impl Tty {
         device_id: dev_t,
         path: &Path,
         niri: &mut Niri,
+        is_retry: bool,
     ) -> anyhow::Result<()> {
         debug!("adding device: {device_id} {path:?}");
 
         let node = DrmNode::from_dev_id(device_id)?;
 
-        if node == self.primary_node {
-            debug!("this is the primary node");
-        }
-
-        // Only consider primary node on udev event
-        // https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/768fbaad54027f8dd027e7e015e8eeb93cb38c52
         if node.ty() != NodeType::Primary {
             debug!("not a primary node, skipping");
             return Ok(());
@@ -768,6 +1681,97 @@ impl Tty {
             return Ok(());
         }
 
+        if self.devices.contains_key(&node) {
+            debug!("device {node:?} already exists, skipping duplicate add");
+            self.remove_pending_device_init(niri, &node);
+            return Ok(());
+        }
+
+        let early_render_node = node.node_with_type(NodeType::Render).and_then(Result::ok);
+        self.prime_gpu_power_state(node, early_render_node);
+
+        // PCIe resume can block, so wake secondary GPUs off the main loop.
+        if !is_retry && node != self.primary_node {
+            if self.pending_device_inits.contains_key(&node) {
+                debug!("GPU {node:?} is already in the process of initialization, skipping duplicate add event");
+                return Ok(());
+            }
+
+            let is_waking_up = self
+                .gpu_power
+                .get(&self.gpu_power_key(node))
+                .map(|p| p.waking_up)
+                .unwrap_or(false);
+            if is_waking_up {
+                debug!(
+                    "GPU {node:?} is already waking up from suspend, skipping duplicate add event"
+                );
+                return Ok(());
+            }
+
+            let render_target =
+                early_render_node.and_then(|rn| rn.dev_path().map(|path| (path, rn.dev_id())));
+
+            let wakeup_state = Arc::new(Mutex::new(WakeupState::Pending));
+            // Keep generation > 0 so Cancelled (generation 0) is never matched.
+            self.next_pending_init_generation =
+                self.next_pending_init_generation.wrapping_add(1).max(1);
+            let generation = self.next_pending_init_generation;
+
+            self.pending_device_inits.insert(
+                node,
+                PendingDeviceInit {
+                    attempts: 0,
+                    generation,
+                    timer_token: None,
+                    wakeup_state: wakeup_state.clone(),
+                },
+            );
+
+            if let Some((render_path, expected_dev_id)) = render_target {
+                spawn_gpu_wakeup_thread(
+                    render_path,
+                    expected_dev_id,
+                    generation,
+                    self.pm_generation,
+                    wakeup_state,
+                    self.gpu_gate.clone(),
+                );
+            } else {
+                // Display-only devices without a render node do not require slow PCIe dGPU wakeups,
+                // so we transition to WokenNoFd immediately. Opening card nodes for display-only
+                // output will not block the event loop.
+                *wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                    WakeupState::WokenNoFd { generation };
+            }
+
+            let dev_id = node.dev_id();
+            let path_buf = path.to_owned();
+            match niri.event_loop.insert_source(
+                Timer::from_duration(wakeup_retry_delay()),
+                move |_, _, state| {
+                    if let Some(tty) = state.backend.tty_checked() {
+                        tty.check_async_device_init(dev_id, &path_buf, &mut state.niri);
+                    }
+                    TimeoutAction::Drop
+                },
+            ) {
+                Ok(token) => {
+                    if let Some(pending) = self.pending_device_inits.get_mut(&node) {
+                        pending.timer_token = Some(token);
+                    }
+                }
+                Err(e) => {
+                    error!("failed to schedule async GPU init check for {node:?}: {e:?}");
+                    self.remove_pending_device_init(niri, &node);
+                    return Err(anyhow::anyhow!(
+                        "failed to schedule async GPU init check: {e:?}"
+                    ));
+                }
+            }
+            return Ok(());
+        }
+
         let _span = tracy_client::span!("Tty::device_added");
 
         let open_flags = OFlags::RDWR | OFlags::CLOEXEC | OFlags::NOCTTY | OFlags::NONBLOCK;
@@ -775,28 +1779,28 @@ impl Tty {
             let _span = tracy_client::span!("LibSeatSession::open");
             self.session.open(path, open_flags)
         }?;
-        let device_fd = DrmDeviceFd::new(DeviceFd::from(fd));
+        let raw_device_fd = DeviceFd::from(fd);
+        let device_fd = DrmDeviceFd::new(raw_device_fd.clone());
 
         let (drm, drm_notifier) = {
             let _span = tracy_client::span!("DrmDevice::new");
             DrmDevice::new(device_fd.clone(), false)
         }?;
+
         let gbm = {
             let _span = tracy_client::span!("GbmDevice::new");
-            GbmDevice::new(device_fd)
+            GbmDevice::new(device_fd.clone())
         }?;
 
-        let mut try_initialize_gpu = || {
+        let mut try_initialize_gpu = || -> Result<Option<DrmNode>, anyhow::Error> {
             let display = unsafe { EGLDisplay::new(gbm.clone())? };
             let egl_device = EGLDevice::device_for_display(&display)?;
 
-            // Software EGL devices (e.g., llvmpipe/softpipe) are rejected for now. They have some
-            // problems (segfault on importing dmabufs from other renderers) and need to be
-            // excluded from some places like DRM leasing.
-            ensure!(
-                !egl_device.is_software(),
-                "software EGL renderers are skipped"
-            );
+            // Software renderers segfault on dmabuf import and mess up DRM leasing,
+            // so skip render integration but keep the device for scanout.
+            if egl_device.is_software() {
+                return Ok(None);
+            }
 
             let render_node = egl_device
                 .try_get_render_node()
@@ -808,16 +1812,25 @@ impl Tty {
                 .add_node(render_node, gbm.clone())
                 .context("error adding render node to GPU manager")?;
 
-            Ok(render_node)
+            Ok(Some(render_node))
         };
 
-        let render_node = match try_initialize_gpu() {
-            Ok(render_node) => {
+        let gpu_init = try_initialize_gpu();
+
+        let render_node = match gpu_init {
+            Ok(Some(render_node)) => {
                 debug!("got render node: {render_node}");
+                self.remove_pending_device_init(niri, &node);
                 Some(render_node)
             }
+            Ok(None) => {
+                debug!("GPU {node:?} is a software renderer, skipping rendering integration");
+                self.remove_pending_device_init(niri, &node);
+                None
+            }
             Err(err) => {
-                debug!("failed to initialize renderer, falling back to primary gpu: {err:?}");
+                self.remove_pending_device_init(niri, &node);
+                debug!("failed to initialize renderer for {node:?}: {err:?}");
                 None
             }
         };
@@ -859,9 +1872,22 @@ impl Tty {
             // Create the dmabuf global.
             let primary_formats = renderer.dmabuf_formats();
             let default_feedback =
-                DmabufFeedbackBuilder::new(render_node.dev_id(), primary_formats.clone())
+                match DmabufFeedbackBuilder::new(render_node.dev_id(), primary_formats.clone())
                     .build()
-                    .context("error building default dmabuf feedback")?;
+                    .context("error building default dmabuf feedback")
+                {
+                    Ok(fb) => fb,
+                    Err(err) => {
+                        drop(renderer);
+                        self.gpu_manager.as_mut().remove_node(&render_node);
+                        drop(drm_notifier);
+                        drop(drm);
+                        drop(gbm);
+                        self.sync_gpu_manager_devices();
+                        return_device_fd(&mut self.session, device_fd, raw_device_fd);
+                        return Err(err);
+                    }
+                };
             let dmabuf_global = niri
                 .dmabuf_state
                 .create_global_with_default_feedback::<State>(
@@ -919,6 +1945,9 @@ impl Tty {
             .map_err(|err| warn!("error initializing DRM leasing for {node}: {err:?}"))
             .ok();
 
+        // Reset stale suspend state after a fresh device init.
+        let _power = self.migrate_and_prepare_gpu_power_state(niri, node, render_node);
+
         let device = OutputDevice {
             token,
             render_node,
@@ -932,14 +1961,227 @@ impl Tty {
             active_leases: Vec::new(),
             non_desktop_connectors: HashSet::new(),
         };
-        assert!(self.devices.insert(node, device).is_none());
+        match self.devices.entry(node) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(device);
+            }
+            std::collections::hash_map::Entry::Occupied(_) => {
+                if let Some(render_node) = render_node {
+                    self.gpu_manager.as_mut().remove_node(&render_node);
+                }
+                niri.event_loop.remove(device.token);
+                drop(device); // drm and gbm live inside, must go before closing the fd
+                self.sync_gpu_manager_devices();
+                return_device_fd(&mut self.session, device_fd, raw_device_fd);
+                bail!("device {node:?} was unexpectedly already present in self.devices");
+            }
+        }
 
         self.device_changed(device_id, niri, true);
 
         Ok(())
     }
 
-    fn device_changed(&mut self, device_id: dev_t, niri: &mut Niri, cleanup: bool) {
+    pub(crate) fn check_suspend_device(&mut self, niri: &mut Niri, node: DrmNode) {
+        if !self.gpu_access_allowed() {
+            return;
+        }
+
+        let key = self.gpu_power_key(node);
+        let should_suspend = node != self.primary_node
+            && self
+                .gpu_power
+                .get(&key)
+                .map(|power| !power.suspended && !power.waking_up)
+                .unwrap_or(false)
+            && is_device_idle_and_last(self, node);
+
+        if !should_suspend {
+            if let Some(power) = self.gpu_power.get_mut(&key) {
+                if let Some(token) = power.suspend_timer.take() {
+                    niri.event_loop.remove(token);
+                }
+            }
+            return;
+        }
+
+        let Some(device) = self.devices.get(&node) else {
+            return;
+        };
+
+        if device.render_node.is_none() {
+            return;
+        }
+
+        if self
+            .gpu_power
+            .get(&key)
+            .and_then(|power| power.suspend_timer.as_ref())
+            .is_some()
+        {
+            return;
+        }
+
+        debug!("secondary GPU {node:?} idle, suspending in {SUSPEND_TIMEOUT_SECS}s");
+
+        let token = match niri.event_loop.insert_source(
+            Timer::from_duration(std::time::Duration::from_secs(SUSPEND_TIMEOUT_SECS)),
+            move |_, _, state| {
+                let Some(tty) = state.backend.tty_checked() else {
+                    return TimeoutAction::Drop;
+                };
+
+                let Some(node) = tty.find_active_primary_for_key(key) else {
+                    debug!("secondary GPU timer fired for key {key:?}, but no active primary devices share it; ignoring suspend");
+                    return TimeoutAction::Drop;
+                };
+
+                if let Some(power) = tty.gpu_power.get_mut(&key) {
+                    power.suspend_timer = None;
+                }
+
+                if !tty.gpu_access_allowed() {
+                    return TimeoutAction::Drop;
+                }
+
+                if !is_device_idle_and_last(tty, node) {
+                    return TimeoutAction::Drop;
+                }
+
+                let Some(render_node) =
+                    tty.devices.get(&node).and_then(|device| device.render_node)
+                else {
+                    return TimeoutAction::Drop;
+                };
+
+                if render_node == tty.primary_render_node {
+                    warn!("attempted to suspend primary render node; skipping suspend");
+                    return TimeoutAction::Drop;
+                }
+
+                tty.cancel_gpu_power_timer_by_key(&mut state.niri, key);
+
+                if let Some(power) = tty.gpu_power.get_mut(&key) {
+                    power.suspended = true;
+                    power.waking_up = false;
+                    power.resume_attempts = 0;
+                    *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                        WakeupState::Cancelled;
+                }
+
+                debug!("secondary GPU {node:?} timer up, suspending");
+                tty.gpu_manager.as_mut().remove_node(&render_node);
+                tty.sync_gpu_manager_devices();
+                tty.update_dmabuf_feedbacks(&mut state.niri);
+
+                TimeoutAction::Drop
+            },
+        ) {
+            Ok(token) => token,
+            Err(err) => {
+                error!("couldn't set suspend timer for GPU {node:?}: {err:?}");
+                return;
+            }
+        };
+
+        self.gpu_power_state_mut(node).suspend_timer = Some(token);
+    }
+
+    pub(crate) fn resume_device(
+        &mut self,
+        niri: &mut Niri,
+        node: DrmNode,
+        is_retry: bool,
+    ) -> Result<bool, ()> {
+        let Some(device) = self.devices.get(&node) else {
+            return Ok(false);
+        };
+
+        let key = self.gpu_power_key(node);
+        let render_node = device.render_node;
+        let gbm = device.gbm.clone();
+
+        if let Some(power) = self.gpu_power.get_mut(&key) {
+            if !should_start_gpu_wakeup(power, is_retry) {
+                if power.wakeup_failed && !is_retry {
+                    debug!("GPU {key:?} failed to wake before, not touching it again");
+                }
+                return Err(());
+            }
+            power.wakeup_failed = false;
+            if let Some(token) = power.suspend_timer.take() {
+                niri.event_loop.remove(token);
+            }
+        }
+
+        let was_suspended = self
+            .gpu_power
+            .get(&key)
+            .map(|power| power.suspended)
+            .unwrap_or(false);
+
+        if !was_suspended {
+            if let Some(power) = self.gpu_power.get_mut(&key) {
+                power.waking_up = false;
+                power.resume_attempts = 0;
+            }
+            return Ok(false);
+        }
+
+        let Some(render_node) = render_node else {
+            if let Some(power) = self.gpu_power.get_mut(&key) {
+                power.suspended = false;
+                power.waking_up = false;
+                power.resume_attempts = 0;
+            }
+            return Ok(false);
+        };
+
+        let shared_active = self.devices.iter().any(|(other_node, other)| {
+            *other_node != node
+                && other.render_node == Some(render_node)
+                && !self
+                    .gpu_power
+                    .get(&self.gpu_power_key(*other_node))
+                    .map(|power| power.suspended)
+                    .unwrap_or(false)
+        });
+
+        if shared_active {
+            if let Some(power) = self.gpu_power.get_mut(&key) {
+                power.suspended = false;
+                power.waking_up = false;
+                power.resume_attempts = 0;
+            }
+            return Ok(false);
+        }
+
+        if !is_retry {
+            self.start_gpu_wakeup(niri, node)?;
+            return Err(());
+        }
+
+        self.gpu_manager
+            .as_mut()
+            .add_node(render_node, gbm)
+            .map_err(|err| {
+                warn!("error re-adding render node {render_node:?}: {err:?}");
+            })?;
+
+        self.sync_gpu_manager_devices();
+
+        {
+            let power = self.gpu_power_state_mut(node);
+            *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+            power.suspended = false;
+            power.waking_up = false;
+            power.resume_attempts = 0;
+        };
+
+        Ok(true)
+    }
+
+    pub(crate) fn device_changed(&mut self, device_id: dev_t, niri: &mut Niri, cleanup: bool) {
         debug!("device changed: {device_id}");
 
         let Ok(node) = DrmNode::from_dev_id(device_id) else {
@@ -952,6 +2194,34 @@ impl Tty {
             return;
         }
 
+        let key = self.gpu_power_key(node);
+        let state = self
+            .gpu_power
+            .get(&key)
+            .map(|power| (power.waking_up, power.suspended));
+
+        if let Some((waking_up, suspended)) = state {
+            if waking_up {
+                // Duplicate udev events get dropped during wakeup: on success we replay one,
+                // on failure the device is marked failed and ignored, so nothing is lost either way.
+                debug!("holding udev event until wakeup is done");
+                return;
+            }
+            if suspended {
+                debug!(
+                    "secondary GPU {device_id} is suspended, triggering async wakeup instead of scanning connectors"
+                );
+                if let Err(err) = self.start_gpu_wakeup(niri, node) {
+                    warn!("failed to start async GPU wakeup for device {device_id}: {err:?}");
+                }
+                return;
+            }
+        }
+
+        if let Some(power) = self.gpu_power.get_mut(&key) {
+            power.resume_attempts = 0;
+        }
+
         if self.ignored_nodes.contains(&node) {
             debug!("node is ignored, skipping");
             return;
@@ -961,7 +2231,7 @@ impl Tty {
             if let Some(path) = node.dev_path() {
                 warn!("unknown device; trying to add");
 
-                if let Err(err) = self.device_added(device_id, &path, niri) {
+                if let Err(err) = self.device_added(device_id, &path, niri, false) {
                     warn!("error adding device: {err:?}");
                 }
             } else {
@@ -1142,8 +2412,16 @@ impl Tty {
             return;
         }
 
+        let key = self.gpu_power_key(node);
+
         let Some(device) = self.devices.get_mut(&node) else {
-            warn!("unknown device");
+            // Stop the wakeup thread if udev removed the device first.
+            if self.pending_device_inits.contains_key(&node) {
+                self.remove_pending_device_init(niri, &node);
+                debug!("cancelled pending async GPU init for removed device {node:?}");
+            } else {
+                warn!("unknown device");
+            }
             return;
         };
 
@@ -1160,6 +2438,24 @@ impl Tty {
         let mut device = self.devices.remove(&node).unwrap();
         let device_fd = device.drm.device_fd().device_fd();
 
+        let was_last_primary_user = if let Some(render_node) = device.render_node {
+            !self
+                .devices
+                .values()
+                .any(|device| device.render_node == Some(render_node))
+        } else {
+            true
+        };
+
+        if was_last_primary_user {
+            self.cancel_gpu_power_timer_by_key(niri, key);
+            if let Some(power) = self.gpu_power.get(&key) {
+                *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                    WakeupState::Cancelled;
+            }
+            self.gpu_power.remove(&key);
+        }
+
         if let Some(lease_state) = &mut device.drm_lease_state {
             lease_state.disable_global::<State>();
         }
@@ -1168,10 +2464,14 @@ impl Tty {
             // Sometimes (Asahi DisplayLink), multiple primary nodes will correspond to the same
             // render node. In this case, we want to keep the render node active until the last
             // primary node that uses it is gone.
-            let was_last = !self
-                .devices
-                .values()
-                .any(|device| device.render_node == Some(render_node));
+            let was_last = !self.devices.iter().any(|(other_node, other)| {
+                other.render_node == Some(render_node)
+                    && !self
+                        .gpu_power
+                        .get(&self.gpu_power_key(*other_node))
+                        .map(|p| p.suspended)
+                        .unwrap_or(false)
+            });
 
             if was_last && render_node == self.primary_render_node {
                 debug!("destroying the primary renderer");
@@ -1213,8 +2513,9 @@ impl Tty {
 
             if was_last {
                 self.gpu_manager.as_mut().remove_node(&render_node);
-                // Trigger re-enumeration in order to remove the device from gpu_manager.
-                let _ = self.gpu_manager.devices();
+                // Nudge gpu_manager to forget the removed render node.
+                self.sync_gpu_manager_devices();
+                self.update_dmabuf_feedbacks(niri);
             }
         }
 
@@ -2349,7 +3650,7 @@ impl Tty {
         }
 
         for (device_id, path) in device_list {
-            if let Err(err) = self.device_added(device_id, &path, niri) {
+            if let Err(err) = self.device_added(device_id, &path, niri, false) {
                 warn!("error adding device {path:?}: {err:?}");
             }
         }
@@ -2565,13 +3866,59 @@ impl Tty {
         // startup, when multiple connectors appear at once.
         to_connect.sort_unstable_by(|a, b| a.3.compare(&b.3));
 
+        let mut gpu_topology_changed = false;
+        let mut failed_resume_nodes = HashSet::new();
+
         for (node, connector, crtc, _name) in to_connect {
+            if failed_resume_nodes.contains(&node) {
+                continue;
+            }
+
+            // Smithay wants the renderer back before we touch connectors.
+            match self.resume_device(niri, node, false) {
+                Ok(true) => gpu_topology_changed = true,
+                Ok(false) => {}
+                Err(_) => {
+                    failed_resume_nodes.insert(node);
+                    continue;
+                }
+            }
+
             if let Err(err) = self.connector_connected(niri, node, connector, crtc) {
                 warn!("error connecting connector: {err:?}");
             }
         }
 
         self.refresh_ipc_outputs(niri);
+
+        let nodes: Vec<_> = self.devices.keys().copied().collect();
+        for node in nodes {
+            let key = self.gpu_power_key(node);
+            let disable_suspend = self.config.borrow().debug.disable_idle_drm_device_suspend
+                || self
+                    .gpu_power
+                    .get(&key)
+                    .map(|p| p.disable_suspend_due_to_nvidia_vram)
+                    .unwrap_or(false);
+            if disable_suspend {
+                if let Some(power) = self.gpu_power.get_mut(&key) {
+                    power.wakeup_failed = false;
+                }
+                if !failed_resume_nodes.contains(&node) {
+                    match self.resume_device(niri, node, false) {
+                        Ok(true) => gpu_topology_changed = true,
+                        Ok(false) => {}
+                        Err(_) => {}
+                    }
+                }
+            } else {
+                self.check_suspend_device(niri, node);
+            }
+        }
+
+        if gpu_topology_changed {
+            self.update_dmabuf_feedbacks(niri);
+        }
     }
 
     pub fn get_device_from_node(&mut self, node: DrmNode) -> Option<&mut OutputDevice> {
@@ -2990,9 +4337,9 @@ fn queue_estimated_vblank_timer(
     let token = niri
         .event_loop
         .insert_source(timer, move |_, _, data| {
-            data.backend
-                .tty()
-                .on_estimated_vblank_timer(&mut data.niri, output.clone());
+            if let Some(tty) = data.backend.tty_checked() {
+                tty.on_estimated_vblank_timer(&mut data.niri, output.clone());
+            }
             TimeoutAction::Drop
         })
         .unwrap();
@@ -3661,5 +5008,130 @@ mod tests {
             ),
         }
         "#);
+    }
+
+    #[test]
+    fn test_gpu_power_state_migration() {
+        use crate::backend::tty::{migrate_gpu_power_state_map, GpuPowerState, WakeupState};
+        use std::collections::HashMap;
+        use std::sync::{Arc, Mutex};
+
+        let event_loop = calloop::EventLoop::<()>::try_new().unwrap();
+        let handle = event_loop.handle();
+        let suspend_token = handle
+            .insert_source(
+                calloop::timer::Timer::from_duration(std::time::Duration::from_millis(100)),
+                |_, _, _| calloop::timer::TimeoutAction::Drop,
+            )
+            .unwrap();
+        let wakeup_token = handle
+            .insert_source(
+                calloop::timer::Timer::from_duration(std::time::Duration::from_millis(100)),
+                |_, _, _| calloop::timer::TimeoutAction::Drop,
+            )
+            .unwrap();
+
+        let early_key = 1u32;
+        let actual_key = 2u32;
+
+        let mut gpu_power = HashMap::new();
+
+        // 1. Setup early state with active timers and pending wakeup
+        let mut early_state = GpuPowerState::new(false);
+        early_state.waking_up = true;
+        early_state.suspend_timer = Some(suspend_token);
+        early_state.wakeup_timer = Some(wakeup_token);
+        let early_wakeup = Arc::new(Mutex::new(WakeupState::Pending));
+        early_state.wakeup_state = early_wakeup.clone();
+        gpu_power.insert(early_key, early_state);
+
+        // 2. Scenario A: Migrate to a non-existent actual_key
+        let tokens = migrate_gpu_power_state_map(&mut gpu_power, early_key, actual_key);
+        // Verify both tokens are returned for cancellation
+        assert_eq!(tokens.len(), 2);
+        assert!(tokens.contains(&suspend_token));
+        assert!(tokens.contains(&wakeup_token));
+
+        assert!(!gpu_power.contains_key(&early_key));
+        assert!(gpu_power.contains_key(&actual_key));
+
+        // 3. Scenario B: Try migrating when actual_key already exists (shared node collision)
+        let mut shared_early = GpuPowerState::new(false);
+        shared_early.waking_up = true;
+        let shared_wakeup = Arc::new(Mutex::new(WakeupState::Pending));
+        shared_early.wakeup_state = shared_wakeup.clone();
+        gpu_power.insert(early_key, shared_early);
+
+        let tokens = migrate_gpu_power_state_map(&mut gpu_power, early_key, actual_key);
+        assert!(tokens.is_empty());
+
+        assert!(!gpu_power.contains_key(&early_key));
+        assert!(gpu_power.contains_key(&actual_key));
+        assert!(matches!(
+            *shared_wakeup.lock().unwrap(),
+            WakeupState::Cancelled
+        ));
+
+        // 4. Scenario C: Migrate when early_key == actual_key (no-op)
+        let early_key_c = 3u32;
+        let mut state_c = GpuPowerState::new(false);
+        state_c.waking_up = true;
+        gpu_power.insert(early_key_c, state_c);
+
+        let tokens = migrate_gpu_power_state_map(&mut gpu_power, early_key_c, early_key_c);
+        assert!(tokens.is_empty());
+        assert!(gpu_power.contains_key(&early_key_c));
+        assert!(gpu_power.get(&early_key_c).unwrap().waking_up);
+    }
+
+    #[test]
+    fn test_gpu_power_state_transitions() {
+        use crate::backend::tty::{should_start_gpu_wakeup, GpuPowerState};
+
+        let mut state = GpuPowerState::new(false);
+
+        // 1. Fresh state: should allow wakeup
+        assert!(should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+
+        // 2. Waking up state: should block normal, but allow retry
+        state.waking_up = true;
+        assert!(!should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+
+        // 3. Reset waking up, set wakeup failed: should block normal, but allow retry
+        state.waking_up = false;
+        state.wakeup_failed = true;
+        assert!(!should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+
+        // 4. Reset wakeup failed: should allow wakeup again
+        state.wakeup_failed = false;
+        assert!(should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+    }
+
+    #[test]
+    fn test_wakeup_failed_reset_and_retry() {
+        use crate::backend::tty::{should_start_gpu_wakeup, GpuPowerState};
+
+        let mut state = GpuPowerState::new(false);
+        // clean slate, nothing blocking either path
+        assert!(should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+
+        // wakeup_failed stops the normal path, retries still go through (same deal as waking_up)
+        state.wakeup_failed = true;
+        assert!(!should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+
+        // resume clears the flag so we can talk to the GPU again
+        state.wakeup_failed = false;
+        assert!(should_start_gpu_wakeup(&state, false));
+
+        // waking_up and wakeup_failed should look the same to is_retry
+        state.waking_up = true;
+        assert!(!should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
     }
 }

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -4,9 +4,10 @@ use std::fmt::Write;
 use std::iter::zip;
 use std::num::NonZeroU64;
 use std::os::fd::{AsFd, OwnedFd};
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 use std::{io, mem};
 
@@ -78,6 +79,172 @@ const SUPPORTED_COLOR_FORMATS_10BIT: [Fourcc; 3] =
 // Smithay should fall back to Xrgb/Xbgr automatically if needed.
 const SUPPORTED_COLOR_FORMATS: [Fourcc; 2] = [Fourcc::Argb8888, Fourcc::Abgr8888];
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemPmState {
+    Running,
+    Quiescing,
+    Suspended,
+    ResumePending,
+}
+
+struct GpuGateState {
+    open_allowed: bool,
+    active_leases: usize,
+    generation: u64,
+}
+
+struct GpuGateShared {
+    state: Mutex<GpuGateState>,
+    cvar: Condvar,
+}
+
+#[derive(Clone)]
+pub struct GpuGate {
+    shared: Arc<GpuGateShared>,
+}
+
+pub struct GpuLease {
+    shared: Arc<GpuGateShared>,
+}
+
+impl Drop for GpuLease {
+    fn drop(&mut self) {
+        let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        state.active_leases = state.active_leases.saturating_sub(1);
+        if state.active_leases == 0 {
+            self.shared.cvar.notify_all();
+        }
+    }
+}
+
+impl Default for GpuGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GpuGate {
+    pub fn new() -> Self {
+        Self {
+            shared: Arc::new(GpuGateShared {
+                state: Mutex::new(GpuGateState {
+                    open_allowed: true,
+                    active_leases: 0,
+                    generation: 0,
+                }),
+                cvar: Condvar::new(),
+            }),
+        }
+    }
+
+    pub fn acquire_lease(&self, expected_generation: u64) -> Option<GpuLease> {
+        let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        if !state.open_allowed || state.generation != expected_generation {
+            return None;
+        }
+
+        state.active_leases = state.active_leases.saturating_add(1);
+
+        Some(GpuLease {
+            shared: self.shared.clone(),
+        })
+    }
+
+    pub fn set_open_allowed(&self, allowed: bool, generation: u64) {
+        let mut state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        state.open_allowed = allowed;
+        state.generation = generation;
+    }
+
+    pub fn active_lease_count(&self) -> usize {
+        let state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.active_leases
+    }
+
+    pub fn wait_for_drain(&self, timeout: Duration) -> bool {
+        let state = self.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        let (state, _) = self
+            .shared
+            .cvar
+            .wait_timeout_while(state, timeout, |state| state.active_leases != 0)
+            .unwrap_or_else(|e| e.into_inner());
+
+        state.active_leases == 0
+    }
+}
+
+fn is_pci_device_ready(node: DrmNode) -> bool {
+    let Some(path) = node.dev_path() else {
+        return true;
+    };
+    let Some(filename) = path.file_name().and_then(|s| s.to_str()) else {
+        return true;
+    };
+    let sysfs_path = format!("/sys/class/drm/{filename}/device/power/runtime_status");
+    if let Ok(content) = std::fs::read_to_string(&sysfs_path) {
+        let status = content.trim();
+        if status == "suspended" || status == "suspending" || status == "resuming" {
+            return false;
+        }
+    }
+    true
+}
+
+#[derive(Debug)]
+enum WakeupState {
+    Pending,
+    Woken {
+        // Held open so the kernel doesn't autosuspend the GPU mid-init.
+        #[allow(dead_code)]
+        file: std::fs::File,
+        generation: u64,
+    },
+    WokenNoFd {
+        generation: u64,
+    },
+    Failed,
+    Cancelled,
+}
+
+struct PendingDeviceInit {
+    attempts: usize,
+    generation: u64,
+    timer_token: Option<RegistrationToken>,
+    wakeup_state: Arc<Mutex<WakeupState>>,
+}
+
+struct GpuPowerState {
+    suspended: bool,
+    waking_up: bool,
+    wakeup_failed: bool,
+    resume_attempts: usize,
+    wakeup_generation: u64,
+    wakeup_state: Arc<Mutex<WakeupState>>,
+    suspend_timer: Option<RegistrationToken>,
+    wakeup_timer: Option<RegistrationToken>,
+    disable_suspend_due_to_nvidia_vram: bool,
+}
+
+impl GpuPowerState {
+    fn new(disable_suspend_due_to_nvidia_vram: bool) -> Self {
+        Self {
+            suspended: false,
+            waking_up: false,
+            wakeup_failed: false,
+            resume_attempts: 0,
+            wakeup_generation: 0,
+            wakeup_state: Arc::new(Mutex::new(WakeupState::Pending)),
+            suspend_timer: None,
+            wakeup_timer: None,
+            disable_suspend_due_to_nvidia_vram,
+        }
+    }
+}
+
 pub struct Tty {
     config: Rc<RefCell<Config>>,
     session: LibSeatSession,
@@ -93,6 +260,15 @@ pub struct Tty {
     ignored_nodes: HashSet<DrmNode>,
     // Devices indexed by DRM node (not necessarily the render node).
     devices: HashMap<DrmNode, OutputDevice>,
+    // PCIe wakeup can take seconds; poll from a thread instead of blocking the event loop.
+    pending_device_inits: HashMap<DrmNode, PendingDeviceInit>,
+    next_pending_init_generation: u64,
+    // Track suspend state across udev churn.
+    gpu_power: HashMap<DrmNode, GpuPowerState>,
+    system_pm: SystemPmState,
+    gpu_gate: GpuGate,
+    pm_generation: u64,
+    inhibitor_fd: Option<OwnedFd>,
     // The dma-buf global corresponds to the output device (the primary GPU). It is only `Some()`
     // if we have a device corresponding to the primary GPU.
     dmabuf_global: Option<DmabufGlobal>,
@@ -410,7 +586,635 @@ struct ConnectorProperties<'a> {
     requests: AtomicModeReq,
 }
 
+// Check if a secondary GPU is completely idle and has no active display attachments.
+//
+// NOTE on render offload (PRIME):
+// Applications doing direct render offload (e.g., via DRI3/Vulkan) open the secondary
+// GPU's render node directly. This access automatically wakes up the hardware at the
+// kernel driver level, independent of the compositor.
+// The compositor imports the resulting dmabufs on the primary GPU's renderer. Thus,
+// removing the secondary render node from GpuManager does not break offloaded clients,
+// as the compositor does not need the secondary renderer registered for presentation.
+fn is_device_idle_and_last(tty: &Tty, node: DrmNode) -> bool {
+    let Some(device) = tty.devices.get(&node) else {
+        return false;
+    };
+    let Some(render_node) = device.render_node else {
+        return false;
+    };
+    let key = tty.gpu_power_key(node);
+    let Some(power) = tty.gpu_power.get(&key) else {
+        return false;
+    };
+
+    if tty.config.borrow().debug.disable_idle_drm_device_suspend
+        || power.disable_suspend_due_to_nvidia_vram
+        || !device.surfaces.is_empty()
+        || !device.active_leases.is_empty()
+    {
+        return false;
+    }
+
+    !tty.devices.iter().any(|(other_node, other)| {
+        let other_is_suspended = tty
+            .gpu_power
+            .get(&tty.gpu_power_key(*other_node))
+            .map(|power| power.suspended)
+            .unwrap_or(false);
+
+        *other_node != node
+            && other.render_node == Some(render_node)
+            && !other_is_suspended
+            && (!other.surfaces.is_empty() || !other.active_leases.is_empty())
+    })
+}
+
+// Checks if VRAM allocations preservation is enabled for NVIDIA GPUs.
+// Returns Some(true) if active, Some(false) if disabled or unreadable, and None if not an NVIDIA
+// card.
+fn check_nvidia_preserve_memory(node: DrmNode) -> Option<bool> {
+    let has_nvidia_driver = std::path::Path::new("/sys/module/nvidia").exists()
+        || std::path::Path::new("/proc/driver/nvidia").exists();
+
+    let try_get_driver_name = || -> Option<std::ffi::OsString> {
+        let path = node.dev_path()?;
+        let name = path.file_name()?;
+        let sys_path = format!("/sys/class/drm/{}/device/driver", name.to_string_lossy());
+        let driver_path = std::fs::read_link(sys_path).ok()?;
+        let driver_name = driver_path.file_name()?;
+        Some(driver_name.to_owned())
+    };
+
+    match try_get_driver_name() {
+        Some(driver_name) => {
+            if driver_name != "nvidia" {
+                return None;
+            }
+        }
+        None => {
+            if has_nvidia_driver {
+                return Some(false);
+            } else {
+                return None;
+            }
+        }
+    }
+
+    if let Ok(content) =
+        std::fs::read_to_string("/sys/module/nvidia/parameters/PreserveVideoMemoryAllocations")
+    {
+        return Some(matches!(content.trim(), "Y" | "1"));
+    }
+
+    if let Ok(content) = std::fs::read_to_string("/proc/driver/nvidia/params") {
+        let val = content
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find(|(key, _)| key.trim() == "PreserveVideoMemoryAllocations")
+            .map(|(_, value)| value.trim() == "1")
+            .unwrap_or(false);
+        return Some(val);
+    }
+
+    Some(false)
+}
+
+fn return_device_fd(session: &mut LibSeatSession, device_fd: DrmDeviceFd, raw_device_fd: DeviceFd) {
+    drop(device_fd);
+    match TryInto::<OwnedFd>::try_into(raw_device_fd) {
+        Ok(fd) => {
+            if let Err(err) = session.close(fd) {
+                warn!("error closing DRM device fd: {err:?}");
+            }
+        }
+        Err(_) => warn!("could not close DRM device fd: unexpected Arc references"),
+    }
+}
+
+fn spawn_gpu_wakeup_thread(
+    render_path: std::path::PathBuf,
+    expected_dev_id: u64,
+    generation: u64,
+    pm_generation: u64,
+    wakeup_state: Arc<Mutex<WakeupState>>,
+    gpu_gate: GpuGate,
+) {
+    std::thread::spawn(move || {
+        for _ in 0..WAKEUP_ATTEMPTS {
+            {
+                let lock = wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+                if let WakeupState::Cancelled = *lock {
+                    return;
+                }
+            }
+
+            let file_opt = {
+                let Some(_lease) = gpu_gate.acquire_lease(pm_generation) else {
+                    debug!(
+                        "gpu gate is closed or stale generation for {render_path:?}, cancelling wakeup"
+                    );
+                    let mut lock = wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+                    if let WakeupState::Pending = *lock {
+                        *lock = WakeupState::Cancelled;
+                    }
+                    return;
+                };
+
+                std::fs::OpenOptions::new().read(true).open(&render_path)
+            };
+
+            if let Ok(file) = file_opt {
+                match file.metadata() {
+                    Ok(meta) => {
+                        if meta.rdev() == expected_dev_id {
+                            let mut lock = wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+                            if let WakeupState::Pending = *lock {
+                                *lock = WakeupState::Woken { file, generation };
+                            }
+                            return;
+                        } else {
+                            let mut lock = wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+                            if let WakeupState::Pending = *lock {
+                                *lock = WakeupState::Failed;
+                            }
+                            return;
+                        }
+                    }
+                    Err(err) => {
+                        warn!("failed to read metadata for {render_path:?}: {err:?}");
+                    }
+                }
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(WAKEUP_DELAY_MS));
+        }
+
+        let mut lock = wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+        if let WakeupState::Pending = *lock {
+            warn!(
+                "failed to open GPU render node at {render_path:?} for wakeup after \
+                 {WAKEUP_ATTEMPTS} attempts"
+            );
+            *lock = WakeupState::Failed;
+        }
+    });
+}
+
+// Avoid power-cycling the GPU during brief connector churn.
+pub(crate) const SUSPEND_TIMEOUT_SECS: u64 = 10;
+// Slow eGPU links need time before the render node comes back.
+pub(crate) const WAKEUP_ATTEMPTS: usize = 40;
+pub(crate) const WAKEUP_DELAY_MS: u64 = 250;
+
+fn wakeup_retry_delay() -> std::time::Duration {
+    std::time::Duration::from_millis(WAKEUP_DELAY_MS)
+}
+
 impl Tty {
+    pub(crate) fn update_dmabuf_feedbacks(&mut self, niri: &mut Niri) {
+        if let Ok(primary_renderer) = self.gpu_manager.single_renderer(&self.primary_render_node) {
+            let primary_formats = primary_renderer.dmabuf_formats();
+
+            if let Some(dmabuf_global) = self.dmabuf_global.as_mut() {
+                if let Ok(default_feedback) = DmabufFeedbackBuilder::new(
+                    self.primary_render_node.dev_id(),
+                    primary_formats.clone(),
+                )
+                .build()
+                {
+                    niri.dmabuf_state
+                        .set_default_feedback(dmabuf_global, &default_feedback);
+                }
+            }
+
+            for (node, device) in self.devices.iter_mut() {
+                for surface in device.surfaces.values_mut() {
+                    match surface_dmabuf_feedback(
+                        &surface.compositor,
+                        primary_formats.clone(),
+                        self.primary_render_node,
+                        device.render_node,
+                        *node,
+                    ) {
+                        Ok(feedback) => {
+                            surface.dmabuf_feedback = Some(feedback);
+                        }
+                        Err(err) => warn!("error building dmabuf feedback: {err:?}"),
+                    }
+                }
+            }
+
+            niri.queue_redraw_all();
+        }
+    }
+
+    fn gpu_power_key(&self, node: DrmNode) -> DrmNode {
+        if let Some(device) = self.devices.get(&node) {
+            return device.render_node.unwrap_or(node);
+        }
+        if node.ty() == NodeType::Render {
+            node
+        } else {
+            node.node_with_type(NodeType::Render)
+                .and_then(Result::ok)
+                .unwrap_or(node)
+        }
+    }
+
+    fn find_active_primary_for_key(&self, key: DrmNode) -> Option<DrmNode> {
+        self.devices.iter().find_map(|(node, device)| {
+            if device.render_node == Some(key) || (device.render_node.is_none() && *node == key) {
+                Some(*node)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn sync_gpu_manager_devices(&mut self) {
+        // Smithay may keep old Arc refs around until devices() runs.
+        // Touch it so stale GPU state gets dropped before fd cleanup.
+        // Otherwise closing or reusing the fd can trip on extra refs.
+        let _ = self.gpu_manager.devices();
+    }
+
+    fn prime_gpu_power_state(&mut self, node: DrmNode, render_node: Option<DrmNode>) {
+        let key = render_node.unwrap_or(node);
+        if self.gpu_power.contains_key(&key) {
+            return;
+        }
+
+        let disable_suspend_due_to_nvidia_vram =
+            node != self.primary_node && check_nvidia_preserve_memory(node) == Some(false);
+
+        if disable_suspend_due_to_nvidia_vram {
+            warn!(
+                "NVIDIA GPU {node:?}: PreserveVideoMemoryAllocations off or unreadable, not suspending. \
+                 Boot with nvidia.NVreg_PreserveVideoMemoryAllocations=1 to fix."
+            );
+        }
+
+        self.gpu_power
+            .insert(key, GpuPowerState::new(disable_suspend_due_to_nvidia_vram));
+    }
+}
+
+fn should_start_gpu_wakeup(power: &GpuPowerState, is_retry: bool) -> bool {
+    let block = (power.waking_up || power.wakeup_failed) && !is_retry;
+    !block
+}
+
+fn migrate_gpu_power_state_map<K: std::hash::Hash + std::cmp::Eq + Copy + std::fmt::Debug>(
+    gpu_power: &mut std::collections::HashMap<K, GpuPowerState>,
+    early_key: K,
+    actual_key: K,
+) -> Vec<calloop::RegistrationToken> {
+    let mut tokens_to_cancel = Vec::new();
+    if early_key != actual_key {
+        if let Some(power) = gpu_power.get_mut(&early_key) {
+            if let Some(token) = power.suspend_timer.take() {
+                tokens_to_cancel.push(token);
+            }
+            if let Some(token) = power.wakeup_timer.take() {
+                tokens_to_cancel.push(token);
+            }
+        }
+
+        if gpu_power.contains_key(&actual_key) {
+            if let Some(power) = gpu_power.remove(&early_key) {
+                *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                    WakeupState::Cancelled;
+            }
+        } else if let Some(power) = gpu_power.remove(&early_key) {
+            gpu_power.insert(actual_key, power);
+            debug!(
+                "migrated GPU power state from early key {early_key:?} to actual key {actual_key:?}"
+            );
+        }
+    }
+    tokens_to_cancel
+}
+
+impl Tty {
+    fn migrate_and_prepare_gpu_power_state(
+        &mut self,
+        niri: &mut Niri,
+        node: DrmNode,
+        render_node: Option<DrmNode>,
+    ) -> &mut GpuPowerState {
+        let early_key = node
+            .node_with_type(NodeType::Render)
+            .and_then(Result::ok)
+            .unwrap_or(node);
+        let actual_key = render_node.unwrap_or(node);
+
+        let tokens = migrate_gpu_power_state_map(&mut self.gpu_power, early_key, actual_key);
+        for token in tokens {
+            niri.event_loop.remove(token);
+        }
+
+        self.prime_gpu_power_state(node, render_node);
+        self.cancel_gpu_power_timer_by_key(niri, actual_key);
+        let power = self
+            .gpu_power
+            .entry(actual_key)
+            .or_insert_with(|| GpuPowerState::new(false));
+        *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+        power.suspended = false;
+        power.waking_up = false;
+        power.wakeup_failed = false;
+        power.resume_attempts = 0;
+        power
+    }
+
+    fn gpu_power_state_mut(&mut self, node: DrmNode) -> &mut GpuPowerState {
+        let key = self.gpu_power_key(node);
+        if !self.gpu_power.contains_key(&key) {
+            let render_node = if node.ty() == NodeType::Render {
+                Some(node)
+            } else {
+                node.node_with_type(NodeType::Render).and_then(Result::ok)
+            };
+            self.prime_gpu_power_state(node, render_node);
+        }
+        self.gpu_power
+            .get_mut(&key)
+            .expect("gpu_power state must exist after priming")
+    }
+
+    fn cancel_gpu_power_timer_by_key(&mut self, niri: &mut Niri, key: DrmNode) {
+        if let Some(power) = self.gpu_power.get_mut(&key) {
+            if let Some(token) = power.suspend_timer.take() {
+                niri.event_loop.remove(token);
+            }
+
+            if let Some(token) = power.wakeup_timer.take() {
+                niri.event_loop.remove(token);
+            }
+        }
+    }
+
+    fn reset_wakeup_state_by_key(&mut self, niri: &mut Niri, key: DrmNode, failed: bool) {
+        self.cancel_gpu_power_timer_by_key(niri, key);
+
+        if let Some(power) = self.gpu_power.get_mut(&key) {
+            power.waking_up = false;
+            power.resume_attempts = 0;
+            if failed {
+                power.wakeup_failed = true;
+            }
+            *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+        }
+    }
+
+    fn reset_wakeup_state(&mut self, niri: &mut Niri, node: DrmNode) {
+        let key = self.gpu_power_key(node);
+        self.reset_wakeup_state_by_key(niri, key, false);
+    }
+
+    fn remove_pending_device_init(&mut self, niri: &mut Niri, node: &DrmNode) {
+        if let Some(pending) = self.pending_device_inits.remove(node) {
+            *pending
+                .wakeup_state
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+            if let Some(token) = pending.timer_token {
+                niri.event_loop.remove(token);
+            }
+        }
+    }
+
+    fn start_gpu_wakeup(&mut self, niri: &mut Niri, node: DrmNode) -> Result<(), ()> {
+        if !self.gpu_access_allowed() {
+            return Err(());
+        }
+
+        let render_node = self
+            .devices
+            .get(&node)
+            .and_then(|device| device.render_node);
+        let render_target =
+            render_node.and_then(|rn| rn.dev_path().map(|path| (path, rn.dev_id())));
+
+        let key = self.gpu_power_key(node);
+        self.cancel_gpu_power_timer_by_key(niri, key);
+
+        let wakeup_state = Arc::new(Mutex::new(WakeupState::Pending));
+        let generation = {
+            let power = self.gpu_power_state_mut(node);
+            // Keep generation > 0 so Cancelled (generation 0) is never matched.
+            power.wakeup_generation = power.wakeup_generation.wrapping_add(1).max(1);
+            *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+
+            power.wakeup_state = wakeup_state.clone();
+            power.waking_up = true;
+            power.resume_attempts = 1;
+
+            power.wakeup_generation
+        };
+
+        if let Some((render_path, expected_dev_id)) = render_target {
+            debug!("waking GPU {node:?} in background thread");
+            spawn_gpu_wakeup_thread(
+                render_path,
+                expected_dev_id,
+                generation,
+                self.pm_generation,
+                wakeup_state,
+                self.gpu_gate.clone(),
+            );
+        } else {
+            *wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                WakeupState::WokenNoFd { generation };
+        }
+
+        if self.schedule_wakeup_retry(niri, key).is_err() {
+            self.reset_wakeup_state(niri, node);
+            return Err(());
+        }
+        Ok(())
+    }
+
+    fn schedule_wakeup_retry(&mut self, niri: &mut Niri, key: DrmNode) -> Result<(), ()> {
+        let token = niri
+            .event_loop
+            .insert_source(
+                Timer::from_duration(wakeup_retry_delay()),
+                move |_, _, state| {
+                    if let Some(tty) = state.backend.tty_checked() {
+                        tty.check_async_device_resume(key, &mut state.niri);
+                    }
+
+                    TimeoutAction::Drop
+                },
+            )
+            .map_err(|err| {
+                error!("couldn't set wakeup check timer for GPU {key:?}: {err:?}");
+            })?;
+
+        if let Some(power) = self.gpu_power.get_mut(&key) {
+            if let Some(old_token) = power.wakeup_timer.take() {
+                niri.event_loop.remove(old_token);
+            }
+            power.wakeup_timer = Some(token);
+        }
+
+        Ok(())
+    }
+
+    fn check_async_device_init(&mut self, device_id: dev_t, path: &Path, niri: &mut Niri) {
+        if !self.session.is_active() {
+            let Ok(node) = DrmNode::from_dev_id(device_id) else {
+                return;
+            };
+            self.remove_pending_device_init(niri, &node);
+            return;
+        }
+
+        let Ok(node) = DrmNode::from_dev_id(device_id) else {
+            return;
+        };
+
+        let Some(pending) = self.pending_device_inits.get_mut(&node) else {
+            debug!("pending GPU init check cancelled because device was removed: {node:?}");
+            return;
+        };
+
+        let status = {
+            let lock = pending
+                .wakeup_state
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            match &*lock {
+                WakeupState::Woken { generation, .. } if *generation == pending.generation => {
+                    Some(Ok(()))
+                }
+                WakeupState::WokenNoFd { generation } if *generation == pending.generation => {
+                    Some(Ok(()))
+                }
+                WakeupState::Failed => Some(Err(())),
+                _ => None,
+            }
+        };
+
+        if let Some(result) = status {
+            if result.is_ok() {
+                debug!("GPU {node:?} is back, adding device");
+                let add_res = self.device_added(device_id, path, niri, true);
+                self.remove_pending_device_init(niri, &node);
+                if let Err(err) = add_res {
+                    error!("async GPU init failed: {err:?}");
+                }
+            } else {
+                self.remove_pending_device_init(niri, &node);
+                error!("GPU {node:?} failed to wake up, giving up");
+            }
+            return;
+        }
+
+        pending.attempts += 1;
+        if pending.attempts >= WAKEUP_ATTEMPTS {
+            error!("gave up waking GPU {node:?}, marking it failed");
+            self.remove_pending_device_init(niri, &node);
+            return;
+        }
+
+        let dev_id = node.dev_id();
+        let path = path.to_owned();
+
+        match niri.event_loop.insert_source(
+            Timer::from_duration(wakeup_retry_delay()),
+            move |_, _, state| {
+                if let Some(tty) = state.backend.tty_checked() {
+                    tty.check_async_device_init(dev_id, &path, &mut state.niri);
+                }
+
+                TimeoutAction::Drop
+            },
+        ) {
+            Ok(token) => {
+                if let Some(pending) = self.pending_device_inits.get_mut(&node) {
+                    pending.timer_token = Some(token);
+                }
+            }
+            Err(err) => {
+                error!("failed to schedule async GPU init check for {node:?}: {err:?}");
+                self.remove_pending_device_init(niri, &node);
+            }
+        }
+    }
+
+    fn check_async_device_resume(&mut self, key: DrmNode, niri: &mut Niri) {
+        if !self.session.is_active() {
+            self.reset_wakeup_state_by_key(niri, key, false);
+            return;
+        }
+
+        let Some(power) = self.gpu_power.get_mut(&key) else {
+            return;
+        };
+
+        if !power.waking_up {
+            return;
+        }
+
+        power.wakeup_timer = None;
+
+        let status = {
+            let lock = power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner());
+            match &*lock {
+                WakeupState::Woken { generation, .. } if *generation == power.wakeup_generation => {
+                    Some(Ok(()))
+                }
+                WakeupState::WokenNoFd { generation } if *generation == power.wakeup_generation => {
+                    Some(Ok(()))
+                }
+                WakeupState::Failed => Some(Err(())),
+                _ => None,
+            }
+        };
+
+        if let Some(result) = status {
+            if result.is_ok() {
+                debug!("GPU {key:?} is back, resuming");
+                if let Some(node) = self.find_active_primary_for_key(key) {
+                    match self.resume_device(niri, node, true) {
+                        Ok(gpu_topology_changed) => {
+                            if gpu_topology_changed {
+                                self.update_dmabuf_feedbacks(niri);
+                            }
+                            self.device_changed(node.dev_id(), niri, true);
+                        }
+                        Err(()) => {
+                            error!("GPU {key:?} failed to resume after wakeup");
+                            self.reset_wakeup_state_by_key(niri, key, true);
+                        }
+                    }
+                } else {
+                    debug!("GPU {key:?} woke up but no active primary devices share this render node; resetting state");
+                    self.reset_wakeup_state_by_key(niri, key, false);
+                }
+            } else {
+                error!("GPU {key:?} failed to resume: wakeup failed");
+                self.reset_wakeup_state_by_key(niri, key, true);
+            }
+            return;
+        }
+
+        let attempts = power.resume_attempts;
+        if attempts >= WAKEUP_ATTEMPTS {
+            error!("gave up waking GPU {key:?}, marking it failed");
+            self.reset_wakeup_state_by_key(niri, key, true);
+            return;
+        }
+
+        power.resume_attempts += 1;
+
+        if self.schedule_wakeup_retry(niri, key).is_err() {
+            self.reset_wakeup_state_by_key(niri, key, true);
+        }
+    }
+
     pub fn new(
         config: Rc<RefCell<Config>>,
         event_loop: LoopHandle<'static, State>,
@@ -505,6 +1309,13 @@ impl Tty {
             primary_render_node,
             ignored_nodes: HashSet::new(),
             devices: HashMap::new(),
+            pending_device_inits: HashMap::new(),
+            next_pending_init_generation: 0,
+            gpu_power: HashMap::new(),
+            system_pm: SystemPmState::Running,
+            gpu_gate: GpuGate::new(),
+            pm_generation: 0,
+            inhibitor_fd: None,
             dmabuf_global: None,
             update_output_config_on_resume: false,
             debug_tint: false,
@@ -512,7 +1323,103 @@ impl Tty {
         })
     }
 
+    pub fn gpu_access_allowed(&self) -> bool {
+        self.system_pm == SystemPmState::Running && self.session.is_active()
+    }
+
+    pub fn on_prepare_for_sleep(&mut self, niri: &mut Niri, start: bool) {
+        if start {
+            info!("system PM: prepare for sleep (start=true)");
+            self.system_pm = SystemPmState::Quiescing;
+            self.pm_generation = self.pm_generation.wrapping_add(1);
+
+            // Disallow new leases from being acquired and record new generation.
+            self.gpu_gate.set_open_allowed(false, self.pm_generation);
+
+            // Cancel all pending timers and background inits.
+            for power in self.gpu_power.values_mut() {
+                if let Some(token) = power.suspend_timer.take() {
+                    niri.event_loop.remove(token);
+                }
+                if let Some(token) = power.wakeup_timer.take() {
+                    niri.event_loop.remove(token);
+                }
+                power.waking_up = false;
+                *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                    WakeupState::Cancelled;
+            }
+
+            for pending in self.pending_device_inits.drain().map(|(_, v)| v) {
+                if let Some(token) = pending.timer_token {
+                    niri.event_loop.remove(token);
+                }
+                *pending
+                    .wakeup_state
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+            }
+
+            let gate = self.gpu_gate.clone();
+            let inhibitor = self.inhibitor_fd.take();
+
+            self.system_pm = SystemPmState::Quiescing;
+
+            // Keep the event loop responsive while pending GPU work stops.
+            if let Err(e) = std::thread::Builder::new()
+                .name("niri-gpu-quiesce".into())
+                .spawn(move || {
+                    if gate.wait_for_drain(Duration::from_secs(4)) {
+                        debug!("dGPU leases drained successfully before sleep");
+                    } else {
+                        warn!("dGPU lease drain timed out during quiesce");
+                    }
+
+                    // logind may sleep after GPU access has stopped or timed out.
+                    drop(inhibitor);
+                })
+            {
+                warn!("failed to spawn GPU quiesce thread: {e}");
+            }
+        } else {
+            info!("system PM: prepare for sleep (start=false, resume)");
+            self.system_pm = SystemPmState::ResumePending;
+            self.pm_generation = self.pm_generation.wrapping_add(1);
+
+            // Clear failed wakeup state on secondary GPUs so they retry on resume.
+            let primary_key = self.gpu_power_key(self.primary_node);
+            let nodes: Vec<_> = self.devices.keys().copied().collect();
+            for node in nodes {
+                if self.gpu_power_key(node) != primary_key && !is_pci_device_ready(node) {
+                    debug!("secondary GPU {node:?} is not active in sysfs yet on resume");
+                }
+            }
+            for power in self.gpu_power.values_mut() {
+                power.wakeup_failed = false;
+            }
+
+            // Re-acquire the sleep inhibitor for the next sleep cycle.
+            #[cfg(feature = "dbus")]
+            {
+                self.inhibitor_fd = crate::dbus::freedesktop_login1::take_sleep_inhibitor_system();
+            }
+
+            // Allow GPU leases again and go back to Running.
+            self.gpu_gate.set_open_allowed(true, self.pm_generation);
+            self.system_pm = SystemPmState::Running;
+
+            if self.update_output_config_on_resume {
+                self.update_output_config_on_resume = false;
+                self.on_output_config_changed(niri);
+            }
+        }
+    }
+
     pub fn init(&mut self, niri: &mut Niri) {
+        #[cfg(feature = "dbus")]
+        {
+            self.inhibitor_fd = crate::dbus::freedesktop_login1::take_sleep_inhibitor_system();
+        }
+
         // If the session is inactive, skip initialization because we won't be able to do much with
         // the devices anyway. We'll get ActivateSession and add the devices there instead.
         //
@@ -533,7 +1440,8 @@ impl Tty {
             .device_list()
             .find(|&(device_id, _)| device_id == self.primary_node.dev_id())
         {
-            if let Err(err) = self.device_added(primary_device_id, primary_device_path, niri) {
+            if let Err(err) = self.device_added(primary_device_id, primary_device_path, niri, false)
+            {
                 warn!(
                     "error adding primary node device, display-only devices may not work: {err:?}"
                 );
@@ -547,7 +1455,7 @@ impl Tty {
                 continue;
             }
 
-            if let Err(err) = self.device_added(device_id, path, niri) {
+            if let Err(err) = self.device_added(device_id, path, niri, false) {
                 warn!("error adding device: {err:?}");
             }
         }
@@ -567,7 +1475,7 @@ impl Tty {
                 // new underlying device IDs.
                 self.ignored_nodes = self.compute_ignored_nodes();
 
-                if let Err(err) = self.device_added(device_id, &path, niri) {
+                if let Err(err) = self.device_added(device_id, &path, niri, false) {
                     warn!("error adding device: {err:?}");
                 }
             }
@@ -597,6 +1505,7 @@ impl Tty {
             SessionEvent::PauseSession => {
                 debug!("pausing session");
 
+                self.gpu_gate.set_open_allowed(false, self.pm_generation);
                 self.libinput.suspend();
 
                 for device in self.devices.values_mut() {
@@ -609,6 +1518,10 @@ impl Tty {
             }
             SessionEvent::ActivateSession => {
                 debug!("resuming session");
+
+                if self.system_pm == SystemPmState::Running {
+                    self.gpu_gate.set_open_allowed(true, self.pm_generation);
+                }
 
                 if self.libinput.resume().is_err() {
                     warn!("error resuming libinput");
@@ -654,6 +1567,11 @@ impl Tty {
                 // Update remained devices.
                 for node in remained_devices {
                     device_list.remove(&node.dev_id());
+
+                    let key = self.gpu_power_key(node);
+                    if let Some(power) = self.gpu_power.get_mut(&key) {
+                        power.wakeup_failed = false;
+                    }
 
                     // It hasn't been removed, update its state as usual.
                     let device = self.devices.get_mut(&node).unwrap();
@@ -720,7 +1638,7 @@ impl Tty {
                 let primary = primary_device_path.map(|path| (primary_device_id, path));
 
                 for (device_id, path) in primary.into_iter().chain(device_list) {
-                    if let Err(err) = self.device_added(device_id, &path, niri) {
+                    if let Err(err) = self.device_added(device_id, &path, niri, false) {
                         warn!("error adding device: {err:?}");
                     }
                 }
@@ -744,17 +1662,12 @@ impl Tty {
         device_id: dev_t,
         path: &Path,
         niri: &mut Niri,
+        is_retry: bool,
     ) -> anyhow::Result<()> {
         debug!("adding device: {device_id} {path:?}");
 
         let node = DrmNode::from_dev_id(device_id)?;
 
-        if node == self.primary_node {
-            debug!("this is the primary node");
-        }
-
-        // Only consider primary node on udev event
-        // https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/768fbaad54027f8dd027e7e015e8eeb93cb38c52
         if node.ty() != NodeType::Primary {
             debug!("not a primary node, skipping");
             return Ok(());
@@ -765,6 +1678,97 @@ impl Tty {
             return Ok(());
         }
 
+        if self.devices.contains_key(&node) {
+            debug!("device {node:?} already exists, skipping duplicate add");
+            self.remove_pending_device_init(niri, &node);
+            return Ok(());
+        }
+
+        let early_render_node = node.node_with_type(NodeType::Render).and_then(Result::ok);
+        self.prime_gpu_power_state(node, early_render_node);
+
+        // PCIe resume can block, so wake secondary GPUs off the main loop.
+        if !is_retry && node != self.primary_node {
+            if self.pending_device_inits.contains_key(&node) {
+                debug!("GPU {node:?} is already in the process of initialization, skipping duplicate add event");
+                return Ok(());
+            }
+
+            let is_waking_up = self
+                .gpu_power
+                .get(&self.gpu_power_key(node))
+                .map(|p| p.waking_up)
+                .unwrap_or(false);
+            if is_waking_up {
+                debug!(
+                    "GPU {node:?} is already waking up from suspend, skipping duplicate add event"
+                );
+                return Ok(());
+            }
+
+            let render_target =
+                early_render_node.and_then(|rn| rn.dev_path().map(|path| (path, rn.dev_id())));
+
+            let wakeup_state = Arc::new(Mutex::new(WakeupState::Pending));
+            // Keep generation > 0 so Cancelled (generation 0) is never matched.
+            self.next_pending_init_generation =
+                self.next_pending_init_generation.wrapping_add(1).max(1);
+            let generation = self.next_pending_init_generation;
+
+            self.pending_device_inits.insert(
+                node,
+                PendingDeviceInit {
+                    attempts: 0,
+                    generation,
+                    timer_token: None,
+                    wakeup_state: wakeup_state.clone(),
+                },
+            );
+
+            if let Some((render_path, expected_dev_id)) = render_target {
+                spawn_gpu_wakeup_thread(
+                    render_path,
+                    expected_dev_id,
+                    generation,
+                    self.pm_generation,
+                    wakeup_state,
+                    self.gpu_gate.clone(),
+                );
+            } else {
+                // Display-only devices without a render node do not require slow PCIe dGPU wakeups,
+                // so we transition to WokenNoFd immediately. Opening card nodes for display-only
+                // output will not block the event loop.
+                *wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                    WakeupState::WokenNoFd { generation };
+            }
+
+            let dev_id = node.dev_id();
+            let path_buf = path.to_owned();
+            match niri.event_loop.insert_source(
+                Timer::from_duration(wakeup_retry_delay()),
+                move |_, _, state| {
+                    if let Some(tty) = state.backend.tty_checked() {
+                        tty.check_async_device_init(dev_id, &path_buf, &mut state.niri);
+                    }
+                    TimeoutAction::Drop
+                },
+            ) {
+                Ok(token) => {
+                    if let Some(pending) = self.pending_device_inits.get_mut(&node) {
+                        pending.timer_token = Some(token);
+                    }
+                }
+                Err(e) => {
+                    error!("failed to schedule async GPU init check for {node:?}: {e:?}");
+                    self.remove_pending_device_init(niri, &node);
+                    return Err(anyhow::anyhow!(
+                        "failed to schedule async GPU init check: {e:?}"
+                    ));
+                }
+            }
+            return Ok(());
+        }
+
         let _span = tracy_client::span!("Tty::device_added");
 
         let open_flags = OFlags::RDWR | OFlags::CLOEXEC | OFlags::NOCTTY | OFlags::NONBLOCK;
@@ -772,28 +1776,28 @@ impl Tty {
             let _span = tracy_client::span!("LibSeatSession::open");
             self.session.open(path, open_flags)
         }?;
-        let device_fd = DrmDeviceFd::new(DeviceFd::from(fd));
+        let raw_device_fd = DeviceFd::from(fd);
+        let device_fd = DrmDeviceFd::new(raw_device_fd.clone());
 
         let (drm, drm_notifier) = {
             let _span = tracy_client::span!("DrmDevice::new");
             DrmDevice::new(device_fd.clone(), false)
         }?;
+
         let gbm = {
             let _span = tracy_client::span!("GbmDevice::new");
-            GbmDevice::new(device_fd)
+            GbmDevice::new(device_fd.clone())
         }?;
 
-        let mut try_initialize_gpu = || {
+        let mut try_initialize_gpu = || -> Result<Option<DrmNode>, anyhow::Error> {
             let display = unsafe { EGLDisplay::new(gbm.clone())? };
             let egl_device = EGLDevice::device_for_display(&display)?;
 
-            // Software EGL devices (e.g., llvmpipe/softpipe) are rejected for now. They have some
-            // problems (segfault on importing dmabufs from other renderers) and need to be
-            // excluded from some places like DRM leasing.
-            ensure!(
-                !egl_device.is_software(),
-                "software EGL renderers are skipped"
-            );
+            // Software renderers segfault on dmabuf import and mess up DRM leasing,
+            // so skip render integration but keep the device for scanout.
+            if egl_device.is_software() {
+                return Ok(None);
+            }
 
             let render_node = egl_device
                 .try_get_render_node()
@@ -805,16 +1809,25 @@ impl Tty {
                 .add_node(render_node, gbm.clone())
                 .context("error adding render node to GPU manager")?;
 
-            Ok(render_node)
+            Ok(Some(render_node))
         };
 
-        let render_node = match try_initialize_gpu() {
-            Ok(render_node) => {
+        let gpu_init = try_initialize_gpu();
+
+        let render_node = match gpu_init {
+            Ok(Some(render_node)) => {
                 debug!("got render node: {render_node}");
+                self.remove_pending_device_init(niri, &node);
                 Some(render_node)
             }
+            Ok(None) => {
+                debug!("GPU {node:?} is a software renderer, skipping rendering integration");
+                self.remove_pending_device_init(niri, &node);
+                None
+            }
             Err(err) => {
-                debug!("failed to initialize renderer, falling back to primary gpu: {err:?}");
+                self.remove_pending_device_init(niri, &node);
+                debug!("failed to initialize renderer for {node:?}: {err:?}");
                 None
             }
         };
@@ -856,9 +1869,22 @@ impl Tty {
             // Create the dmabuf global.
             let primary_formats = renderer.dmabuf_formats();
             let default_feedback =
-                DmabufFeedbackBuilder::new(render_node.dev_id(), primary_formats.clone())
+                match DmabufFeedbackBuilder::new(render_node.dev_id(), primary_formats.clone())
                     .build()
-                    .context("error building default dmabuf feedback")?;
+                    .context("error building default dmabuf feedback")
+                {
+                    Ok(fb) => fb,
+                    Err(err) => {
+                        drop(renderer);
+                        self.gpu_manager.as_mut().remove_node(&render_node);
+                        drop(drm_notifier);
+                        drop(drm);
+                        drop(gbm);
+                        self.sync_gpu_manager_devices();
+                        return_device_fd(&mut self.session, device_fd, raw_device_fd);
+                        return Err(err);
+                    }
+                };
             let dmabuf_global = niri
                 .dmabuf_state
                 .create_global_with_default_feedback::<State>(
@@ -916,6 +1942,9 @@ impl Tty {
             .map_err(|err| warn!("error initializing DRM leasing for {node}: {err:?}"))
             .ok();
 
+        // Reset stale suspend state after a fresh device init.
+        let _power = self.migrate_and_prepare_gpu_power_state(niri, node, render_node);
+
         let device = OutputDevice {
             token,
             render_node,
@@ -929,14 +1958,227 @@ impl Tty {
             active_leases: Vec::new(),
             non_desktop_connectors: HashSet::new(),
         };
-        assert!(self.devices.insert(node, device).is_none());
+        match self.devices.entry(node) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(device);
+            }
+            std::collections::hash_map::Entry::Occupied(_) => {
+                if let Some(render_node) = render_node {
+                    self.gpu_manager.as_mut().remove_node(&render_node);
+                }
+                niri.event_loop.remove(device.token);
+                drop(device); // drm and gbm live inside, must go before closing the fd
+                self.sync_gpu_manager_devices();
+                return_device_fd(&mut self.session, device_fd, raw_device_fd);
+                bail!("device {node:?} was unexpectedly already present in self.devices");
+            }
+        }
 
         self.device_changed(device_id, niri, true);
 
         Ok(())
     }
 
-    fn device_changed(&mut self, device_id: dev_t, niri: &mut Niri, cleanup: bool) {
+    pub(crate) fn check_suspend_device(&mut self, niri: &mut Niri, node: DrmNode) {
+        if !self.gpu_access_allowed() {
+            return;
+        }
+
+        let key = self.gpu_power_key(node);
+        let should_suspend = node != self.primary_node
+            && self
+                .gpu_power
+                .get(&key)
+                .map(|power| !power.suspended && !power.waking_up)
+                .unwrap_or(false)
+            && is_device_idle_and_last(self, node);
+
+        if !should_suspend {
+            if let Some(power) = self.gpu_power.get_mut(&key) {
+                if let Some(token) = power.suspend_timer.take() {
+                    niri.event_loop.remove(token);
+                }
+            }
+            return;
+        }
+
+        let Some(device) = self.devices.get(&node) else {
+            return;
+        };
+
+        if device.render_node.is_none() {
+            return;
+        }
+
+        if self
+            .gpu_power
+            .get(&key)
+            .and_then(|power| power.suspend_timer.as_ref())
+            .is_some()
+        {
+            return;
+        }
+
+        debug!("secondary GPU {node:?} idle, suspending in {SUSPEND_TIMEOUT_SECS}s");
+
+        let token = match niri.event_loop.insert_source(
+            Timer::from_duration(std::time::Duration::from_secs(SUSPEND_TIMEOUT_SECS)),
+            move |_, _, state| {
+                let Some(tty) = state.backend.tty_checked() else {
+                    return TimeoutAction::Drop;
+                };
+
+                let Some(node) = tty.find_active_primary_for_key(key) else {
+                    debug!("secondary GPU timer fired for key {key:?}, but no active primary devices share it; ignoring suspend");
+                    return TimeoutAction::Drop;
+                };
+
+                if let Some(power) = tty.gpu_power.get_mut(&key) {
+                    power.suspend_timer = None;
+                }
+
+                if !tty.gpu_access_allowed() {
+                    return TimeoutAction::Drop;
+                }
+
+                if !is_device_idle_and_last(tty, node) {
+                    return TimeoutAction::Drop;
+                }
+
+                let Some(render_node) =
+                    tty.devices.get(&node).and_then(|device| device.render_node)
+                else {
+                    return TimeoutAction::Drop;
+                };
+
+                if render_node == tty.primary_render_node {
+                    warn!("attempted to suspend primary render node; skipping suspend");
+                    return TimeoutAction::Drop;
+                }
+
+                tty.cancel_gpu_power_timer_by_key(&mut state.niri, key);
+
+                if let Some(power) = tty.gpu_power.get_mut(&key) {
+                    power.suspended = true;
+                    power.waking_up = false;
+                    power.resume_attempts = 0;
+                    *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                        WakeupState::Cancelled;
+                }
+
+                debug!("secondary GPU {node:?} timer up, suspending");
+                tty.gpu_manager.as_mut().remove_node(&render_node);
+                tty.sync_gpu_manager_devices();
+                tty.update_dmabuf_feedbacks(&mut state.niri);
+
+                TimeoutAction::Drop
+            },
+        ) {
+            Ok(token) => token,
+            Err(err) => {
+                error!("couldn't set suspend timer for GPU {node:?}: {err:?}");
+                return;
+            }
+        };
+
+        self.gpu_power_state_mut(node).suspend_timer = Some(token);
+    }
+
+    pub(crate) fn resume_device(
+        &mut self,
+        niri: &mut Niri,
+        node: DrmNode,
+        is_retry: bool,
+    ) -> Result<bool, ()> {
+        let Some(device) = self.devices.get(&node) else {
+            return Ok(false);
+        };
+
+        let key = self.gpu_power_key(node);
+        let render_node = device.render_node;
+        let gbm = device.gbm.clone();
+
+        if let Some(power) = self.gpu_power.get_mut(&key) {
+            if !should_start_gpu_wakeup(power, is_retry) {
+                if power.wakeup_failed && !is_retry {
+                    debug!("GPU {key:?} failed to wake before, not touching it again");
+                }
+                return Err(());
+            }
+            power.wakeup_failed = false;
+            if let Some(token) = power.suspend_timer.take() {
+                niri.event_loop.remove(token);
+            }
+        }
+
+        let was_suspended = self
+            .gpu_power
+            .get(&key)
+            .map(|power| power.suspended)
+            .unwrap_or(false);
+
+        if !was_suspended {
+            if let Some(power) = self.gpu_power.get_mut(&key) {
+                power.waking_up = false;
+                power.resume_attempts = 0;
+            }
+            return Ok(false);
+        }
+
+        let Some(render_node) = render_node else {
+            if let Some(power) = self.gpu_power.get_mut(&key) {
+                power.suspended = false;
+                power.waking_up = false;
+                power.resume_attempts = 0;
+            }
+            return Ok(false);
+        };
+
+        let shared_active = self.devices.iter().any(|(other_node, other)| {
+            *other_node != node
+                && other.render_node == Some(render_node)
+                && !self
+                    .gpu_power
+                    .get(&self.gpu_power_key(*other_node))
+                    .map(|power| power.suspended)
+                    .unwrap_or(false)
+        });
+
+        if shared_active {
+            if let Some(power) = self.gpu_power.get_mut(&key) {
+                power.suspended = false;
+                power.waking_up = false;
+                power.resume_attempts = 0;
+            }
+            return Ok(false);
+        }
+
+        if !is_retry {
+            self.start_gpu_wakeup(niri, node)?;
+            return Err(());
+        }
+
+        self.gpu_manager
+            .as_mut()
+            .add_node(render_node, gbm)
+            .map_err(|err| {
+                warn!("error re-adding render node {render_node:?}: {err:?}");
+            })?;
+
+        self.sync_gpu_manager_devices();
+
+        {
+            let power = self.gpu_power_state_mut(node);
+            *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) = WakeupState::Cancelled;
+            power.suspended = false;
+            power.waking_up = false;
+            power.resume_attempts = 0;
+        };
+
+        Ok(true)
+    }
+
+    pub(crate) fn device_changed(&mut self, device_id: dev_t, niri: &mut Niri, cleanup: bool) {
         debug!("device changed: {device_id}");
 
         let Ok(node) = DrmNode::from_dev_id(device_id) else {
@@ -949,6 +2191,34 @@ impl Tty {
             return;
         }
 
+        let key = self.gpu_power_key(node);
+        let state = self
+            .gpu_power
+            .get(&key)
+            .map(|power| (power.waking_up, power.suspended));
+
+        if let Some((waking_up, suspended)) = state {
+            if waking_up {
+                // Duplicate udev events get dropped during wakeup: on success we replay one,
+                // on failure the device is marked failed and ignored, so nothing is lost either way.
+                debug!("holding udev event until wakeup is done");
+                return;
+            }
+            if suspended {
+                debug!(
+                    "secondary GPU {device_id} is suspended, triggering async wakeup instead of scanning connectors"
+                );
+                if let Err(err) = self.start_gpu_wakeup(niri, node) {
+                    warn!("failed to start async GPU wakeup for device {device_id}: {err:?}");
+                }
+                return;
+            }
+        }
+
+        if let Some(power) = self.gpu_power.get_mut(&key) {
+            power.resume_attempts = 0;
+        }
+
         if self.ignored_nodes.contains(&node) {
             debug!("node is ignored, skipping");
             return;
@@ -958,7 +2228,7 @@ impl Tty {
             if let Some(path) = node.dev_path() {
                 warn!("unknown device; trying to add");
 
-                if let Err(err) = self.device_added(device_id, &path, niri) {
+                if let Err(err) = self.device_added(device_id, &path, niri, false) {
                     warn!("error adding device: {err:?}");
                 }
             } else {
@@ -1139,8 +2409,16 @@ impl Tty {
             return;
         }
 
+        let key = self.gpu_power_key(node);
+
         let Some(device) = self.devices.get_mut(&node) else {
-            warn!("unknown device");
+            // Stop the wakeup thread if udev removed the device first.
+            if self.pending_device_inits.contains_key(&node) {
+                self.remove_pending_device_init(niri, &node);
+                debug!("cancelled pending async GPU init for removed device {node:?}");
+            } else {
+                warn!("unknown device");
+            }
             return;
         };
 
@@ -1157,6 +2435,24 @@ impl Tty {
         let mut device = self.devices.remove(&node).unwrap();
         let device_fd = device.drm.device_fd().device_fd();
 
+        let was_last_primary_user = if let Some(render_node) = device.render_node {
+            !self
+                .devices
+                .values()
+                .any(|device| device.render_node == Some(render_node))
+        } else {
+            true
+        };
+
+        if was_last_primary_user {
+            self.cancel_gpu_power_timer_by_key(niri, key);
+            if let Some(power) = self.gpu_power.get(&key) {
+                *power.wakeup_state.lock().unwrap_or_else(|e| e.into_inner()) =
+                    WakeupState::Cancelled;
+            }
+            self.gpu_power.remove(&key);
+        }
+
         if let Some(lease_state) = &mut device.drm_lease_state {
             lease_state.disable_global::<State>();
         }
@@ -1165,10 +2461,14 @@ impl Tty {
             // Sometimes (Asahi DisplayLink), multiple primary nodes will correspond to the same
             // render node. In this case, we want to keep the render node active until the last
             // primary node that uses it is gone.
-            let was_last = !self
-                .devices
-                .values()
-                .any(|device| device.render_node == Some(render_node));
+            let was_last = !self.devices.iter().any(|(other_node, other)| {
+                other.render_node == Some(render_node)
+                    && !self
+                        .gpu_power
+                        .get(&self.gpu_power_key(*other_node))
+                        .map(|p| p.suspended)
+                        .unwrap_or(false)
+            });
 
             if was_last && render_node == self.primary_render_node {
                 debug!("destroying the primary renderer");
@@ -1210,8 +2510,9 @@ impl Tty {
 
             if was_last {
                 self.gpu_manager.as_mut().remove_node(&render_node);
-                // Trigger re-enumeration in order to remove the device from gpu_manager.
-                let _ = self.gpu_manager.devices();
+                // Nudge gpu_manager to forget the removed render node.
+                self.sync_gpu_manager_devices();
+                self.update_dmabuf_feedbacks(niri);
             }
         }
 
@@ -2356,7 +3657,7 @@ impl Tty {
         }
 
         for (device_id, path) in device_list {
-            if let Err(err) = self.device_added(device_id, &path, niri) {
+            if let Err(err) = self.device_added(device_id, &path, niri, false) {
                 warn!("error adding device {path:?}: {err:?}");
             }
         }
@@ -2572,13 +3873,59 @@ impl Tty {
         // startup, when multiple connectors appear at once.
         to_connect.sort_unstable_by(|a, b| a.3.compare(&b.3));
 
+        let mut gpu_topology_changed = false;
+        let mut failed_resume_nodes = HashSet::new();
+
         for (node, connector, crtc, _name) in to_connect {
+            if failed_resume_nodes.contains(&node) {
+                continue;
+            }
+
+            // Smithay wants the renderer back before we touch connectors.
+            match self.resume_device(niri, node, false) {
+                Ok(true) => gpu_topology_changed = true,
+                Ok(false) => {}
+                Err(_) => {
+                    failed_resume_nodes.insert(node);
+                    continue;
+                }
+            }
+
             if let Err(err) = self.connector_connected(niri, node, connector, crtc) {
                 warn!("error connecting connector: {err:?}");
             }
         }
 
         self.refresh_ipc_outputs(niri);
+
+        let nodes: Vec<_> = self.devices.keys().copied().collect();
+        for node in nodes {
+            let key = self.gpu_power_key(node);
+            let disable_suspend = self.config.borrow().debug.disable_idle_drm_device_suspend
+                || self
+                    .gpu_power
+                    .get(&key)
+                    .map(|p| p.disable_suspend_due_to_nvidia_vram)
+                    .unwrap_or(false);
+            if disable_suspend {
+                if let Some(power) = self.gpu_power.get_mut(&key) {
+                    power.wakeup_failed = false;
+                }
+                if !failed_resume_nodes.contains(&node) {
+                    match self.resume_device(niri, node, false) {
+                        Ok(true) => gpu_topology_changed = true,
+                        Ok(false) => {}
+                        Err(_) => {}
+                    }
+                }
+            } else {
+                self.check_suspend_device(niri, node);
+            }
+        }
+
+        if gpu_topology_changed {
+            self.update_dmabuf_feedbacks(niri);
+        }
     }
 
     pub fn get_device_from_node(&mut self, node: DrmNode) -> Option<&mut OutputDevice> {
@@ -2999,9 +4346,9 @@ fn queue_estimated_vblank_timer(
     let token = niri
         .event_loop
         .insert_source(timer, move |_, _, data| {
-            data.backend
-                .tty()
-                .on_estimated_vblank_timer(&mut data.niri, output.clone());
+            if let Some(tty) = data.backend.tty_checked() {
+                tty.on_estimated_vblank_timer(&mut data.niri, output.clone());
+            }
             TimeoutAction::Drop
         })
         .unwrap();
@@ -3670,5 +5017,130 @@ mod tests {
             ),
         }
         "#);
+    }
+
+    #[test]
+    fn test_gpu_power_state_migration() {
+        use crate::backend::tty::{migrate_gpu_power_state_map, GpuPowerState, WakeupState};
+        use std::collections::HashMap;
+        use std::sync::{Arc, Mutex};
+
+        let event_loop = calloop::EventLoop::<()>::try_new().unwrap();
+        let handle = event_loop.handle();
+        let suspend_token = handle
+            .insert_source(
+                calloop::timer::Timer::from_duration(std::time::Duration::from_millis(100)),
+                |_, _, _| calloop::timer::TimeoutAction::Drop,
+            )
+            .unwrap();
+        let wakeup_token = handle
+            .insert_source(
+                calloop::timer::Timer::from_duration(std::time::Duration::from_millis(100)),
+                |_, _, _| calloop::timer::TimeoutAction::Drop,
+            )
+            .unwrap();
+
+        let early_key = 1u32;
+        let actual_key = 2u32;
+
+        let mut gpu_power = HashMap::new();
+
+        // 1. Setup early state with active timers and pending wakeup
+        let mut early_state = GpuPowerState::new(false);
+        early_state.waking_up = true;
+        early_state.suspend_timer = Some(suspend_token);
+        early_state.wakeup_timer = Some(wakeup_token);
+        let early_wakeup = Arc::new(Mutex::new(WakeupState::Pending));
+        early_state.wakeup_state = early_wakeup.clone();
+        gpu_power.insert(early_key, early_state);
+
+        // 2. Scenario A: Migrate to a non-existent actual_key
+        let tokens = migrate_gpu_power_state_map(&mut gpu_power, early_key, actual_key);
+        // Verify both tokens are returned for cancellation
+        assert_eq!(tokens.len(), 2);
+        assert!(tokens.contains(&suspend_token));
+        assert!(tokens.contains(&wakeup_token));
+
+        assert!(!gpu_power.contains_key(&early_key));
+        assert!(gpu_power.contains_key(&actual_key));
+
+        // 3. Scenario B: Try migrating when actual_key already exists (shared node collision)
+        let mut shared_early = GpuPowerState::new(false);
+        shared_early.waking_up = true;
+        let shared_wakeup = Arc::new(Mutex::new(WakeupState::Pending));
+        shared_early.wakeup_state = shared_wakeup.clone();
+        gpu_power.insert(early_key, shared_early);
+
+        let tokens = migrate_gpu_power_state_map(&mut gpu_power, early_key, actual_key);
+        assert!(tokens.is_empty());
+
+        assert!(!gpu_power.contains_key(&early_key));
+        assert!(gpu_power.contains_key(&actual_key));
+        assert!(matches!(
+            *shared_wakeup.lock().unwrap(),
+            WakeupState::Cancelled
+        ));
+
+        // 4. Scenario C: Migrate when early_key == actual_key (no-op)
+        let early_key_c = 3u32;
+        let mut state_c = GpuPowerState::new(false);
+        state_c.waking_up = true;
+        gpu_power.insert(early_key_c, state_c);
+
+        let tokens = migrate_gpu_power_state_map(&mut gpu_power, early_key_c, early_key_c);
+        assert!(tokens.is_empty());
+        assert!(gpu_power.contains_key(&early_key_c));
+        assert!(gpu_power.get(&early_key_c).unwrap().waking_up);
+    }
+
+    #[test]
+    fn test_gpu_power_state_transitions() {
+        use crate::backend::tty::{should_start_gpu_wakeup, GpuPowerState};
+
+        let mut state = GpuPowerState::new(false);
+
+        // 1. Fresh state: should allow wakeup
+        assert!(should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+
+        // 2. Waking up state: should block normal, but allow retry
+        state.waking_up = true;
+        assert!(!should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+
+        // 3. Reset waking up, set wakeup failed: should block normal, but allow retry
+        state.waking_up = false;
+        state.wakeup_failed = true;
+        assert!(!should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+
+        // 4. Reset wakeup failed: should allow wakeup again
+        state.wakeup_failed = false;
+        assert!(should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+    }
+
+    #[test]
+    fn test_wakeup_failed_reset_and_retry() {
+        use crate::backend::tty::{should_start_gpu_wakeup, GpuPowerState};
+
+        let mut state = GpuPowerState::new(false);
+        // clean slate, nothing blocking either path
+        assert!(should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+
+        // wakeup_failed stops the normal path, retries still go through (same deal as waking_up)
+        state.wakeup_failed = true;
+        assert!(!should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
+
+        // resume clears the flag so we can talk to the GPU again
+        state.wakeup_failed = false;
+        assert!(should_start_gpu_wakeup(&state, false));
+
+        // waking_up and wakeup_failed should look the same to is_retry
+        state.waking_up = true;
+        assert!(!should_start_gpu_wakeup(&state, false));
+        assert!(should_start_gpu_wakeup(&state, true));
     }
 }

--- a/src/dbus/freedesktop_login1.rs
+++ b/src/dbus/freedesktop_login1.rs
@@ -2,8 +2,41 @@ use futures_util::StreamExt;
 use zbus::fdo;
 use zbus::names::InterfaceName;
 
+#[zbus::proxy(
+    interface = "org.freedesktop.login1.Manager",
+    default_service = "org.freedesktop.login1",
+    default_path = "/org/freedesktop/login1"
+)]
+trait Login1Manager {
+    #[zbus(signal)]
+    fn prepare_for_sleep(&self, start: bool) -> zbus::Result<()>;
+}
+
 pub enum Login1ToNiri {
     LidClosedChanged(bool),
+    PrepareForSleep(bool),
+}
+
+pub fn take_sleep_inhibitor(conn: &zbus::blocking::Connection) -> Option<std::os::fd::OwnedFd> {
+    let proxy = zbus::blocking::Proxy::new(
+        conn,
+        "org.freedesktop.login1",
+        "/org/freedesktop/login1",
+        "org.freedesktop.login1.Manager",
+    )
+    .ok()?;
+    let fd: zbus::zvariant::OwnedFd = proxy
+        .call(
+            "Inhibit",
+            &("sleep", "niri", "Preparing GPU for sleep", "delay"),
+        )
+        .ok()?;
+    Some(fd.into())
+}
+
+pub fn take_sleep_inhibitor_system() -> Option<std::os::fd::OwnedFd> {
+    let conn = zbus::blocking::Connection::system().ok()?;
+    take_sleep_inhibitor(&conn)
 }
 
 pub fn start(
@@ -12,6 +45,31 @@ pub fn start(
     let conn = zbus::blocking::Connection::system()?;
 
     let async_conn = conn.inner().clone();
+
+    // Listen for system PrepareForSleep signals.
+    let manager_proxy = Login1ManagerProxy::builder(&async_conn).build();
+    let to_niri_sleep = to_niri.clone();
+    async_conn
+        .executor()
+        .spawn(
+            async move {
+                let Ok(proxy) = manager_proxy.await else {
+                    return;
+                };
+                let Ok(mut stream) = proxy.receive_prepare_for_sleep().await else {
+                    return;
+                };
+                while let Some(signal) = stream.next().await {
+                    if let Ok(args) = signal.args() {
+                        debug!("login1 PrepareForSleep signal: start={}", args.start);
+                        let _ = to_niri_sleep.send(Login1ToNiri::PrepareForSleep(args.start));
+                    }
+                }
+            },
+            "monitor login1 PrepareForSleep",
+        )
+        .detach();
+
     let future = async move {
         let proxy = fdo::PropertiesProxy::new(
             &async_conn,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -539,8 +539,9 @@ impl ForeignToplevelHandler for State {
     fn activate(&mut self, wl_surface: WlSurface) {
         if let Some((mapped, _)) = self.niri.layout.find_window_and_output(&wl_surface) {
             let window = mapped.window.clone();
-            self.niri.layout.activate_window(&window);
             self.niri.layer_shell_on_demand_focus = None;
+            self.update_keyboard_focus();
+            self.focus_window(&window);
             self.niri.queue_redraw_all();
         }
     }
@@ -721,11 +722,15 @@ impl DrmLeaseHandler for State {
 
     fn lease_destroyed(&mut self, node: DrmNode, lease_id: u32) {
         debug!("Destroyed lease");
+        let Some(device) = self.backend.tty().get_device_from_node(node) else {
+            warn!("lease destroyed for unknown DRM device {node:?}");
+            return;
+        };
+        device.remove_lease(lease_id);
+        // kick off the suspend debounce now that a lease is gone
         self.backend
             .tty()
-            .get_device_from_node(node)
-            .unwrap()
-            .remove_lease(lease_id);
+            .check_suspend_device(&mut self.niri, node);
     }
 }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -540,8 +540,9 @@ impl ForeignToplevelHandler for State {
     fn activate(&mut self, wl_surface: WlSurface) {
         if let Some((mapped, _)) = self.niri.layout.find_window_and_output(&wl_surface) {
             let window = mapped.window.clone();
-            self.niri.layout.activate_window(&window);
             self.niri.layer_shell_on_demand_focus = None;
+            self.update_keyboard_focus();
+            self.focus_window(&window);
             self.niri.queue_redraw_all();
         }
     }
@@ -726,11 +727,15 @@ impl DrmLeaseHandler for State {
 
     fn lease_destroyed(&mut self, node: DrmNode, lease_id: u32) {
         debug!("Destroyed lease");
+        let Some(device) = self.backend.tty().get_device_from_node(node) else {
+            warn!("lease destroyed for unknown DRM device {node:?}");
+            return;
+        };
+        device.remove_lease(lease_id);
+        // kick off the suspend debounce now that a lease is gone
         self.backend
             .tty()
-            .get_device_from_node(node)
-            .unwrap()
-            .remove_lease(lease_id);
+            .check_suspend_device(&mut self.niri, node);
     }
 }
 delegate_drm_lease!(State);

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2206,10 +2206,16 @@ impl State {
 
     #[cfg(feature = "dbus")]
     pub fn on_login1_msg(&mut self, msg: Login1ToNiri) {
-        let Login1ToNiri::LidClosedChanged(is_closed) = msg;
-
-        trace!("login1 lid {}", if is_closed { "closed" } else { "opened" });
-        self.set_lid_closed(is_closed);
+        match msg {
+            Login1ToNiri::LidClosedChanged(is_closed) => {
+                trace!("login1 lid {}", if is_closed { "closed" } else { "opened" });
+                self.set_lid_closed(is_closed);
+            }
+            Login1ToNiri::PrepareForSleep(start) => {
+                debug!("login1 prepare for sleep: start={start}");
+                self.backend.on_prepare_for_sleep(&mut self.niri, start);
+            }
+        }
     }
 
     #[cfg(feature = "dbus")]

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2226,10 +2226,16 @@ impl State {
 
     #[cfg(feature = "dbus")]
     pub fn on_login1_msg(&mut self, msg: Login1ToNiri) {
-        let Login1ToNiri::LidClosedChanged(is_closed) = msg;
-
-        trace!("login1 lid {}", if is_closed { "closed" } else { "opened" });
-        self.set_lid_closed(is_closed);
+        match msg {
+            Login1ToNiri::LidClosedChanged(is_closed) => {
+                trace!("login1 lid {}", if is_closed { "closed" } else { "opened" });
+                self.set_lid_closed(is_closed);
+            }
+            Login1ToNiri::PrepareForSleep(start) => {
+                debug!("login1 prepare for sleep: start={start}");
+                self.backend.on_prepare_for_sleep(&mut self.niri, start);
+            }
+        }
     }
 
     #[cfg(feature = "dbus")]


### PR DESCRIPTION
### What

Lets secondary GPUs power down when nothing is using them.

Aimed at hybrid laptops and eGPU setups where a dGPU isn't driving any output and has no active DRM leases. In that state, niri lets the device runtime-suspend (all the way down to ACPI `D3cold` where supported). The primary GPU is never suspended.

### Why

On my AMD 780M + RTX 5060 laptop, the NVIDIA dGPU stayed awake with no display and no workload — burning power and making heat for nothing. This lets it sleep while keeping enough compositor state around to bring it back when needed.

### How

* Power management state (`GpuPowerState`) in `Tty` is keyed by the physical `render_node` (falling back to the primary node). That also covers setups where several DRM nodes point at one physical GPU, like Asahi DisplayLink.
* When a secondary GPU has no active outputs or leases, a 10s debounce timer runs before its render node gets dropped from `gpu_manager`.
* The DRM fd stays open so the Wayland session survives; EGL state is re-created on wakeup.
* Wakeup runs on a background thread so the compositor doesn't block while the PCIe link comes back. Generation tracking (via `Arc<Mutex<WakeupState>>`) cancels stale wakeup threads and avoids races.
* Zero-spin `GpuGate` and `GpuLease` built on `Condvar` for active lease tracking, plus a background `niri-gpu-quiesce` thread that holds logind sleep inhibitors while leases drain.
* Duplicate udev events during wakeup are dropped — on success niri refreshes connectors itself, on failure the device is parked, so dropping them is safe.
* Runtime suspend is off for NVIDIA unless `PreserveVideoMemoryAllocations` is enabled, since suspending without it corrupts EGL contexts.
* Added a `disable-idle-drm-device-suspend` debug flag as an escape hatch.

### Related Issues

Ref #678, #3384, #3993, #4097, #4266

### Testing

Tested on AMD 780M + RTX 5060, proprietary NVIDIA driver, open kernel modules, dynamic power management on.

* **Idle:** unplugging the display starts the 10s timer, GPU cleanly reaches `suspended`. Replugging during the debounce cancels it.
* **PRIME offload:** launching Steam or other offloaded apps wakes the GPU, it suspends again after exit. No visible stutter.
* **Resume:** hotplug and offload wake it every time, no compositor hangs.

#### Logs: dGPU suspend and debounce
```
DEBUG niri::backend::tty: secondary GPU DrmNode { dev: 57857, ty: Primary } idle, suspending in 10s
DEBUG niri::backend::tty: secondary GPU DrmNode { dev: 57857, ty: Primary } timer up, suspending
```

#### Sysfs state when idle
```
/sys/class/drm/card2
power/control=auto
power/runtime_status=suspended
power/runtime_suspended_time=1302960
```

#### Logs: asynchronous wakeup
```
DEBUG niri::backend::tty: waking GPU DrmNode { dev: 57857, ty: Primary } in background thread
DEBUG niri::backend::tty: GPU DrmNode { dev: 57857, ty: Primary } is back, resuming
```

### Notes

* Didn't test VR or DRM leasing — this covers normal outputs and PRIME flows.
* **Caveat:** legacy clients that ignore dmabuf feedback v4 may keep allocating buffers with dGPU modifiers after suspend. If that bites you, turn suspend off with `disable-idle-drm-device-suspend` in the config.
* There's an experimental VR branch, separate from this PR: https://github.com/gimgiwer/niri/tree/gpu-suspend-vr
