### PR TITLE
ipc: expose atomic cursor state

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -119,6 +119,8 @@ pub enum Request {
     OverviewState,
     /// Request information about screencasts.
     Casts,
+    /// Request the current global cursor position and image state.
+    CursorState,
 }
 
 /// Reply from niri to client.
@@ -165,6 +167,30 @@ pub enum Response {
     OverviewState(Overview),
     /// Information about screencasts.
     Casts(Vec<Cast>),
+    /// Current global cursor position and image state.
+    CursorState(CursorState),
+}
+
+/// Cursor state sampled atomically with its global position.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct CursorState {
+    /// Global cursor position in logical pixels.
+    pub position: [f64; 2],
+    /// Current compositor-visible cursor image.
+    pub image: CursorImage,
+}
+
+/// Compositor-visible cursor image classification.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub enum CursorImage {
+    /// A standard Wayland cursor shape such as `text` or `pointer`.
+    Named(String),
+    /// An application-owned cursor surface with no portable shape name.
+    Surface,
+    /// A hidden cursor.
+    Hidden,
 }
 
 /// Overview information.
@@ -2163,5 +2189,24 @@ mod tests {
         );
         assert!("-".parse::<PositionChange>().is_err());
         assert!("10% ".parse::<PositionChange>().is_err());
+    }
+
+    #[test]
+    fn cursor_state_ipc_messages_round_trip() {
+        let request = serde_json::to_string(&Request::CursorState).unwrap();
+        assert!(matches!(
+            serde_json::from_str::<Request>(&request).unwrap(),
+            Request::CursorState
+        ));
+
+        let state = CursorState {
+            position: [123.5, 456.25],
+            image: CursorImage::Named("text".to_owned()),
+        };
+        let response = serde_json::to_string(&Response::CursorState(state.clone())).unwrap();
+        let Response::CursorState(actual) = serde_json::from_str(&response).unwrap() else {
+            panic!("cursor state response did not deserialize");
+        };
+        assert_eq!(actual, state);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,8 @@ pub enum Msg {
     OverviewState,
     /// List screencasts.
     Casts,
+    /// Print the current global cursor position and image state.
+    CursorState,
 }
 
 #[derive(Clone, Debug, clap::ValueEnum)]

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -49,6 +49,7 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::RequestError => Request::ReturnError,
         Msg::OverviewState => Request::OverviewState,
         Msg::Casts => Request::Casts,
+        Msg::CursorState => Request::CursorState,
     };
 
     let mut socket = Socket::connect().context("error connecting to the niri socket")?;
@@ -548,6 +549,21 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
             for cast in casts {
                 print_cast(&cast);
                 println!();
+            }
+        }
+        Msg::CursorState => {
+            let Response::CursorState(state) = response else {
+                bail!("unexpected response: expected CursorState, got {response:?}");
+            };
+            if json {
+                println!("{}", serde_json::to_string(&state)?);
+            } else {
+                let image = match state.image {
+                    niri_ipc::CursorImage::Named(name) => name,
+                    niri_ipc::CursorImage::Surface => "surface".to_owned(),
+                    niri_ipc::CursorImage::Hidden => "hidden".to_owned(),
+                };
+                println!("{},{},{}", state.position[0], state.position[1], image);
             }
         }
     }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -17,8 +17,8 @@ use futures_util::{select_biased, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, Fu
 use niri_config::OutputName;
 use niri_ipc::state::{EventStreamState, EventStreamStatePart as _};
 use niri_ipc::{
-    Action, Event, KeyboardLayouts, OutputConfigChanged, Overview, Reply, Request, Response,
-    Timestamp, WindowLayout, Workspace,
+    Action, CursorImage, CursorState, Event, KeyboardLayouts, OutputConfigChanged, Overview, Reply,
+    Request, Response, Timestamp, WindowLayout, Workspace,
 };
 use smithay::desktop::layer_map_for_output;
 use smithay::input::pointer::{
@@ -454,6 +454,26 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let state = ctx.event_stream_state.borrow();
             let casts = state.casts.casts.values().cloned().collect();
             Response::Casts(casts)
+        }
+        Request::CursorState => {
+            let (tx, rx) = async_channel::bounded(1);
+            ctx.event_loop.insert_idle(move |state| {
+                let position = state.niri.seat.get_pointer().unwrap().current_location();
+                let image = match state.niri.cursor_manager.cursor_image() {
+                    CursorImageStatus::Named(icon) => CursorImage::Named(icon.name().to_owned()),
+                    CursorImageStatus::Surface(_) => CursorImage::Surface,
+                    CursorImageStatus::Hidden => CursorImage::Hidden,
+                };
+                let _ = tx.send_blocking(CursorState {
+                    position: [position.x, position.y],
+                    image,
+                });
+            });
+            let state = rx
+                .recv()
+                .await
+                .map_err(|_| String::from("error getting cursor state"))?;
+            Response::CursorState(state)
         }
     };
 


### PR DESCRIPTION
## Summary

Add `niri msg cursor-state`, with an equivalent JSON response, to return the current global pointer position and compositor-visible cursor image as one snapshot.

## Why

IPC clients that draw or react to the cursor currently need to combine separate observations. Between those observations the pointer can move or the active cursor can change, so the pair can describe two different compositor moments. A single snapshot is useful for screen-recording overlays, input visualizers, accessibility tools, and other integrations that need to mirror the cursor state faithfully.

## Scope

- The API exposes only the current state; it does not add cursor pixel data, cursor-surface contents, subscriptions, or a new event stream.
- Cursor images are intentionally classified as a named standard shape, an application-owned surface, or hidden.
- The position and image are sampled together from the compositor event loop.

## Validation

- Added IPC JSON round-trip coverage for the request and response.
- Ran `cargo test --offline -p niri-ipc` and `cargo check --offline`.

I would appreciate feedback on the API shape and naming, especially whether this belongs alongside the existing one-shot IPC queries.