### PR TITLE
ipc: populate tile_pos_in_workspace_view for tiled windows

### DIFF
--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2422,19 +2422,21 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let scale = self.scale;
         let col_xs = self.column_xs(self.data.iter().copied());
         zip(self.columns.iter().enumerate(), col_xs).flat_map(move |((col_idx, col), col_x)| {
-            col.tiles().enumerate().map(move |(tile_idx, (tile, tile_off))| {
-                // Tile position within the workspace view. Excludes animated
-                // offsets (matching the floating equivalent) to avoid IPC spam.
-                let pos = Point::from((col_x - view_pos, 0.)) + tile_off;
-                let pos = pos.to_physical_precise_round(scale).to_logical(scale);
-                let layout = WindowLayout {
-                    // Our indices are 1-based, consistent with the actions.
-                    pos_in_scrolling_layout: Some((col_idx + 1, tile_idx + 1)),
-                    tile_pos_in_workspace_view: Some(pos.into()),
-                    ..tile.ipc_layout_template()
-                };
-                (tile, layout)
-            })
+            col.tiles()
+                .enumerate()
+                .map(move |(tile_idx, (tile, tile_off))| {
+                    // Tile position within the workspace view. Excludes animated
+                    // offsets (matching the floating equivalent) to avoid IPC spam.
+                    let pos = Point::from((col_x - view_pos, 0.)) + tile_off;
+                    let pos = pos.to_physical_precise_round(scale).to_logical(scale);
+                    let layout = WindowLayout {
+                        // Our indices are 1-based, consistent with the actions.
+                        pos_in_scrolling_layout: Some((col_idx + 1, tile_idx + 1)),
+                        tile_pos_in_workspace_view: Some(pos.into()),
+                        ..tile.ipc_layout_template()
+                    };
+                    (tile, layout)
+                })
         })
     }
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2418,19 +2418,24 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     }
 
     pub fn tiles_with_ipc_layouts(&self) -> impl Iterator<Item = (&Tile<W>, WindowLayout)> {
-        self.columns
-            .iter()
-            .enumerate()
-            .flat_map(move |(col_idx, col)| {
-                col.tiles().enumerate().map(move |(tile_idx, (tile, _))| {
-                    let layout = WindowLayout {
-                        // Our indices are 1-based, consistent with the actions.
-                        pos_in_scrolling_layout: Some((col_idx + 1, tile_idx + 1)),
-                        ..tile.ipc_layout_template()
-                    };
-                    (tile, layout)
-                })
+        let view_pos = self.target_view_pos();
+        let scale = self.scale;
+        let col_xs = self.column_xs(self.data.iter().copied());
+        zip(self.columns.iter().enumerate(), col_xs).flat_map(move |((col_idx, col), col_x)| {
+            col.tiles().enumerate().map(move |(tile_idx, (tile, tile_off))| {
+                // Tile position within the workspace view. Excludes animated
+                // offsets (matching the floating equivalent) to avoid IPC spam.
+                let pos = Point::from((col_x - view_pos, 0.)) + tile_off;
+                let pos = pos.to_physical_precise_round(scale).to_logical(scale);
+                let layout = WindowLayout {
+                    // Our indices are 1-based, consistent with the actions.
+                    pos_in_scrolling_layout: Some((col_idx + 1, tile_idx + 1)),
+                    tile_pos_in_workspace_view: Some(pos.into()),
+                    ..tile.ipc_layout_template()
+                };
+                (tile, layout)
             })
+        })
     }
 
     pub(super) fn insert_hint_area(


### PR DESCRIPTION
#1265 added `tile_pos_in_workspace_view` and populated it for floating windows, but `ScrollingSpace::tiles_with_ipc_layouts` only sets `pos_in_scrolling_layout` (the column/row indices). It leaves `tile_pos_in_workspace_view` at the `ipc_layout_template()` default of `None`. So tiled windows expose their indices and size but not their on-screen position, while floating windows expose all three.

This computes it for tiled windows the same way the render path does (`col_x - view_pos + tile_offset`), using `target_view_pos()` and excluding the animated render offsets. That matches floating, which for the same reason "[doesn't] include render offset in [the] tile pos." Rounded to physical pixels, same as floating.

Verified on a two-column tiled layout: focused tile `[16, 16]`, neighbor `[1416, 16]` (16px gaps), matching rendered positions.
