### PR TITLE
Adding `--now` flag for `niri msg pick-window` for immediate window picking under the cursor.

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -82,7 +82,10 @@ pub enum Request {
     /// Request information about the focused window.
     FocusedWindow,
     /// Request picking a window and get its information.
-    PickWindow,
+    PickWindow {
+        /// Immediately picking the window under the cursor.
+        now: bool,
+    },
     /// Request picking a color from the screen.
     PickColor,
     /// Perform an action.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,7 +76,11 @@ pub enum Msg {
     /// Print information about the focused window.
     FocusedWindow,
     /// Pick a window with the mouse and print information about it.
-    PickWindow,
+    PickWindow {
+        /// Immediately picking the window under the cursor.
+        #[arg(long, short)]
+        now: bool,
+    },
     /// Pick a color from the screen with the mouse.
     PickColor,
     /// Perform an action.

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -34,7 +34,7 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
         Msg::Outputs => Request::Outputs,
         Msg::FocusedWindow => Request::FocusedWindow,
         Msg::FocusedOutput => Request::FocusedOutput,
-        Msg::PickWindow => Request::PickWindow,
+        Msg::PickWindow { now } => Request::PickWindow { now: *now },
         Msg::PickColor => Request::PickColor,
         Msg::Action { action } => Request::Action(action.clone()),
         Msg::Output { output, action } => Request::Output {
@@ -280,7 +280,7 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                 println!("No output is focused.");
             }
         }
-        Msg::PickWindow => {
+        Msg::PickWindow { .. } => {
             let Response::PickedWindow(window) = response else {
                 bail!("unexpected response: expected PickedWindow, got {response:?}");
             };

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -340,9 +340,15 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let window = windows.values().find(|win| win.is_focused).cloned();
             Response::FocusedWindow(window)
         }
-        Request::PickWindow => {
+        Request::PickWindow { now } => {
             let (tx, rx) = async_channel::bounded(1);
             ctx.event_loop.insert_idle(move |state| {
+                if now {
+                    let id = state.niri.window_under_cursor().map(Mapped::id);
+                    let _ = tx.send_blocking(id);
+                    return;
+                }
+
                 let pointer = state.niri.seat.get_pointer().unwrap();
                 let start_data = PointerGrabStartData {
                     focus: None,


### PR DESCRIPTION
originally from pr https://github.com/niri-wm/niri/pull/4189.  
it seems like the pr was stale (inactive for a few months) and the original author (@KapDecy) wasn't applying the suggestions in the comments.  

### Changes
- added `now` as a flag in `cli.rs`
- added `now` boolean as a field in the `PickWindow` Request and Msg
- added a conditional check for the `now` boolean in `Request::PickWindow` enum `event_loop` closure using `window_under_cursor()` function

### Command
`niri msg pick-window --now` - immediate pick  
`niri msg pick-window`       - pick by choosing (as usual)

## Tests
all tests from `cargo test --all` with the recommended env went through  
also tested by running niri on a tty  