### PR TITLE
Add input.wake-monitors-on-input option

### DIFF
--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -308,6 +308,28 @@ input {
 }
 ```
 
+#### `wake-monitors-on-input`
+
+<sup>Since: next release</sup>
+
+By default, when monitors are powered off (for example, with the `power-off-monitors` action), any input like moving the mouse or pressing a key powers them back on.
+
+Set this to `false` to keep the monitors off regardless of input.
+Then, the only way to power them back on is the `power-on-monitors` action, for example bound to a key or invoked with `niri msg action power-on-monitors`.
+
+Keep in mind that other input keeps working normally while the monitors are off: keys will go to the focused window, and binds will trigger their actions.
+
+```kdl
+input {
+    wake-monitors-on-input false
+}
+
+binds {
+    Mod+Shift+P { power-off-monitors; }
+    Mod+Shift+O { power-on-monitors; }
+}
+```
+
 #### `warp-mouse-to-focus`
 
 Makes the mouse warp to newly focused windows.

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -8,7 +8,7 @@ use crate::binds::Modifiers;
 use crate::utils::{Flag, MergeWith, Percent};
 use crate::FloatOrInt;
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Input {
     pub keyboard: Keyboard,
     pub touchpad: Touchpad,
@@ -18,11 +18,33 @@ pub struct Input {
     pub tablet: Tablet,
     pub touch: Touch,
     pub disable_power_key_handling: bool,
+    pub wake_monitors_on_input: bool,
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
     pub workspace_auto_back_and_forth: bool,
     pub mod_key: Option<ModKey>,
     pub mod_key_nested: Option<ModKey>,
+}
+
+impl Default for Input {
+    fn default() -> Self {
+        Self {
+            keyboard: Default::default(),
+            touchpad: Default::default(),
+            mouse: Default::default(),
+            trackpoint: Default::default(),
+            trackball: Default::default(),
+            tablet: Default::default(),
+            touch: Default::default(),
+            disable_power_key_handling: false,
+            wake_monitors_on_input: true,
+            warp_mouse_to_focus: None,
+            focus_follows_mouse: None,
+            workspace_auto_back_and_forth: false,
+            mod_key: None,
+            mod_key_nested: None,
+        }
+    }
 }
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
@@ -44,6 +66,8 @@ pub struct InputPart {
     #[knuffel(child)]
     pub disable_power_key_handling: Option<Flag>,
     #[knuffel(child)]
+    pub wake_monitors_on_input: Option<Flag>,
+    #[knuffel(child)]
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     #[knuffel(child)]
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
@@ -61,6 +85,7 @@ impl MergeWith<InputPart> for Input {
             (self, part),
             keyboard,
             disable_power_key_handling,
+            wake_monitors_on_input,
             workspace_auto_back_and_forth,
         );
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -730,6 +730,7 @@ mod tests {
                 }
 
                 disable-power-key-handling
+                wake-monitors-on-input false
 
                 warp-mouse-to-focus
                 focus-follows-mouse
@@ -1126,6 +1127,7 @@ mod tests {
                     ),
                 },
                 disable_power_key_handling: true,
+                wake_monitors_on_input: false,
                 warp_mouse_to_focus: Some(
                     WarpMouseToFocus {
                         mode: None,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -128,7 +128,9 @@ impl State {
             }
         } else {
             // Power on monitors if they were off.
-            if should_activate_monitors(&event) {
+            if self.niri.config.borrow().input.wake_monitors_on_input
+                && should_activate_monitors(&event)
+            {
                 self.niri.activate_monitors(&mut self.backend);
 
                 // Notify the idle-notifier of activity only if we're also powering on the


### PR DESCRIPTION
I switched niri from hyrpland. It's excellent and ultimately stable. Firstly thanks for this.

My case: I always close my monitors when I'm away. I have a script for that. Problem is my monitors wakes up again in slight mouse movements or because of pressing a button unwillingly. In hyprland it wasn't a problem because I could wake my screen with special keybind so I need a solution for niri too. 