### PR TITLE
Add option to not expel window from column when fullscreening

### DIFF
--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -12,6 +12,7 @@ layout {
     empty-workspace-above-first
     default-column-display "tabbed"
     background-color "#003300"
+    maximized-window-placement "expel-from-column"
 
     preset-column-widths {
         proportion 0.33333
@@ -561,3 +562,16 @@ layout {
 ```
 
 You can also set the color per-output [in the output config](./Configuration:-Outputs.md#layout-config-overrides).
+
+### maximized-window-placement
+
+<sup>Since: next release</sup>
+
+Determines whether windows are expelled from their column on maximize/fullscreen.
+Can be `expel-from-column` or `keep-in-column`.
+
+```kdl
+layout {
+    maximized-window-placement "expel-from-column"
+}
+```

--- a/niri-config/src/layout.rs
+++ b/niri-config/src/layout.rs
@@ -24,6 +24,7 @@ pub struct Layout {
     pub gaps: f64,
     pub struts: Struts,
     pub background_color: Color,
+    pub maximized_window_placement: MaximizedWindowPlacement,
 }
 
 impl Default for Layout {
@@ -52,6 +53,7 @@ impl Default for Layout {
                 PresetSize::Proportion(2. / 3.),
             ],
             background_color: DEFAULT_BACKGROUND_COLOR,
+            maximized_window_placement: MaximizedWindowPlacement::ExpelFromColumn,
         }
     }
 }
@@ -78,6 +80,7 @@ impl MergeWith<LayoutPart> for Layout {
             default_column_display,
             struts,
             background_color,
+            maximized_window_placement,
         );
 
         if let Some(x) = part.default_column_width {
@@ -126,6 +129,8 @@ pub struct LayoutPart {
     pub struts: Option<Struts>,
     #[knuffel(child)]
     pub background_color: Option<Color>,
+    #[knuffel(child, unwrap(argument))]
+    pub maximized_window_placement: Option<MaximizedWindowPlacement>,
 }
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
@@ -168,6 +173,16 @@ pub enum CenterFocusedColumn {
     /// Focusing a column will center it if it doesn't fit on the screen together with the
     /// previously focused column.
     OnOverflow,
+}
+
+/// How to handle maximizing or fullscreening a window contained in a column with other windows.
+#[derive(knuffel::DecodeScalar, Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub enum MaximizedWindowPlacement {
+    /// When maximizing or fullscreening a window, expel it to the right of its containing column
+    #[default]
+    ExpelFromColumn,
+    /// When maximizing or fullscreening a window, keep it in its containing column
+    KeepInColumn,
 }
 
 impl<S> knuffel::Decode<S> for DefaultPresetSize

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -2026,6 +2026,24 @@ macro_rules! ensure {
     };
 }
 
+impl ColumnDisplay {
+    /// Returns `true` if the column display is [`Normal`]
+    ///
+    /// [`Normal`]: ColumnDisplay::Normal
+    #[must_use]
+    pub fn is_normal(&self) -> bool {
+        *self == ColumnDisplay::Normal
+    }
+
+    /// Returns `true` if the column display is [`Tabbed`]
+    ///
+    /// [`Tabbed`]: ColumnDisplay::Tabbed
+    #[must_use]
+    pub fn is_tabbed(&self) -> bool {
+        *self == ColumnDisplay::Tabbed
+    }
+}
+
 impl OutputAction {
     /// Validates some required constraints on the modeline and custom mode.
     pub fn validate(&self) -> Result<(), String> {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -588,6 +588,11 @@ impl SizingMode {
     pub fn is_maximized(&self) -> bool {
         matches!(self, Self::Maximized)
     }
+
+    #[must_use]
+    pub fn is_fullscreen_or_maximized(&self) -> bool {
+        matches!(self, Self::Fullscreen | Self::Maximized)
+    }
 }
 
 impl<W: LayoutElement> InteractiveMoveState<W> {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2963,10 +2963,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         push: &mut dyn FnMut(ScrollingSpaceRenderElement<R>),
     ) {
         let scale = Scale::from(self.scale);
+        let view_rect = Rectangle::new(Point::from((self.view_pos(), 0.)), self.view_size);
 
         // Draw the closing windows on top of the other windows.
         if layer.is_normal() {
-            let view_rect = Rectangle::new(Point::from((self.view_pos(), 0.)), self.view_size);
             for closing in self.closing_windows.iter().rev() {
                 let elem = closing.render(ctx.as_gles(), view_rect, scale);
                 push(elem.into());
@@ -3005,12 +3005,18 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 let focus_ring = focus_ring && first;
                 first = false;
 
-                // In the scrolling layout, we currently use visible only for hidden tabs in the
-                // tabbed mode. We want to animate their opacity when going in and out of tabbed
-                // mode, so we don't want to apply "visible" immediately. However, "visible" is
-                // also used for input handling, and there we *do* want to apply it immediately.
-                // So, let's just selectively ignore "visible" here when animating alpha.
-                let visible = visible || tile.alpha_animation.is_some();
+                let tile_rect: Rectangle<f64, Logical> = Rectangle::new(tile_pos, tile.tile_size());
+                let tile_intersects_view = tile_rect.intersection(view_rect).is_some();
+
+                // In the scrolling layout, we currently use visible only for
+                // - hidden tabs in the tabbed mode
+                // - fullscreen/maximized inactive tiles in normal mode
+                // We want to animate their opacity when going in and out of tabbed mode, and when
+                // maximizing/unmaximizing, so we don't want to apply "visible" immediately.
+                // However, "visible" is also used for input handling, and there we *do* want to
+                // apply it immediately. So, let's just selectively ignore "visible" here when
+                // animating alpha.
+                let visible = visible || (tile.alpha_animation.is_some() && tile_intersects_view);
                 if !visible {
                     continue;
                 }

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4478,46 +4478,74 @@ impl<W: LayoutElement> Column<W> {
         tile.update_window();
         self.data[tile_idx].update(tile);
 
-        let offset = prev_height - self.data[tile_idx].size.h;
+        match self.display_mode {
+            ColumnDisplay::Normal => {
+                let new_height = self.data[tile_idx].size.h;
+                let offset = prev_height - new_height;
 
-        let is_tabbed = self.display_mode == ColumnDisplay::Tabbed;
-
-        // Move windows below in tandem with resizing.
-        //
-        // FIXME: in always-centering mode, window resizing will affect the offsets of all other
-        // windows in the column, so they should all be animated. How should this interact with
-        // animated vs. non-animated resizes? For example, an animated +20 resize followed by two
-        // non-animated -10 resizes.
-        if !is_tabbed && offset != 0. {
-            if tile.resize_animation().is_some() {
-                // If there's a resize animation (that may have just started in
-                // tile.update_window()), then the apparent size change is smooth with no sudden
-                // jumps. This corresponds to adding an Y animation to tiles below.
-                for tile in &mut self.tiles[tile_idx + 1..] {
-                    tile.animate_move_y_from_with_config(
-                        offset,
-                        self.options.animations.window_resize.anim,
-                    );
-                }
-            } else {
-                // There's no resize animation, but the offset is nonzero. This could happen for
-                // example:
-                // - if the window resized on its own, which we don't animate
-                // - if the window resized by less than 10 px (the resize threshold)
+                // Move windows below in tandem with resizing.
                 //
-                // The latter case could also cancel an ongoing resize animation.
-                //
-                // Now, stationary tiles below shouldn't react to this offset change in any way,
-                // i.e. their apparent Y position should jump together with the resize. However,
-                // tiles below that are already animating an Y movement should offset their
-                // animations to avoid the jump.
-                //
-                // Notably, this is necessary to fix the animation jump when resizing height back
-                // and forth in quick succession (in a way that cancels the resize animation).
-                for tile in &mut self.tiles[tile_idx + 1..] {
-                    tile.offset_move_y_anim_current(offset);
+                // FIXME: in always-centering mode, window resizing will affect the offsets of all
+                // other windows in the column, so they should all be animated. How
+                // should this interact with animated vs. non-animated resizes? For
+                // example, an animated +20 resize followed by two non-animated -10
+                // resizes.
+                if offset != 0. {
+                    let tile = &mut &self.tiles[tile_idx];
+                    if tile.resize_animation().is_some() {
+                        // If there's a resize animation (that may have just started in
+                        // tile.update_window()), then the apparent size change is smooth with no
+                        // sudden jumps. This corresponds to adding an Y
+                        // animation to tiles below.
+                        for tile_below in &mut self.tiles[tile_idx + 1..] {
+                            tile_below.animate_move_y_from_with_config(
+                                offset,
+                                self.options.animations.window_resize.anim,
+                            );
+                        }
+                        if self.pending_sizing_mode().is_fullscreen_or_maximized() {
+                            // Adjust offset as to not shift the origin of the active tile
+                            if tile_idx < self.active_tile_idx {
+                                for tile in &mut self.tiles {
+                                    tile.animate_move_y_from_with_config(
+                                        -offset,
+                                        self.options.animations.window_resize.anim,
+                                    );
+                                }
+                            }
+                        }
+                    } else {
+                        // There's no resize animation, but the offset is nonzero. This could happen
+                        // for example:
+                        // - if the window resized on its own, which we don't animate
+                        // - if the window resized by less than 10 px (the resize threshold)
+                        //
+                        // The latter case could also cancel an ongoing resize animation.
+                        //
+                        // Now, stationary tiles below shouldn't react to this offset change in any
+                        // way, i.e. their apparent Y position should jump
+                        // together with the resize. However, tiles below
+                        // that are already animating an Y movement should offset their
+                        // animations to avoid the jump.
+                        //
+                        // Notably, this is necessary to fix the animation jump when resizing height
+                        // back and forth in quick succession (in a way that
+                        // cancels the resize animation).
+                        for tile_below in &mut self.tiles[tile_idx + 1..] {
+                            tile_below.offset_move_y_anim_current(offset);
+                        }
+                        if self.pending_sizing_mode().is_fullscreen_or_maximized() {
+                            // Adjust offset as to not shift the origin of the active tile
+                            if tile_idx < self.active_tile_idx {
+                                for tile in &mut self.tiles {
+                                    tile.offset_move_y_anim_current(-offset);
+                                }
+                            }
+                        }
+                    }
                 }
             }
+            ColumnDisplay::Tabbed => {}
         }
     }
 
@@ -5229,8 +5257,9 @@ impl<W: LayoutElement> Column<W> {
             return;
         }
 
-        self.is_pending_fullscreen = is_fullscreen;
-        self.update_tile_sizes(true);
+        animate_sizing_mode_change(self, |column| {
+            column.is_pending_fullscreen = is_fullscreen;
+        });
     }
 
     fn set_maximized(&mut self, maximize: bool) {
@@ -5238,8 +5267,9 @@ impl<W: LayoutElement> Column<W> {
             return;
         }
 
-        self.is_pending_maximized = maximize;
-        self.update_tile_sizes(true);
+        animate_sizing_mode_change(self, |column| {
+            column.is_pending_maximized = maximize;
+        });
     }
 
     fn set_column_display(&mut self, display: ColumnDisplay) {
@@ -5704,6 +5734,47 @@ fn resolve_preset_size(
             (view_size - options.layout.gaps) * proportion - options.layout.gaps - extra_size,
         ),
         PresetSize::Fixed(width) => ResolvedSize::Window(f64::from(width)),
+    }
+}
+
+fn animate_sizing_mode_change<CHANGE, W>(column: &mut Column<W>, change: CHANGE)
+where
+    W: LayoutElement,
+    CHANGE: FnOnce(&mut Column<W>),
+{
+    let prev_sizing_mode = column.pending_sizing_mode();
+    let prev_active_tile_offset = column.tile_offset(column.active_tile_idx);
+
+    change(column);
+    column.update_tile_sizes(true);
+
+    let new_sizing_mode = column.pending_sizing_mode();
+    let new_active_tile_offset = column.tile_offset(column.active_tile_idx);
+
+    let active_tile_offset_y_delta = (prev_active_tile_offset - new_active_tile_offset).y;
+
+    for (tile_idx, tile) in column.tiles.iter_mut().enumerate() {
+        tile.animate_move_y_from_with_config(
+            active_tile_offset_y_delta,
+            column.options.animations.window_movement.0,
+        );
+
+        // fade out other tiles in the column while maximizing
+        if tile_idx != column.active_tile_idx {
+            let alpha_from = match prev_sizing_mode {
+                SizingMode::Normal => 1.,
+                SizingMode::Fullscreen | SizingMode::Maximized => 0.,
+            };
+            let alpha_to = match new_sizing_mode {
+                SizingMode::Normal => 1.,
+                SizingMode::Fullscreen | SizingMode::Maximized => 0.,
+            };
+            tile.animate_alpha(
+                alpha_from,
+                alpha_to,
+                column.options.animations.window_movement.0,
+            );
+        }
     }
 }
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use niri_config::utils::MergeWith as _;
-use niri_config::{CenterFocusedColumn, PresetSize, Struts};
+use niri_config::{CenterFocusedColumn, MaximizedWindowPlacement, PresetSize, Struts};
 use niri_ipc::{ColumnDisplay, SizeChange, WindowLayout};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -2218,7 +2218,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         col.update_tile_sizes(true);
 
         // Disable fullscreen if needed.
-        if col.display_mode != ColumnDisplay::Tabbed && col.tiles.len() > 1 {
+        if self.options.layout.maximized_window_placement
+            == MaximizedWindowPlacement::ExpelFromColumn
+            && col.display_mode != ColumnDisplay::Tabbed
+            && col.tiles.len() > 1
+        {
             let window = col.tiles[col.active_tile_idx].window().id().clone();
             self.set_fullscreen(&window, false);
             self.set_maximized(&window, false);
@@ -2878,11 +2882,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         let mut col = &mut self.columns[col_idx];
-        let is_tabbed = col.display_mode == ColumnDisplay::Tabbed;
 
         cancel_resize_for_column(&mut self.interactive_resize, col);
 
-        if is_fullscreen && (col.tiles.len() > 1 && !is_tabbed) {
+        if self.options.layout.maximized_window_placement
+            == MaximizedWindowPlacement::ExpelFromColumn
+            && is_fullscreen
+            && (col.tiles.len() > 1 && !col.display_mode.is_tabbed())
+        {
             // This wasn't the only window in its column; extract it into a separate column.
             self.consume_or_expel_window_right(Some(window));
             col_idx += 1;
@@ -2913,7 +2920,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         cancel_resize_for_column(&mut self.interactive_resize, col);
 
-        if maximize && (col.tiles.len() > 1 && !is_tabbed) {
+        if self.options.layout.maximized_window_placement
+            == MaximizedWindowPlacement::ExpelFromColumn
+            && maximize
+            && (col.tiles.len() > 1 && !is_tabbed)
+        {
             // This wasn't the only window in its column; extract it into a separate column.
             self.consume_or_expel_window_right(Some(window));
             col_idx += 1;
@@ -5218,10 +5229,6 @@ impl<W: LayoutElement> Column<W> {
             return;
         }
 
-        if is_fullscreen {
-            assert!(self.tiles.len() == 1 || self.display_mode == ColumnDisplay::Tabbed);
-        }
-
         self.is_pending_fullscreen = is_fullscreen;
         self.update_tile_sizes(true);
     }
@@ -5229,10 +5236,6 @@ impl<W: LayoutElement> Column<W> {
     fn set_maximized(&mut self, maximize: bool) {
         if self.is_pending_maximized == maximize {
             return;
-        }
-
-        if maximize {
-            assert!(self.tiles.len() == 1 || self.display_mode == ColumnDisplay::Tabbed);
         }
 
         self.is_pending_maximized = maximize;
@@ -5324,14 +5327,15 @@ impl<W: LayoutElement> Column<W> {
     // borrowing. Note that this method's return value does not borrow the entire &Self!
     fn tile_offsets_iter(
         &self,
-        data: impl Iterator<Item = TileData>,
+        data: impl Iterator<Item = TileData> + Clone,
     ) -> impl Iterator<Item = Point<f64, Logical>> {
         // FIXME: this should take into account always-center-single-column, which means that
         // Column should somehow know when it is being centered due to being the single column on
         // the workspace or some other reason.
         let center = self.options.layout.center_focused_column == CenterFocusedColumn::Always;
         let gaps = self.options.layout.gaps;
-        let tabbed = self.display_mode == ColumnDisplay::Tabbed;
+        let stacked = self.display_mode == ColumnDisplay::Normal;
+        let is_maximized = self.pending_sizing_mode().is_fullscreen_or_maximized();
 
         // Does not include extra size from the tab indicator.
         let tiles_width = self
@@ -5352,7 +5356,7 @@ impl<W: LayoutElement> Column<W> {
         };
         let data = data.chain(iter::once(dummy));
 
-        data.map(move |data| {
+        let offsets = data.map(move |data| {
             let mut pos = origin;
 
             if center {
@@ -5361,11 +5365,21 @@ impl<W: LayoutElement> Column<W> {
                 pos.x += tiles_width - data.size.w;
             }
 
-            if !tabbed {
+            if stacked {
                 origin.y += data.size.h + gaps;
             }
 
             pos
+        });
+
+        let active_window_offset = offsets.clone().nth(self.active_tile_idx).unwrap();
+
+        offsets.map(move |offset| {
+            if stacked && is_maximized {
+                origin + offset - active_window_offset
+            } else {
+                offset
+            }
         })
     }
 
@@ -5379,7 +5393,7 @@ impl<W: LayoutElement> Column<W> {
 
     fn tile_offsets_in_render_order(
         &self,
-        data: impl Iterator<Item = TileData>,
+        data: impl Iterator<Item = TileData> + Clone,
     ) -> impl Iterator<Item = Point<f64, Logical>> {
         let active_idx = self.active_tile_idx;
         let active_pos = self.tile_offset(active_idx);
@@ -5410,7 +5424,7 @@ impl<W: LayoutElement> Column<W> {
 
         let active = active.iter().map(|tile| (tile, true));
 
-        let rest_visible = self.display_mode != ColumnDisplay::Tabbed;
+        let rest_visible = self.display_mode.is_normal() && self.pending_sizing_mode().is_normal();
         let rest = first.iter().chain(rest);
         let rest = rest.map(move |tile| (tile, rest_visible));
 
@@ -5488,10 +5502,6 @@ impl<W: LayoutElement> Column<W> {
         assert!(self.active_tile_idx < self.tiles.len());
         assert_eq!(self.tiles.len(), self.data.len());
 
-        if !self.pending_sizing_mode().is_normal() {
-            assert!(self.tiles.len() == 1 || self.display_mode == ColumnDisplay::Tabbed);
-        }
-
         if let Some(idx) = self.preset_width_idx {
             assert!(idx < self.options.layout.preset_column_widths.len());
         }
@@ -5567,7 +5577,8 @@ impl<W: LayoutElement> Column<W> {
             total_min_height += min_tile_height;
         }
 
-        if !is_tabbed
+        if self.display_mode.is_normal()
+            && self.pending_sizing_mode().is_normal()
             && tile_count > 1
             && self.scale.round() == self.scale
             && working_size.h.round() == working_size.h

--- a/src/layout/tests/fullscreen.rs
+++ b/src/layout/tests/fullscreen.rs
@@ -657,3 +657,151 @@ fn removing_only_fullscreen_tile_updates_view_offset() {
     // FIXME: currently, removing a tile doesn't cause the view offset to update.
     assert_snapshot!(layout.active_workspace().unwrap().scrolling().view_pos(), @"0");
 }
+
+#[test]
+fn expected_number_of_columns_after_toggling_fullscreen() {
+    use niri_config::MaximizedWindowPlacement;
+
+    enum ToggleType {
+        Fullscreen,
+        MaximizeToEdges,
+    }
+
+    #[track_caller]
+    fn test_with_params(
+        toggle_type: ToggleType,
+        maximized_column_placement: MaximizedWindowPlacement,
+        expected_number_of_columns: usize,
+    ) {
+        let mut options = Options::default();
+        options.layout.maximized_window_placement = maximized_column_placement;
+        let mut layout =
+            Layout::<TestWindow>::with_options(Clock::with_time(Duration::ZERO), options);
+
+        let every_op = [
+            Op::AddOutput(0),
+            Op::AddWindow {
+                params: TestWindowParams::new(0),
+            },
+            Op::AddWindow {
+                params: TestWindowParams::new(1),
+            },
+            Op::FocusColumnLeft,
+            Op::ConsumeWindowIntoColumn,
+            match toggle_type {
+                ToggleType::Fullscreen => Op::FullscreenWindow(0),
+                ToggleType::MaximizeToEdges => Op::MaximizeWindowToEdges { id: Some(0) },
+            },
+        ];
+
+        for op in every_op {
+            op.apply(&mut layout);
+        }
+
+        let columns = layout
+            .active_workspace()
+            .into_iter()
+            .flat_map(|ws| ws.scrolling().columns());
+        assert_eq!(columns.count(), expected_number_of_columns);
+    }
+
+    test_with_params(
+        ToggleType::Fullscreen,
+        MaximizedWindowPlacement::KeepInColumn,
+        1,
+    );
+    test_with_params(
+        ToggleType::Fullscreen,
+        MaximizedWindowPlacement::ExpelFromColumn,
+        2,
+    );
+    test_with_params(
+        ToggleType::MaximizeToEdges,
+        MaximizedWindowPlacement::KeepInColumn,
+        1,
+    );
+    test_with_params(
+        ToggleType::MaximizeToEdges,
+        MaximizedWindowPlacement::ExpelFromColumn,
+        2,
+    );
+}
+
+#[test]
+fn expected_number_of_columns_and_sizing_mode_after_toggling_tabbed_mode_during_fullscreen() {
+    use niri_config::MaximizedWindowPlacement;
+
+    enum ToggleType {
+        Fullscreen,
+        MaximizeToEdges,
+    }
+
+    const EXPECTED_NUMBER_OF_COLUMNS: usize = 1;
+
+    #[track_caller]
+    fn test_with_params(
+        toggle_type: ToggleType,
+        maximized_column_placement: MaximizedWindowPlacement,
+        expected_sizing_mode: SizingMode,
+    ) {
+        let mut options = Options::default();
+        options.layout.maximized_window_placement = maximized_column_placement;
+        let mut layout =
+            Layout::<TestWindow>::with_options(Clock::with_time(Duration::ZERO), options);
+
+        let every_op = [
+            Op::AddOutput(0),
+            Op::AddWindow {
+                params: TestWindowParams::new(0),
+            },
+            Op::AddWindow {
+                params: TestWindowParams::new(1),
+            },
+            Op::FocusColumnLeft,
+            Op::ToggleColumnTabbedDisplay,
+            Op::ConsumeWindowIntoColumn,
+            match toggle_type {
+                ToggleType::Fullscreen => Op::FullscreenWindow(0),
+                ToggleType::MaximizeToEdges => Op::MaximizeWindowToEdges { id: Some(0) },
+            },
+            Op::ToggleColumnTabbedDisplay,
+        ];
+
+        for op in every_op {
+            op.apply(&mut layout);
+        }
+
+        let columns = layout
+            .active_workspace()
+            .into_iter()
+            .flat_map(|ws| ws.scrolling().columns());
+        assert_eq!(columns.count(), EXPECTED_NUMBER_OF_COLUMNS);
+        let active_window = layout.active_workspace().and_then(|ws| ws.active_window());
+        assert!(active_window.is_some());
+        assert_eq!(
+            active_window.unwrap().pending_sizing_mode(),
+            expected_sizing_mode
+        );
+    }
+
+    test_with_params(
+        ToggleType::Fullscreen,
+        MaximizedWindowPlacement::KeepInColumn,
+        SizingMode::Fullscreen,
+    );
+    test_with_params(
+        ToggleType::Fullscreen,
+        MaximizedWindowPlacement::ExpelFromColumn,
+        SizingMode::Normal,
+    );
+    test_with_params(
+        ToggleType::MaximizeToEdges,
+        MaximizedWindowPlacement::KeepInColumn,
+        SizingMode::Maximized,
+    );
+    test_with_params(
+        ToggleType::MaximizeToEdges,
+        MaximizedWindowPlacement::ExpelFromColumn,
+        SizingMode::Normal,
+    );
+}


### PR DESCRIPTION
This PR addresses issue #426.

It adds an option `layout::maximized-window-placement` with default value `"expel-from-column"`, which is the current behaviour of expelling a tile from its column before fullscreening/maximizing. By setting the value to `"keep-in-column"` the fullscreened/maximized window will not be expelled and stays in the column. Animations are adjusted to make the transition seamless.

## TODO
- [x] Add tests
- [x] ~~Not sure if events stream reports the correct layout~~ Not an issue for non-floating tiles, as the view-/workspace-relative location is not being reported https://github.com/niri-wm/niri/issues/2381
- [x] ~~Animation issue under the presence of firefox, maybe something related to this comment https://github.com/cornservant/niri/blob/46a76eee2fb0dc72570c2616a35d65d85ae6ce3c/src/layout/scrolling.rs#L1338-L1407 ~~ Seems to be a bug (in vanilla niri) https://github.com/niri-wm/niri/issues/4456
- [x] ~~maximizing/unmaximizing fractal is delayed and at times freezes the window, check if this is due to this PR~~ https://github.com/niri-wm/niri/pull/4384#issuecomment-5181770773
- [x] ~~vram usage can jump up for a period of time (for example: put firefox and ghostty in a column, maximize ghostty, vram usage increases massively until you switch focus to firefox); doesn't occur with animations off~~ https://github.com/niri-wm/niri/pull/4384#issuecomment-5181529210