### PR TITLE
feat: add --print-request flag to niri msg

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,10 @@ pub enum Sub {
         /// Format output as JSON.
         #[arg(short, long)]
         json: bool,
+
+        /// Print the request as JSON instead of sending it.
+        #[arg(long)]
+        print_request: bool,
     },
     /// Validate the config file.
     Validate {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -15,7 +15,7 @@ use serde_json::json;
 use crate::cli::Msg;
 use crate::utils::version;
 
-pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
+pub fn handle_msg(mut msg: Msg, json: bool, print_request: bool) -> anyhow::Result<()> {
     // For actions taking paths, prepend the niri CLI's working directory.
     if let Msg::Action {
         action:
@@ -50,6 +50,10 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::OverviewState => Request::OverviewState,
         Msg::Casts => Request::Casts,
     };
+    if print_request {
+        println!("{}", serde_json::to_string(&request)?);
+        return Ok(());
+    }
 
     let mut socket = Socket::connect().context("error connecting to the niri socket")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,8 +106,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 info!("config is valid");
                 return Ok(());
             }
-            Sub::Msg { msg, json } => {
-                handle_msg(msg, json)?;
+            Sub::Msg {
+                msg,
+                json,
+                print_request,
+            } => {
+                handle_msg(msg, json, print_request)?;
                 return Ok(());
             }
             Sub::Panic => cause_panic(),


### PR DESCRIPTION
## Summary
- Adds `--print-request` to `niri msg`. When set, prints the constructed request as JSON to stdout instead of connecting to the socket and sending it — no niri instance required to run it.
- Addresses the `--print-request` half of #3903 (nicer alternative to the `socat` request-building workaround documented at https://niri-wm.github.io/niri/IPC.html#programmatic-access).
- The second half of #3903 (a `niri msg` command to send a raw JSON request from stdin) is intentionally left out of this PR to keep the change small — happy to follow up if wanted.

## Test plan
- [x] `cargo check --bin niri` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --bin niri -- -D warnings` — clean
- [ ] Manual run of `niri msg --print-request <subcommand>` against a live compositor session (not available in this dev environment)