### PR TITLE
fix nix build failures

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           cairo,
           dbus,
           libGL,
-          libdisplay-info,
+          libdisplay-info_0_3,
           libinput,
           seatd,
           libxkbcommon,
@@ -77,7 +77,7 @@
               cairo
               dbus
               libGL
-              libdisplay-info
+              libdisplay-info_0_3
               libinput
               seatd
               libxkbcommon


### PR DESCRIPTION
libdisplay-info is now 4.0

<details>
<summary>which causes:</summary>

```
error: failed to run custom build command for `libdisplay-info-sys v0.3.0`

Caused by:
  process didn't exit successfully: `/build/source/target/release/build/libdisplay-info-sys-aba2ddfb817ce2c5/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=/build/cargo-vendor-dir/libdisplay-info-sys-0.3.0/Cargo.toml
  cargo:rerun-if-env-changed=LIBDISPLAY_INFO_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr

  thread 'main' (5382) panicked at /build/cargo-vendor-dir/libdisplay-info-sys-0.3.0/build.rs:9:51:
  called `Result::unwrap()` on an `Err` value: PkgConfig(
  pkg-config exited with status code 1
  > PKG_CONFIG_PATH=/nix/store/3h6xnv0614bd6q4x57sjlrxy0hhshkkg-cairo-1.18.4-dev/lib/pkgconfig:/nix/store/lp5dqcflpn6wnwnxcrv39yjsn45pwpys-fontconfig-2.18.1-dev/lib/pkgconfig:/nix/store/qmajm5vxiwziaw4d34d5mwiy>

  pkg-config output:
    Requested 'libdisplay-info < 0.4.0' but version of libdisplay-info is 0.4.0
    You may find new versions of libdisplay-info at https://gitlab.freedesktop.org/emersion/libdisplay-info

  The system library `libdisplay-info` required by crate `libdisplay-info-sys` was not found.
  The file `libdisplay-info.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  PKG_CONFIG_PATH contains the following:
      - /nix/store/3h6xnv0614bd6q4x57sjlrxy0hhshkkg-cairo-1.18.4-dev/lib/pkgconfig
      - /nix/store/lp5dqcflpn6wnwnxcrv39yjsn45pwpys-fontconfig-2.18.1-dev/lib/pkgconfig
      - /nix/store/qmajm5vxiwziaw4d34d5mwiy39d65wj4-freetype-2.14.3-dev/lib/pkgconfig
      - /nix/store/ydgdz8pf2in3rlb5agwkgr76vfrdf2s5-zlib-1.3.2-dev/share/pkgconfig
      - /nix/store/g9233lb7899rdmaw3gr6jnc35g8jxhmi-bzip2-1.0.8-dev/lib/pkgconfig
      - /nix/store/xkjdypjdb61dqq0z79fdqd1mjhw3k3vi-brotli-1.2.0-dev/lib/pkgconfig
      - /nix/store/c1zcwag5x9i24jj9nxv3dfn35ng33yn3-libpng-apng-1.6.58-dev/lib/pkgconfig
      - /nix/store/g0nnb14m078jyiwlhfmvj2jckz0cgmgx-expat-2.8.2-dev/lib/pkgconfig
      - /nix/store/456p4q4ka95c0i2i5hd5hfbinn1568s0-pixman-0.46.4/lib/pkgconfig
      - /nix/store/jhmp55f7pj4p0hw24d6c7zygsvgsv56a-libxext-1.3.7-dev/lib/pkgconfig
      - /nix/store/cnf77zjffsdyncsm7q2kgcsfi21hvbd8-xorgproto-2025.1/share/pkgconfig
      - /nix/store/fws1421cr8h1y4gb2wf66mr1c84005iv-libxau-1.0.12-dev/lib/pkgconfig
      - /nix/store/b6wld0pjv5mqkdmp0xmjd5k830alq4w2-libxrender-0.9.12-dev/lib/pkgconfig
      - /nix/store/f7kgxfrak6yngbzj7gkzx7v7mq59fcml-libx11-1.8.13-dev/lib/pkgconfig
      - /nix/store/7w2z7kbvifnwg57divcmygmysqwa59s2-libxcb-1.17.0-dev/lib/pkgconfig
      - /nix/store/593rzz2xs5i67biyv2hz898j6v5ylms0-glib-2.88.1-dev/lib/pkgconfig
      - /nix/store/6hyghr8bpj6h9bavs8fp7v5w3qlc42i6-libffi-3.7.0-dev/lib/pkgconfig
      - /nix/store/1wm786v5ia3iprwv7bs04sbisd2gakhg-dbus-1.16.2-dev/lib/pkgconfig
      - /nix/store/gmjap7779bi62jq6gfnbc6qmhg3kzvps-libglvnd-1.7.0-dev/lib/pkgconfig
      - /nix/store/b7x6chcrkkw0yx5ccrgl0lhzvxpfz9b2-libdisplay-info-0.4.0/lib/pkgconfig
      - /nix/store/mpi0xx3npi99i72n80q43bmx7ypn85rp-libinput-1.31.3-dev/lib/pkgconfig
      - /nix/store/0w4b04fz6hghav0gcmvvq9gizlgp3jzy-systemd-minimal-libs-261-dev/lib/pkgconfig
      - /nix/store/0w4b04fz6hghav0gcmvvq9gizlgp3jzy-systemd-minimal-libs-261-dev/share/pkgconfig
      - /nix/store/4mn2svifmd94lq7vrrq3733dl84r5aqc-seatd-0.9.3-dev/lib/pkgconfig
      - /nix/store/gxwk0j6mpbm0xav65bhdi3adfy1n9pr9-libxkbcommon-1.13.2-dev/lib/pkgconfig
      - /nix/store/kzym5fa5jsw2ykpxlmdy9sswh5g81kxj-mesa-libgbm-26.1.3/lib/pkgconfig
      - /nix/store/7syv288j5rzlm6rzrl29h2skdakb82zf-libdrm-2.4.134-dev/lib/pkgconfig
      - /nix/store/i54snrx1bkzvzyil5ybzpgp6brviqbvd-pango-1.57.1-dev/lib/pkgconfig
      - /nix/store/ydrx7d5vkrzsa4jcjxihskxi1ydpwh3l-harfbuzz-13.2.1-dev/lib/pkgconfig
      - /nix/store/cq57xrw40gsph6x04y4y7jjbbns47hw4-graphite2-1.3.15-dev/lib/pkgconfig
      - /nix/store/z6b3vkjx6q5dr7yymalsxsld2z80vg2b-libxft-2.3.9-dev/lib/pkgconfig
      - /nix/store/0f7v73wfccb594s137p30fjj5gcpkwvx-wayland-1.26.0-dev/lib/pkgconfig
      - /nix/store/r01xiqzmkq9z43iw4dhq7z7jwsq5qpfk-pipewire-1.6.8-dev/lib/pkgconfig
      - /nix/store/yyn2602fggin0dqgvicd4rhlj9391bl0-systemd-261-dev/lib/pkgconfig
      - /nix/store/yyn2602fggin0dqgvicd4rhlj9391bl0-systemd-261-dev/share/pkgconfig

  HINT: you may need to install a package such as libdisplay-info, libdisplay-info-dev or libdisplay-info-devel.
  )
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

</details>