### PR TITLE
feat: force render (v2)

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1883,7 +1883,6 @@ mod tests {
                     scroll_factor: None,
                     tiled_state: None,
                     force_render: None,
-                    force_render_fps: None,
                     background_effect: BackgroundEffectRule {
                         xray: None,
                         blur: None,

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1882,6 +1882,8 @@ mod tests {
                     ),
                     scroll_factor: None,
                     tiled_state: None,
+                    force_render: None,
+                    force_render_fps: None,
                     background_effect: BackgroundEffectRule {
                         xray: None,
                         blur: None,

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -76,9 +76,7 @@ pub struct WindowRule {
     #[knuffel(child, unwrap(argument))]
     pub tiled_state: Option<bool>,
     #[knuffel(child, unwrap(argument))]
-    pub force_render: Option<bool>,
-    #[knuffel(child, unwrap(argument))]
-    pub force_render_fps: Option<u16>,
+    pub force_render: Option<u16>,
     #[knuffel(child, default)]
     pub background_effect: BackgroundEffectRule,
     #[knuffel(child, default)]

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -75,6 +75,10 @@ pub struct WindowRule {
     pub scroll_factor: Option<FloatOrInt<0, 100>>,
     #[knuffel(child, unwrap(argument))]
     pub tiled_state: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub force_render: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub force_render_fps: Option<u16>,
     #[knuffel(child, default)]
     pub background_effect: BackgroundEffectRule,
     #[knuffel(child, default)]

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4996,43 +4996,6 @@ impl<W: LayoutElement> Layout<W> {
         moving_window.chain(rest)
     }
 
-    pub fn windows_mut(&mut self) -> impl Iterator<Item = &mut W> {
-        let iter_normal;
-        let iter_no_outputs;
-
-        match &mut self.monitor_set {
-            MonitorSet::Normal { monitors, .. } => {
-                let it = monitors
-                    .iter_mut()
-                    .flat_map(|mon| mon.workspaces.iter_mut());
-
-                iter_normal = Some(it);
-                iter_no_outputs = None;
-            }
-            MonitorSet::NoOutputs { workspaces } => {
-                let it = workspaces.iter_mut();
-
-                iter_normal = None;
-                iter_no_outputs = Some(it);
-            }
-        }
-
-        let iter_normal = iter_normal.into_iter().flatten();
-        let iter_no_outputs = iter_no_outputs.into_iter().flatten();
-        let workspace_windows = iter_normal
-            .chain(iter_no_outputs)
-            .flat_map(|ws| ws.windows_mut());
-
-        let moving_window = self
-            .interactive_move
-            .as_mut()
-            .and_then(|x| x.moving_mut())
-            .map(|move_| move_.tile.window_mut())
-            .into_iter();
-
-        workspace_windows.chain(moving_window)
-    }
-
     pub fn has_window(&self, window: &W::Id) -> bool {
         self.windows().any(|(_, win)| win.id() == window)
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4996,6 +4996,43 @@ impl<W: LayoutElement> Layout<W> {
         moving_window.chain(rest)
     }
 
+    pub fn windows_mut(&mut self) -> impl Iterator<Item = &mut W> {
+        let iter_normal;
+        let iter_no_outputs;
+
+        match &mut self.monitor_set {
+            MonitorSet::Normal { monitors, .. } => {
+                let it = monitors
+                    .iter_mut()
+                    .flat_map(|mon| mon.workspaces.iter_mut());
+
+                iter_normal = Some(it);
+                iter_no_outputs = None;
+            }
+            MonitorSet::NoOutputs { workspaces } => {
+                let it = workspaces.iter_mut();
+
+                iter_normal = None;
+                iter_no_outputs = Some(it);
+            }
+        }
+
+        let iter_normal = iter_normal.into_iter().flatten();
+        let iter_no_outputs = iter_no_outputs.into_iter().flatten();
+        let workspace_windows = iter_normal
+            .chain(iter_no_outputs)
+            .flat_map(|ws| ws.windows_mut());
+
+        let moving_window = self
+            .interactive_move
+            .as_mut()
+            .and_then(|x| x.moving_mut())
+            .map(|move_| move_.tile.window_mut())
+            .into_iter();
+
+        workspace_windows.chain(moving_window)
+    }
+
     pub fn has_window(&self, window: &W::Id) -> bool {
         self.windows().any(|(_, win)| win.id() == window)
     }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -571,7 +571,7 @@ struct SurfaceFrameThrottlingState {
 
 struct SurfaceForceRenderState {
     /// Whether a forced render is scheduled in the event loop.
-    scheduled: RefCell<bool>,
+    scheduled: Cell<bool>,
 }
 
 pub enum CenterCoords {
@@ -668,7 +668,35 @@ impl Default for SurfaceFrameThrottlingState {
 impl Default for SurfaceForceRenderState {
     fn default() -> Self {
         Self {
-            scheduled: RefCell::new(false),
+            scheduled: Cell::new(false),
+        }
+    }
+}
+
+pub fn setup_force_render(event_loop: &mut LoopHandle<'static, State>, mapped: &Mapped) -> bool {
+    if mapped.force_render().is_none() {
+        return false;
+    }
+
+    let already_scheduled = with_states(mapped.toplevel().wl_surface(), |states| {
+        let force_render_state = states
+            .data_map
+            .get_or_insert(SurfaceForceRenderState::default);
+        force_render_state.scheduled.replace(true)
+    });
+    if already_scheduled {
+        return false;
+    }
+
+    let mapped_id = mapped.id();
+    let res = event_loop.insert_source(Timer::immediate(), move |_, _, state| {
+        force_render_callback(state, mapped_id)
+    });
+    match res {
+        Ok(_) => true,
+        Err(e) => {
+            warn!("error scheduling forced render: {e}");
+            false
         }
     }
 }
@@ -696,9 +724,7 @@ fn force_render_callback(state: &mut State, mapped_id: MappedId) -> TimeoutActio
             let force_render_state = states
                 .data_map
                 .get_or_insert(SurfaceForceRenderState::default);
-            let mut scheduled = force_render_state.scheduled.borrow_mut();
-
-            *scheduled = false;
+            force_render_state.scheduled.set(false);
             return None;
         };
 
@@ -5133,12 +5159,8 @@ impl Niri {
 
         let frame_callback_time = get_monotonic_time();
 
-        // Borrow checker decided to be annoying here.
-        let mut to_force_render = Vec::new();
         for mapped in self.layout.windows_for_output_mut(output) {
-            if mapped.force_render().is_some() {
-                to_force_render.push(mapped.id());
-            }
+            setup_force_render(&mut self.event_loop, mapped);
             mapped.send_frame(
                 output,
                 frame_callback_time,
@@ -5146,9 +5168,6 @@ impl Niri {
                 should_send,
             );
         }
-        to_force_render
-            .drain(..)
-            .for_each(|x| self.setup_force_render(x));
 
         for surface in layer_map_for_output(output).layers() {
             surface.send_frame(
@@ -5257,36 +5276,6 @@ impl Niri {
                 |_, _| None,
             );
         }
-    }
-
-    fn setup_force_render(&mut self, mapped_id: MappedId) {
-        let Some(mapped) = self
-            .layout
-            .windows()
-            .find(|(_, m)| m.id() == mapped_id)
-            .map(|(_, m)| m)
-        else {
-            return;
-        };
-        with_states(mapped.toplevel().wl_surface(), |states| {
-            let force_render_state = states
-                .data_map
-                .get_or_insert(SurfaceForceRenderState::default);
-            let mut scheduled = force_render_state.scheduled.borrow_mut();
-            if *scheduled {
-                return;
-            }
-            *scheduled = true;
-
-            let res = self
-                .event_loop
-                .insert_source(Timer::immediate(), move |_, _, state| {
-                    force_render_callback(state, mapped_id)
-                });
-            if let Err(e) = res {
-                warn!("error scheduling forced render: {e}")
-            };
-        })
     }
 
     pub fn take_presentation_feedbacks(

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -178,9 +178,9 @@ use crate::utils::vblank_throttle::VBlankThrottle;
 use crate::utils::watcher::Watcher;
 use crate::utils::xwayland::satellite::Satellite;
 use crate::utils::{
-    center, center_f64, expand_home, get_monotonic_time, ipc_transform_to_smithay, is_mapped,
-    logical_output, make_screenshot_path, output_matches_name, output_size, panel_orientation,
-    send_scale_transform, write_png_rgba8, xwayland,
+    center, center_f64, expand_home, frequency_to_period, get_monotonic_time,
+    ipc_transform_to_smithay, is_mapped, logical_output, make_screenshot_path, output_matches_name,
+    output_size, panel_orientation, send_scale_transform, write_png_rgba8, xwayland,
 };
 use crate::window::mapped::MappedId;
 use crate::window::{InitialConfigureState, Mapped, ResolvedWindowRules, Unmapped, WindowRef};
@@ -569,6 +569,11 @@ struct SurfaceFrameThrottlingState {
     last_sent_at: RefCell<Option<(Output, u32)>>,
 }
 
+struct SurfaceForceRenderState {
+    /// Whether a forced render is scheduled in the event loop.
+    scheduled: RefCell<bool>,
+}
+
 pub enum CenterCoords {
     Separately,
     Both,
@@ -659,6 +664,68 @@ impl Default for SurfaceFrameThrottlingState {
             last_sent_at: RefCell::new(None),
         }
     }
+}
+impl Default for SurfaceForceRenderState {
+    fn default() -> Self {
+        Self {
+            scheduled: RefCell::new(false),
+        }
+    }
+}
+
+fn force_render_callback(state: &mut State, mapped_id: MappedId) -> TimeoutAction {
+    let Some(mapped) = state
+        .niri
+        .layout
+        .windows_mut()
+        .find(|m| m.id() == mapped_id)
+    else {
+        return TimeoutAction::Drop;
+    };
+
+    let Some(period) = with_states(mapped.toplevel().wl_surface(), |states| {
+        let Some(rate) = mapped.force_render() else {
+            let force_render_state = states
+                .data_map
+                .get_or_insert(SurfaceForceRenderState::default);
+            let mut scheduled = force_render_state.scheduled.borrow_mut();
+
+            *scheduled = false;
+            return None;
+        };
+
+        let frame_throttling_state = states
+            .data_map
+            .get_or_insert(SurfaceFrameThrottlingState::default);
+        let last_sent_at = frame_throttling_state.last_sent_at.borrow();
+
+        let output_rate = last_sent_at
+            .as_ref()
+            .and_then(|(output, _)| output.current_mode())
+            .map(|mode| mode.refresh)
+            .unwrap_or(0);
+
+        let period = std::cmp::max(frequency_to_period(rate), frequency_to_period(output_rate));
+        Some(period)
+    }) else {
+        return TimeoutAction::Drop;
+    };
+
+    let output = &Output::new(
+        String::new(),
+        PhysicalProperties {
+            size: Size::from((0, 0)),
+            subpixel: Subpixel::Unknown,
+            make: String::new(),
+            model: String::new(),
+            serial_number: String::new(),
+        },
+    );
+    let frame_callback_time = get_monotonic_time();
+
+    mapped.send_frame(output, frame_callback_time, Some(period), |_, _| None);
+
+    TimeoutAction::ToDuration(period)
 }
 
 impl KeyboardFocus {
@@ -5066,7 +5133,12 @@ impl Niri {
 
         let frame_callback_time = get_monotonic_time();
 
+        // Borrow checker decided to be annoying here.
+        let mut to_force_render = Vec::new();
         for mapped in self.layout.windows_for_output_mut(output) {
+            if mapped.force_render().is_some() {
+                to_force_render.push(mapped.id());
+            }
             mapped.send_frame(
                 output,
                 frame_callback_time,
@@ -5074,6 +5146,9 @@ impl Niri {
                 should_send,
             );
         }
+        to_force_render
+            .drain(..)
+            .for_each(|x| self.setup_force_render(x));
 
         for surface in layer_map_for_output(output).layers() {
             surface.send_frame(
@@ -5182,6 +5257,36 @@ impl Niri {
                 |_, _| None,
             );
         }
+    }
+
+    fn setup_force_render(&mut self, mapped_id: MappedId) {
+        let Some(mapped) = self
+            .layout
+            .windows()
+            .find(|(_, m)| m.id() == mapped_id)
+            .map(|(_, m)| m)
+        else {
+            return;
+        };
+        with_states(mapped.toplevel().wl_surface(), |states| {
+            let force_render_state = states
+                .data_map
+                .get_or_insert(SurfaceForceRenderState::default);
+            let mut scheduled = force_render_state.scheduled.borrow_mut();
+            if *scheduled {
+                return;
+            }
+            *scheduled = true;
+
+            let res = self
+                .event_loop
+                .insert_source(Timer::immediate(), move |_, _, state| {
+                    force_render_callback(state, mapped_id)
+                });
+            if let Err(e) = res {
+                warn!("error scheduling forced render: {e}")
+            };
+        })
     }
 
     pub fn take_presentation_feedbacks(

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -674,11 +674,19 @@ impl Default for SurfaceForceRenderState {
 }
 
 fn force_render_callback(state: &mut State, mapped_id: MappedId) -> TimeoutAction {
-    let Some(mapped) = state
+    let Some((output_rate, mapped)) = state
         .niri
         .layout
-        .windows_mut()
-        .find(|m| m.id() == mapped_id)
+        .workspaces_mut()
+        .flat_map(|ws| {
+            let rate = ws
+                .current_output()
+                .and_then(|out| out.current_mode())
+                .map(|mode| mode.refresh)
+                .unwrap_or(0);
+            ws.windows_mut().map(move |win| (rate, win))
+        })
+        .find(|(_, win)| win.id() == mapped_id)
     else {
         return TimeoutAction::Drop;
     };
@@ -694,18 +702,10 @@ fn force_render_callback(state: &mut State, mapped_id: MappedId) -> TimeoutActio
             return None;
         };
 
-        let frame_throttling_state = states
-            .data_map
-            .get_or_insert(SurfaceFrameThrottlingState::default);
-        let last_sent_at = frame_throttling_state.last_sent_at.borrow();
-
-        let output_rate = last_sent_at
-            .as_ref()
-            .and_then(|(output, _)| output.current_mode())
-            .map(|mode| mode.refresh)
-            .unwrap_or(0);
-
-        let period = std::cmp::max(frequency_to_period(rate), frequency_to_period(output_rate));
+        let period = std::cmp::max(
+            frequency_to_period(rate),
+            frequency_to_period(output_rate as u32),
+        );
         Some(period)
     }) else {
         return TimeoutAction::Drop;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -164,6 +164,16 @@ pub fn get_monotonic_time() -> Duration {
     Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32)
 }
 
+/// Converts a frequency in millihertz to the corresponding period, clamping to
+/// `Duration::ZERO` for negative values and `Duration::MAX` on overflow.
+pub fn frequency_to_period(rate: i32) -> Duration {
+    if rate > 0 {
+        Duration::try_from_secs_f64(1000.0 / rate as f64).unwrap_or(Duration::MAX)
+    } else {
+        Duration::ZERO
+    }
+}
+
 pub fn center(rect: Rectangle<i32, Logical>) -> Point<i32, Logical> {
     rect.loc + rect.size.downscale(2).to_point()
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -165,8 +165,8 @@ pub fn get_monotonic_time() -> Duration {
 }
 
 /// Converts a frequency in millihertz to the corresponding period, clamping to
-/// `Duration::ZERO` for negative values and `Duration::MAX` on overflow.
-pub fn frequency_to_period(rate: i32) -> Duration {
+/// `Duration::ZERO` for nonpositive rates and `Duration::MAX` on overflow.
+pub fn frequency_to_period(rate: u32) -> Duration {
     if rate > 0 {
         Duration::try_from_secs_f64(1000.0 / rate as f64).unwrap_or(Duration::MAX)
     } else {

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -617,10 +617,8 @@ impl Mapped {
     pub fn force_render(&self) -> Option<u32> {
         if self.is_window_cast_target {
             Some(0) // use last output's refresh rate
-        } else if self.rules.force_render == Some(true) {
-            Some(self.rules.force_render_fps.unwrap_or(0) as u32 * 1000)
         } else {
-            None
+            self.rules.force_render.map(|fps| fps as u32 * 1000)
         }
     }
 }

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -612,11 +612,13 @@ impl Mapped {
         self.is_urgent
     }
 
-    /// The forced rendering rate if enabled (either due to the window rule or
-    /// due to being a cast target), or `None` if disabled.
-    pub fn force_render(&self) -> Option<i32> {
-        if self.is_window_cast_target || self.rules.force_render == Some(true) {
-            Some(self.rules.force_render_fps.unwrap_or(0) as i32 * 1000)
+    /// The forced rendering frame rate in millihertz if enabled (either due to
+    /// the window rule or due to being a cast target), or `None` if disabled.
+    pub fn force_render(&self) -> Option<u32> {
+        if self.is_window_cast_target {
+            Some(0) // use last output's refresh rate
+        } else if self.rules.force_render == Some(true) {
+            Some(self.rules.force_render_fps.unwrap_or(0) as u32 * 1000)
         } else {
             None
         }

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -611,6 +611,16 @@ impl Mapped {
     pub fn is_urgent(&self) -> bool {
         self.is_urgent
     }
+
+    /// The forced rendering rate if enabled (either due to the window rule or
+    /// due to being a cast target), or `None` if disabled.
+    pub fn force_render(&self) -> Option<i32> {
+        if self.is_window_cast_target || self.rules.force_render == Some(true) {
+            Some(self.rules.force_render_fps.unwrap_or(0) as i32 * 1000)
+        } else {
+            None
+        }
+    }
 }
 
 impl Drop for Mapped {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -120,6 +120,12 @@ pub struct ResolvedWindowRules {
     /// Override whether to set the Tiled xdg-toplevel state on the window.
     pub tiled_state: Option<bool>,
 
+    /// Whether to force renders on this window.
+    pub force_render: Option<bool>,
+
+    /// Forced render FPS limit for this window.
+    pub force_render_fps: Option<u16>,
+
     /// Background effect configuration.
     pub background_effect: BackgroundEffect,
 
@@ -301,6 +307,12 @@ impl ResolvedWindowRules {
                 }
                 if let Some(x) = rule.tiled_state {
                     resolved.tiled_state = Some(x);
+                }
+                if let Some(x) = rule.force_render {
+                    resolved.force_render = Some(x);
+                }
+                if let Some(x) = rule.force_render_fps {
+                    resolved.force_render_fps = Some(x);
                 }
 
                 resolved

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -120,7 +120,7 @@ pub struct ResolvedWindowRules {
     /// Override whether to set the Tiled xdg-toplevel state on the window.
     pub tiled_state: Option<bool>,
 
-    /// Whether to force renders on this window.
+    /// What FPS to force renders for this window.
     pub force_render: Option<u16>,
 
     /// Background effect configuration.

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -121,10 +121,7 @@ pub struct ResolvedWindowRules {
     pub tiled_state: Option<bool>,
 
     /// Whether to force renders on this window.
-    pub force_render: Option<bool>,
-
-    /// Forced render FPS limit for this window.
-    pub force_render_fps: Option<u16>,
+    pub force_render: Option<u16>,
 
     /// Background effect configuration.
     pub background_effect: BackgroundEffect,
@@ -310,9 +307,6 @@ impl ResolvedWindowRules {
                 }
                 if let Some(x) = rule.force_render {
                     resolved.force_render = Some(x);
-                }
-                if let Some(x) = rule.force_render_fps {
-                    resolved.force_render_fps = Some(x);
                 }
 
                 resolved


### PR DESCRIPTION
Renders a window when it is being screencast or as configured by the force-render window rule.  Maximum FPS of windows being rendered this way is controlled by the force-render-fps window rule (unlimited by default, or when explicitly set to 0).

This is inspired by #2609, but is not a direct update of it. In particular, this avoids storing the force render state globally, and instead puts it in the data map, which should prevent the memory leak (https://github.com/niri-wm/niri/pull/2609/changes#r3588566980).

Closes #2609.

TODO: bikeshedding, docs