### PR TITLE
fix(render): use to_physical_precise_up in SolidColorRenderElement

### DIFF
--- a/src/render_helpers/solid_color.rs
+++ b/src/render_helpers/solid_color.rs
@@ -130,7 +130,7 @@ impl Element for SolidColorRenderElement {
     }
 
     fn geometry(&self, scale: Scale<f64>) -> Rectangle<i32, Physical> {
-        self.geometry.to_physical_precise_round(scale)
+        self.geometry.to_physical_precise_up(scale)
     }
 
     fn opaque_regions(&self, scale: Scale<f64>) -> OpaqueRegions<i32, Physical> {


### PR DESCRIPTION
### What
Switches `SolidColorRenderElement::geometry` from `to_physical_precise_round` to `to_physical_precise_up`.

### Why
On outputs with fractional scaling (such as 1.5x or 1.25x), precision rounding of logical dimensions can round down by 1 physical pixel compared to the display mode width/height. This leaves a small background sliver on the right or bottom screen edge.

### How
By using `to_physical_precise_up()` (which uses ceiling rounding for the physical rectangle calculation), solid color elements—most notably the workspace background—are guaranteed to span the full physical output area without leaving single-pixel gaps.

### Testing
- `cargo test` passes cleanly (198/198).
- Addresses the output background sliver issue reported in #4294.
