### PR TITLE
Honor client input-region holes for window activation

### DIFF
--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -881,6 +881,21 @@ impl<W: LayoutElement> Tile<W> {
         activation_region.contains(point)
     }
 
+    /// Whether the border or the focus ring can draw a solid background behind the window.
+    ///
+    /// When they do, input-region holes within the window geometry are visually covered by
+    /// the background, so clicks there should activate the window rather than fall through.
+    fn draws_background_behind_window(&self) -> bool {
+        if self.border.is_off() && self.focus_ring.is_off() {
+            return false;
+        }
+
+        self.window
+            .rules()
+            .draw_border_with_background
+            .unwrap_or_else(|| !self.window.has_ssd())
+    }
+
     pub fn hit(&self, point: Point<f64, Logical>) -> Option<HitType> {
         let offset = self.bob_offset();
         let point = point - offset;
@@ -892,9 +907,11 @@ impl<W: LayoutElement> Tile<W> {
             // If the point lies within the window's own geometry, the client explicitly
             // excluded it from its input region (e.g. a click-through transparent overlay
             // window). Let the hit fall through to windows below instead of activating
-            // this one. Points outside the window geometry (borders etc.) still activate.
+            // this one, unless the border or the focus ring draw a solid background
+            // behind the window there. Points outside the window geometry (the border
+            // ring, etc.) still activate.
             let window_rect = Rectangle::new(self.window_loc(), self.window_size());
-            if window_rect.contains(point) {
+            if window_rect.contains(point) && !self.draws_background_behind_window() {
                 return None;
             }
             Some(HitType::Activate {

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -889,6 +889,14 @@ impl<W: LayoutElement> Tile<W> {
             let win_pos = self.buf_loc() + offset;
             Some(HitType::Input { win_pos })
         } else if self.is_in_activation_region(point) {
+            // If the point lies within the window's own geometry, the client explicitly
+            // excluded it from its input region (e.g. a click-through transparent overlay
+            // window). Let the hit fall through to windows below instead of activating
+            // this one. Points outside the window geometry (borders etc.) still activate.
+            let window_rect = Rectangle::new(self.window_loc(), self.window_size());
+            if window_rect.contains(point) {
+                return None;
+            }
             Some(HitType::Activate {
                 is_tab_indicator: false,
             })


### PR DESCRIPTION
## Summary
- When a click lands inside a window's geometry but outside its `wl_surface` input region, fall through to windows below instead of returning `HitType::Activate`.
- Keeps current activation behavior for points outside the window geometry (borders / chrome).
- Fixes transparent overlay clients that deliberately punch holes in their input region (e.g. desktop/taskbar HUD games under Xwayland). See #4380.

## Test plan
- [ ] Floating window with a non-rectangular input region: click outside the region but inside the window rect → window underneath receives the click / focus; overlay is not activated.
- [ ] Same window: click on content inside the input region → events still go to that window.
- [ ] Window with borders / focus ring: click on the border outside client geometry → still activates the window (`HitType::Activate`).
- [ ] Tabbed tiles: tab indicator activation still works.
- [ ] Overlay smoke test: Task Bar Hero (Steam `3678970`) with Proton `WINE_LAYERED_OVERLAY_ALPHA=1` — transparent areas click through; sprites/UI remain interactive.


Made with [Cursor](https://cursor.com)