### PR TITLE
fix(handlers): unblock minimize requests and fix foreign-toplevel activation focus

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -540,8 +540,9 @@ impl ForeignToplevelHandler for State {
     fn activate(&mut self, wl_surface: WlSurface) {
         if let Some((mapped, _)) = self.niri.layout.find_window_and_output(&wl_surface) {
             let window = mapped.window.clone();
-            self.niri.layout.activate_window(&window);
             self.niri.layer_shell_on_demand_focus = None;
+            self.update_keyboard_focus();
+            self.focus_window(&window);
             self.niri.queue_redraw_all();
         }
     }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -539,8 +539,9 @@ impl ForeignToplevelHandler for State {
     fn activate(&mut self, wl_surface: WlSurface) {
         if let Some((mapped, _)) = self.niri.layout.find_window_and_output(&wl_surface) {
             let window = mapped.window.clone();
-            self.niri.layout.activate_window(&window);
             self.niri.layer_shell_on_demand_focus = None;
+            self.update_keyboard_focus();
+            self.focus_window(&window);
             self.niri.queue_redraw_all();
         }
     }

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -875,6 +875,17 @@ impl XdgShellHandler for State {
         }
     }
 
+    fn minimize_request(&mut self, toplevel: ToplevelSurface) {
+        if let Some((mapped, _)) = self
+            .niri
+            .layout
+            .find_window_and_output_mut(toplevel.wl_surface())
+        {
+            // Send a configure because some clients stop committing frames after requesting minimize.
+            mapped.set_needs_configure();
+        }
+    }
+
     fn toplevel_destroyed(&mut self, surface: ToplevelSurface) {
         if self
             .niri

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -817,6 +817,17 @@ impl XdgShellHandler for State {
         }
     }
 
+    fn minimize_request(&mut self, toplevel: ToplevelSurface) {
+        if let Some((mapped, _)) = self
+            .niri
+            .layout
+            .find_window_and_output_mut(toplevel.wl_surface())
+        {
+            // Send a configure because some clients stop committing frames after requesting minimize.
+            mapped.set_needs_configure();
+        }
+    }
+
     fn toplevel_destroyed(&mut self, surface: ToplevelSurface) {
         if self
             .niri


### PR DESCRIPTION
### What
Fixes window freezing on minimize requests (`xdg_toplevel.set_minimized`) and fixes cursor warping when activating windows via `wlr-foreign-toplevel` (docks and taskbars).

### Why
- Niri doesn't implement window minimization (windows stay in the tiling layout). Previously, `XdgShellHandler::minimize_request` was unhandled, causing clients that request minimization (such as GTK, Qt, or Electron apps) to freeze on frame callbacks waiting for a compositor `configure` response.
- Workarounds that triggered full refocusing (`focus_window`) inside `minimize_request` caused unwanted mouse cursor warps back to the window and corrupted the active window state (`xdg_toplevel::State::Activated`), leaving apps with visually inactive header bars.
- When activating windows via dock or taskbar (`wlr-foreign-toplevel`), cursor warping triggered on-output-switch fallback jumps across monitors because keyboard focus wasn't updated prior to `focus_window`.

### How
- **Unblock `minimize_request`**: Implemented `minimize_request` in `XdgShellHandler` to call `mapped.set_needs_configure()`. This sends an updated `xdg_toplevel.configure` with `Activated` status preserved, keeping clients responsive without unexpected cursor warps or focus changes.
- **Fix Activation Focus Order**: Updated `ForeignToplevelHandler::activate` to call `self.update_keyboard_focus()` right after clearing `layer_shell_on_demand_focus` and prior to `self.focus_window(&window)`. This matches the pattern in `confirm_mru()` so cursor warping correctly detects that focus is already on the layout.

### Related Issues

Fixes #3780

### Testing
- Tested across GTK, Qt, and Electron applications.
- **Minimize Request**: Clicking minimize in window titlebars or pressing minimize hotkeys responds immediately without freezing frame rendering or losing active header bar styling.
- **Dock Activation**: Clicking window icons in external docks or status bars across single and multi-monitor setups focuses the target window smoothly and respects `warp-mouse-to-focus` configuration.
- Verified with unit tests (`cargo test` passes all 198 tests cleanly).
