### PR TITLE
Fix non-xray blur capture on render-only framebuffers

### DIFF
--- a/src/render_helpers/framebuffer_effect.rs
+++ b/src/render_helpers/framebuffer_effect.rs
@@ -254,7 +254,20 @@ impl RenderElement<GlesRenderer> for FramebufferEffectElement {
                 while gl.GetError() != ffi::NO_ERROR {}
 
                 let mut current_fbo = 0i32;
+                let mut current_read_buffer = 0i32;
                 gl.GetIntegerv(ffi::DRAW_FRAMEBUFFER_BINDING, &mut current_fbo as *mut _);
+                gl.GetIntegerv(ffi::READ_BUFFER, &mut current_read_buffer as *mut _);
+
+                // Render targets may be configured as render-only.
+                let temporary_read_buffer =
+                    (current_read_buffer == ffi::NONE as i32).then_some(if current_fbo == 0 {
+                        ffi::BACK
+                    } else {
+                        ffi::COLOR_ATTACHMENT0
+                    });
+                if let Some(read_buffer) = temporary_read_buffer {
+                    gl.ReadBuffer(read_buffer);
+                }
 
                 // BlitFramebuffer is affected by the scissor test, we don't want that.
                 gl.Disable(ffi::SCISSOR_TEST);
@@ -286,6 +299,9 @@ impl RenderElement<GlesRenderer> for FramebufferEffectElement {
 
                 // Restore state set by GlesFrame that we just modified.
                 gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, current_fbo as u32);
+                if temporary_read_buffer.is_some() {
+                    gl.ReadBuffer(current_read_buffer as u32);
+                }
                 gl.Enable(ffi::SCISSOR_TEST);
 
                 gl.DeleteFramebuffers(1, &mut fbo as *mut _);


### PR DESCRIPTION
Fixes #4378.

The multi-GPU renderer uses an offscreen framebuffer whose read buffer may be `GL_NONE`. Non-xray blur calls `glBlitFramebuffer()` to capture the contents behind a window, but it previously changed only the draw framebuffer. On this target, the capture was all zeroes.

If the read buffer is `GL_NONE`, select `GL_BACK` for the default framebuffer or `GL_COLOR_ATTACHMENT0` for other framebuffers while blitting, then restore the previous state.

I reproduced this on an Intel + NVIDIA system using DRM CRTC CRC, so screencopy would not trigger a separate render. I tested both Smithay's CPU-copy path and a separate Vulkan copy path. In both cases, non-xray blur updated the Intel-connected output immediately after this change.

`cargo test --workspace` and `cargo check -p niri` pass.