### PR TITLE
nix: bump inputs, pin libdisplay-info_0_3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1785110946,
+        "narHash": "sha256-WWuWxmXKzGZWryswWlijP3Mjp6aGy4Ngmeil5nGMMjk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "d3498f786f97ac0bded21b34bae0bf3809b45aa3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           cairo,
           dbus,
           libGL,
-          libdisplay-info,
+          libdisplay-info_0_3,
           libinput,
           seatd,
           libxkbcommon,
@@ -77,7 +77,7 @@
               cairo
               dbus
               libGL
-              libdisplay-info
+              libdisplay-info_0_3
               libinput
               seatd
               libxkbcommon


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/546004 for rationale, basically `libdisplay-info` 0.4.0 will break build, so Niri should pin to `libdisplay-info` 0.3.0 for now.

There are two commits:

* `nix: bump inputs` to bump Nixpkgs
* `nix: pin libdisplay-info_0_3` to fix build