### PR TITLE
fix: convert IME popup target into surface space for CSD

### DIFF
--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -1257,6 +1257,13 @@ impl State {
         let mut target = self.niri.layout.popup_target_rect(window);
         target.loc -= get_popup_toplevel_coords(popup).to_f64();
 
+        // IME text_input_rectangle is surface-local, while popup_target_rect is relative to the
+        // window geometry. With CSD, geometry.loc is often non-zero (e.g. Alacritty title bar),
+        // so convert the target into surface space before positioning.
+        if matches!(popup, PopupKind::InputMethod(_)) {
+            target.loc += window.geometry().loc.to_f64();
+        }
+
         self.position_popup_within_rect(popup, target, true);
     }
 


### PR DESCRIPTION
IME popup unconstraining compared `text_input_rectangle` (surface-local) against `popup_target_rect` (geometry-relative) without accounting for `window.geometry().loc`. On CSD clients like Alacritty that offset is the title bar, so near the bottom of the window the candidate popup could end up off-screen.

This adds `geometry.loc` to the IME target so both sides are in surface space. When `geometry.loc` is `(0, 0)` the behavior is unchanged.

**Note:** This pull request was prepared with AI assistance. The change was validated by hand (including Alacritty + fcitx5 near the bottom edge).

### Testing

1. Use a CSD client such as Alacritty (without `prefer-no-csd`).
2. Put the caret on the last visible line and type with fcitx5 (or another `zwp_input_method_v2` IME).
3. Check that the candidate window stays on screen above/near the caret instead of being clipped below the window.
4. Optionally check with `prefer-no-csd` / an SSD client that placement still looks normal.

### Screenshots

After:
<img width="1207" height="262" alt="image" src="https://github.com/user-attachments/assets/580bfdd9-8f9b-4850-8394-b8e91efa7c71" />

Before:
<img width="1775" height="280" alt="image" src="https://github.com/user-attachments/assets/c3e96576-ce3d-4437-96e1-364d737d43c6" />