### PR TITLE
Add named column groups to window rules

### DIFF
--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -43,6 +43,8 @@ window-rule {
     default-window-height { fixed 500; }
     open-on-output "Some Company CoolMonitor 1234"
     open-on-workspace "chat"
+    open-in-column "messaging"
+    open-in-column-order 10
     open-maximized true
     open-maximized-to-edges true
     open-fullscreen true
@@ -422,6 +424,66 @@ window-rule {
     open-on-workspace "chat"
 }
 ```
+
+#### `open-in-column`
+
+Make the window join a named column group.
+
+The first tiled window with a given group name opens in a new column as usual.
+Further tiled windows with the same group name on the same workspace open at the bottom of that column.
+The group name is local to each workspace, so windows never join a group on another workspace.
+
+Use this together with [`open-on-workspace`](#open-on-workspace) to place a set of applications in a predictable workspace and column:
+
+```kdl
+// Open Telegram and Fractal in one column on the "chat" workspace.
+window-rule {
+    match app-id=r#"^org\.telegram\.desktop$"#
+    match app-id=r#"^org\.gnome\.Fractal$"#
+
+    open-on-workspace "chat"
+    open-in-column "messaging"
+}
+```
+
+This property only controls initial window placement.
+You can move or expel windows from the column afterwards, and niri will not move them back.
+If you split a group across multiple columns, a later window joins the first tiled column containing a window with that group name.
+
+Floating windows do not join column groups.
+Parented windows, such as dialogs, continue to open next to their parent instead.
+
+#### `open-in-column-order`
+
+Set the window's position within its named column group.
+Lower integer values open higher in the column.
+
+This makes the result independent of application startup timing.
+For example, Telegram will open above Fractal in this configuration even if Fractal creates its window first:
+
+```kdl
+window-rule {
+    match app-id=r#"^org\.telegram\.desktop$"#
+
+    open-on-workspace "chat"
+    open-in-column "messaging"
+    open-in-column-order 10
+}
+
+window-rule {
+    match app-id=r#"^org\.gnome\.Fractal$"#
+
+    open-on-workspace "chat"
+    open-in-column "messaging"
+    open-in-column-order 20
+}
+```
+
+Windows without `open-in-column-order` open after explicitly ordered windows.
+Windows with the same order retain the order in which they open.
+The order is only applied when a new window opens; changing the configuration does not rearrange windows that are already open, and manual rearrangement remains possible.
+
+`open-in-column-order` has no effect without [`open-in-column`](#open-in-column).
 
 #### `open-maximized`
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -655,6 +655,7 @@ mod tests {
 window-rule {
     match app-id="org.telegram.desktop"
     open-in-column "communications"
+    open-in-column-order 10
 }
 "#,
         )
@@ -664,6 +665,7 @@ window-rule {
             config.window_rules[0].open_in_column.as_deref(),
             Some("communications")
         );
+        assert_eq!(config.window_rules[0].open_in_column_order, Some(10));
     }
 
     #[track_caller]
@@ -1806,6 +1808,7 @@ window-rule {
                     ),
                     open_on_workspace: None,
                     open_in_column: None,
+                    open_in_column_order: None,
                     open_maximized: Some(
                         true,
                     ),

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -648,6 +648,24 @@ mod tests {
         assert_eq!(config.input.keyboard.repeat_rate, 25);
     }
 
+    #[test]
+    fn parse_open_in_column_window_rule() {
+        let config = Config::parse_mem(
+            r#"
+window-rule {
+    match app-id="org.telegram.desktop"
+    open-in-column "communications"
+}
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.window_rules[0].open_in_column.as_deref(),
+            Some("communications")
+        );
+    }
+
     #[track_caller]
     fn do_parse(text: &str) -> Config {
         Config::parse_mem(text)
@@ -1787,6 +1805,7 @@ mod tests {
                         "eDP-1",
                     ),
                     open_on_workspace: None,
+                    open_in_column: None,
                     open_maximized: Some(
                         true,
                     ),

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -27,6 +27,8 @@ pub struct WindowRule {
     #[knuffel(child, unwrap(argument))]
     pub open_in_column: Option<String>,
     #[knuffel(child, unwrap(argument))]
+    pub open_in_column_order: Option<i32>,
+    #[knuffel(child, unwrap(argument))]
     pub open_maximized: Option<bool>,
     #[knuffel(child, unwrap(argument))]
     pub open_maximized_to_edges: Option<bool>,

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -25,6 +25,8 @@ pub struct WindowRule {
     #[knuffel(child, unwrap(argument))]
     pub open_on_workspace: Option<String>,
     #[knuffel(child, unwrap(argument))]
+    pub open_in_column: Option<String>,
+    #[knuffel(child, unwrap(argument))]
     pub open_maximized: Option<bool>,
     #[knuffel(child, unwrap(argument))]
     pub open_maximized_to_edges: Option<bool>,

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -20,7 +20,7 @@ use smithay::{delegate_compositor, delegate_shm};
 
 use super::xdg_shell::add_mapped_toplevel_pre_commit_hook;
 use crate::handlers::XDG_ACTIVATION_TOKEN_TIMEOUT;
-use crate::layout::{ActivateWindow, AddWindowTarget, LayoutElement as _};
+use crate::layout::{ActivateWindow, AddWindowTarget, LayoutElement};
 use crate::niri::{CastTarget, ClientState, LockState, State};
 use crate::utils::transaction::Transaction;
 use crate::utils::{is_mapped, send_scale_transform};
@@ -149,6 +149,7 @@ impl CompositorHandler for State {
                     // before mapping, so we need to compute open_floating at the last possible
                     // moment, that is here.
                     let is_floating = rules.compute_open_floating(toplevel);
+                    let open_in_column = rules.open_in_column.clone();
 
                     // Figure out if we should activate the window.
                     let activate = rules.open_focused.map(|focus| {
@@ -201,9 +202,32 @@ impl CompositorHandler for State {
                     };
                     let window = mapped.window.clone();
 
+                    let target_workspace_id = workspace_id
+                        .or_else(|| {
+                            output.as_ref().and_then(|output| {
+                                self.niri
+                                    .layout
+                                    .monitor_for_output(output)
+                                    .map(|monitor| monitor.active_workspace_ref().id())
+                            })
+                        })
+                        .or_else(|| self.niri.layout.active_workspace().map(|ws| ws.id()));
+                    let column_group_target = (!is_floating && parent.is_none())
+                        .then_some(open_in_column.as_deref())
+                        .flatten()
+                        .zip(target_workspace_id)
+                        .and_then(|(group, workspace_id)| {
+                            self.niri
+                                .layout
+                                .window_in_column_group(workspace_id, group)
+                                .map(|window| LayoutElement::id(window).clone())
+                        });
+
                     let target = if let Some(p) = &parent {
                         // Open dialogs next to their parent window.
                         AddWindowTarget::NextTo(p)
+                    } else if let Some(group_target) = &column_group_target {
+                        AddWindowTarget::InColumn(group_target)
                     } else if let Some(id) = workspace_id {
                         AddWindowTarget::Workspace(id)
                     } else if let Some(output) = &output {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -523,6 +523,8 @@ pub enum AddWindowTarget<'a, W: LayoutElement> {
     Workspace(WorkspaceId),
     /// Next to this existing window.
     NextTo(&'a W::Id),
+    /// At the bottom of this existing window's column.
+    InColumn(&'a W::Id),
 }
 
 /// Type of the window hit from `window_under()`.
@@ -999,6 +1001,15 @@ impl<W: LayoutElement> Layout<W> {
                             (mon_idx, MonitorAddWindowTarget::NextTo(next_to))
                         }
                     }
+                    AddWindowTarget::InColumn(in_column) => {
+                        let mon_idx = monitors
+                            .iter()
+                            .position(|mon| {
+                                mon.workspaces.iter().any(|ws| ws.has_window(in_column))
+                            })
+                            .unwrap();
+                        (mon_idx, MonitorAddWindowTarget::InColumn(in_column))
+                    }
                 };
                 let mon = &mut monitors[mon_idx];
 
@@ -1081,6 +1092,13 @@ impl<W: LayoutElement> Layout<W> {
                                 .unwrap();
                             (ws_idx, WorkspaceAddWindowTarget::NextTo(next_to))
                         }
+                    }
+                    AddWindowTarget::InColumn(in_column) => {
+                        let ws_idx = workspaces
+                            .iter()
+                            .position(|ws| ws.has_window(in_column))
+                            .unwrap();
+                        (ws_idx, WorkspaceAddWindowTarget::InColumn(in_column))
                     }
                 };
                 let ws = &mut workspaces[ws_idx];
@@ -4994,6 +5012,18 @@ impl<W: LayoutElement> Layout<W> {
             .flat_map(|(mon, _, ws)| ws.windows().map(move |win| (mon, win)));
 
         moving_window.chain(rest)
+    }
+
+    /// Finds a tiled window carrying this column-group name on the target workspace.
+    pub fn window_in_column_group(&self, workspace_id: WorkspaceId, group: &str) -> Option<&W> {
+        let (_, _, workspace) = self
+            .workspaces()
+            .find(|(_, _, workspace)| workspace.id() == workspace_id)?;
+
+        workspace.windows().find(|window| {
+            !workspace.is_floating(window.id())
+                && window.rules().open_in_column.as_deref() == Some(group)
+        })
     }
 
     pub fn has_window(&self, window: &W::Id) -> bool {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -173,6 +173,8 @@ pub enum MonitorAddWindowTarget<'a, W: LayoutElement> {
     },
     /// Next to this existing window.
     NextTo(&'a W::Id),
+    /// At the bottom of this existing window's column.
+    InColumn(&'a W::Id),
 }
 
 impl<'a, W: LayoutElement> Copy for MonitorAddWindowTarget<'a, W> {}
@@ -506,6 +508,14 @@ impl<W: LayoutElement> Monitor<W> {
                     .position(|ws| ws.has_window(win_id))
                     .unwrap();
                 (idx, WorkspaceAddWindowTarget::NextTo(win_id))
+            }
+            MonitorAddWindowTarget::InColumn(win_id) => {
+                let idx = self
+                    .workspaces
+                    .iter()
+                    .position(|ws| ws.has_window(win_id))
+                    .unwrap();
+                (idx, WorkspaceAddWindowTarget::InColumn(win_id))
             }
         }
     }

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -942,6 +942,15 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
     }
 
+    pub fn add_tile_to_window_column(&mut self, window: &W::Id, tile: Tile<W>, activate: bool) {
+        let col_idx = self
+            .columns
+            .iter()
+            .position(|col| col.contains(window))
+            .unwrap();
+        self.add_tile_to_column(col_idx, None, tile, activate);
+    }
+
     pub fn add_tile_right_of(
         &mut self,
         right_of: &W::Id,

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -948,7 +948,20 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             .iter()
             .position(|col| col.contains(window))
             .unwrap();
-        self.add_tile_to_column(col_idx, None, tile, activate);
+
+        let tile_idx = {
+            let rules = tile.window().rules();
+            rules.open_in_column_order.and_then(|new_order| {
+                let group = rules.open_in_column.as_deref();
+                self.columns[col_idx].tiles().position(|(existing, _)| {
+                    let existing_rules = existing.window().rules();
+                    existing_rules.open_in_column.as_deref() == group
+                        && existing_rules.open_in_column_order.unwrap_or(i32::MAX) > new_order
+                })
+            })
+        };
+
+        self.add_tile_to_column(col_idx, tile_idx, tile, activate);
     }
 
     pub fn add_tile_right_of(

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -190,6 +190,8 @@ pub enum WorkspaceAddWindowTarget<'a, W: LayoutElement> {
     NewColumnAt(usize),
     /// Next to this existing window.
     NextTo(&'a W::Id),
+    /// At the bottom of this existing window's column.
+    InColumn(&'a W::Id),
 }
 
 impl OutputId {
@@ -687,6 +689,19 @@ impl<W: LayoutElement> Workspace<W> {
                     if activate {
                         self.floating_is_active = FloatingActive::No;
                     }
+                }
+            }
+            WorkspaceAddWindowTarget::InColumn(in_column) => {
+                let activate = activate.map_smart(|| {
+                    self.active_window()
+                        .is_some_and(|window| window.id() == in_column)
+                });
+
+                self.scrolling
+                    .add_tile_to_window_column(in_column, tile, activate);
+
+                if activate {
+                    self.floating_is_active = FloatingActive::No;
                 }
             }
         }

--- a/src/tests/window_opening.rs
+++ b/src/tests/window_opening.rs
@@ -71,8 +71,14 @@ fn open_in_named_column_group() {
         r#"
 window-rule {
     match title="Telegram"
+    open-in-column "communications"
+    open-in-column-order 10
+}
+
+window-rule {
     match title="ZapZap"
     open-in-column "communications"
+    open-in-column-order 20
 }
 "#,
     )
@@ -81,7 +87,8 @@ window-rule {
     f.add_output(1, (1920, 1080));
 
     let id = f.add_client();
-    for title in ["Telegram", "Unrelated", "ZapZap"] {
+    // Launch in the opposite order to prove that rule order, not map order, wins.
+    for title in ["ZapZap", "Unrelated", "Telegram"] {
         let window = f.client(id).create_window();
         let surface = window.surface.clone();
         window.set_title(title);
@@ -95,12 +102,20 @@ window-rule {
     }
 
     let mut positions = Vec::new();
-    f.niri().layout.with_windows(|_, _, _, layout| {
-        positions.push(layout.pos_in_scrolling_layout.unwrap());
+    f.niri().layout.with_windows(|window, _, _, layout| {
+        let title = with_toplevel_role(window.toplevel(), |role| role.title.clone().unwrap());
+        positions.push((title, layout.pos_in_scrolling_layout.unwrap()));
     });
-    positions.sort_unstable();
+    positions.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
-    assert_eq!(positions, [(1, 1), (1, 2), (2, 1)]);
+    assert_eq!(
+        positions,
+        [
+            (String::from("Telegram"), (1, 1)),
+            (String::from("Unrelated"), (2, 1)),
+            (String::from("ZapZap"), (1, 2)),
+        ]
+    );
 }
 
 #[test]

--- a/src/tests/window_opening.rs
+++ b/src/tests/window_opening.rs
@@ -66,6 +66,44 @@ fn simple() {
 }
 
 #[test]
+fn open_in_named_column_group() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="Telegram"
+    match title="ZapZap"
+    open-in-column "communications"
+}
+"#,
+    )
+    .unwrap();
+    let mut f = Fixture::with_config(config);
+    f.add_output(1, (1920, 1080));
+
+    let id = f.add_client();
+    for title in ["Telegram", "Unrelated", "ZapZap"] {
+        let window = f.client(id).create_window();
+        let surface = window.surface.clone();
+        window.set_title(title);
+        window.commit();
+        f.roundtrip(id);
+
+        let window = f.client(id).window(&surface);
+        window.attach_new_buffer();
+        window.ack_last_and_commit();
+        f.double_roundtrip(id);
+    }
+
+    let mut positions = Vec::new();
+    f.niri().layout.with_windows(|_, _, _, layout| {
+        positions.push(layout.pos_in_scrolling_layout.unwrap());
+    });
+    positions.sort_unstable();
+
+    assert_eq!(positions, [(1, 1), (1, 2), (2, 1)]);
+}
+
+#[test]
 #[should_panic(expected = "Protocol error 3 on object xdg_surface")]
 fn dont_ack_initial_configure() {
     let mut f = Fixture::new();

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -58,6 +58,9 @@ pub struct ResolvedWindowRules {
     /// Workspace to open this window on.
     pub open_on_workspace: Option<String>,
 
+    /// Named column group to join when the window opens.
+    pub open_in_column: Option<String>,
+
     /// Whether the window should open full-width.
     pub open_maximized: Option<bool>,
 
@@ -193,6 +196,7 @@ impl ResolvedWindowRules {
 
             let mut open_on_output = None;
             let mut open_on_workspace = None;
+            let mut open_in_column = None;
 
             for rule in rules {
                 let matches = |m: &Match| {
@@ -235,6 +239,10 @@ impl ResolvedWindowRules {
 
                 if let Some(x) = rule.open_on_workspace.as_deref() {
                     open_on_workspace = Some(x);
+                }
+
+                if let Some(x) = rule.open_in_column.as_deref() {
+                    open_in_column = Some(x);
                 }
 
                 if let Some(x) = rule.open_maximized {
@@ -312,6 +320,7 @@ impl ResolvedWindowRules {
 
             resolved.open_on_output = open_on_output.map(|x| x.to_owned());
             resolved.open_on_workspace = open_on_workspace.map(|x| x.to_owned());
+            resolved.open_in_column = open_in_column.map(|x| x.to_owned());
         });
 
         resolved

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -61,6 +61,9 @@ pub struct ResolvedWindowRules {
     /// Named column group to join when the window opens.
     pub open_in_column: Option<String>,
 
+    /// Sort order within the named column group. Lower values open higher.
+    pub open_in_column_order: Option<i32>,
+
     /// Whether the window should open full-width.
     pub open_maximized: Option<bool>,
 
@@ -197,6 +200,7 @@ impl ResolvedWindowRules {
             let mut open_on_output = None;
             let mut open_on_workspace = None;
             let mut open_in_column = None;
+            let mut open_in_column_order = None;
 
             for rule in rules {
                 let matches = |m: &Match| {
@@ -243,6 +247,10 @@ impl ResolvedWindowRules {
 
                 if let Some(x) = rule.open_in_column.as_deref() {
                     open_in_column = Some(x);
+                }
+
+                if let Some(x) = rule.open_in_column_order {
+                    open_in_column_order = Some(x);
                 }
 
                 if let Some(x) = rule.open_maximized {
@@ -321,6 +329,7 @@ impl ResolvedWindowRules {
             resolved.open_on_output = open_on_output.map(|x| x.to_owned());
             resolved.open_on_workspace = open_on_workspace.map(|x| x.to_owned());
             resolved.open_in_column = open_in_column.map(|x| x.to_owned());
+            resolved.open_in_column_order = open_in_column_order;
         });
 
         resolved


### PR DESCRIPTION
## What

Add `open-in-column` for grouping tiled windows into a named column and `open-in-column-order` for deterministic vertical placement. Includes configuration documentation and tests.

## Why

I needed a way to open windows on top of each other  in a particular workspace on startup. Since, window rules can only select a workspace, but cannot place related applications in the same column. 

## Testing

Created unit tests and been running locally for a week, no issues so far.
