### PR TITLE
fix: ignore subpixel scroll when activating columns

### DIFF
--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1429,7 +1429,15 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let new_col_x = self.column_x(column_idx);
         let from_view_offset = target_x - new_col_x;
 
-        (from_view_offset - new_view_offset).abs() / self.working_area.size.w
+        let amount = (from_view_offset - new_view_offset).abs();
+
+        // Column activation treats changes smaller than one physical pixel as no movement.
+        // Mirror that tolerance here so rounding noise does not prevent focus-follows-mouse.
+        if amount < 1. / self.scale {
+            return 0.;
+        }
+
+        amount / self.working_area.size.w
     }
 
     pub fn activate_window(&mut self, window: &W::Id) -> bool {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -3732,6 +3732,51 @@ fn workspace_render_geo_at_fractional_scale() {
     );
 }
 
+#[test]
+fn fully_visible_column_needs_no_scroll_at_fractional_scale() {
+    let options = Options {
+        layout: niri_config::Layout {
+            gaps: 8.,
+            struts: Struts {
+                left: FloatOrInt(2.),
+                right: FloatOrInt(2.),
+                top: FloatOrInt(2.),
+                bottom: FloatOrInt(2.),
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let ops = [
+        Op::AddScaledOutput {
+            id: 1,
+            scale: 2.3,
+            layout_config: None,
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::Communicate(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::Communicate(2),
+        Op::FocusWindow(2),
+        Op::CompleteAnimations,
+    ];
+
+    let layout = check_ops_with_options(options, ops);
+    let workspace = layout.active_workspace().unwrap();
+    let working_area = workspace.working_area();
+
+    for (tile, pos, _) in workspace.tiles_with_render_positions() {
+        let tile_geo = Rectangle::new(pos, tile.tile_size());
+        assert!(working_area.contains_rect(tile_geo));
+    }
+
+    assert_eq!(layout.scroll_amount_to_activate(&1), 0.);
+}
+
 fn parent_id_causes_loop(layout: &Layout<TestWindow>, id: usize, mut parent_id: usize) -> bool {
     if parent_id == id {
         return true;


### PR DESCRIPTION
At fractional output scales, fully visible adjacent columns can yield a tiny
nonzero result from `scroll_amount_to_activate`. With
`focus-follows-mouse max-scroll-amount="0%"`, that rounding residue prevents
hover focus.

Treat view changes smaller than one physical pixel as zero, matching
`animate_view_offset_with_config`, and add a regression test using fractional
scale, gaps, and struts.

This addresses the focus-follows-mouse case reported in #3790, which was
marked as a duplicate of #1402.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --all --exclude niri-visual-tests -- --nocapture --skip=::egl`
- `cargo clippy --all --all-targets`

## Manual validation

- Compared unpatched commit `0777769e` with this PR's `6fde0c6` build in
  otherwise identical nested compositor sessions: scale `2.3`, gaps `8`,
  struts `2`, `max-scroll-amount="0%"`, and two fully visible Kitty columns.
- Unpatched: pointer crossings did not change focus and emitted no
  `WindowFocusChanged` events.
- Patched: pointer crossings changed focus on every crossing and emitted the
  expected alternating `WindowFocusChanged` events.
- Deployed the patched build on a daily-driver NixOS session and repeated the
  test with Thunar and Kitty in adjacent columns on the same scale `2.3`
  output. Focus followed the pointer in both directions at `0%`, with the live
  event stream confirming alternating focus events.
