### PR TITLE
Add `fill-empty-space` layout option

### DIFF
--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -9,6 +9,7 @@ layout {
     gaps 16
     center-focused-column "never"
     always-center-single-column
+    fill-empty-space
     empty-workspace-above-first
     default-column-display "tabbed"
     background-color "#003300"
@@ -139,6 +140,18 @@ If set, niri will always center a single column on a workspace, regardless of th
 ```kdl
 layout {
     always-center-single-column
+}
+```
+
+### `fill-empty-space`
+
+If set, niri will scroll the view to avoid leaving empty space on screen when there are more columns off-screen. Whenever the content that fills the view shrinks — closing a window, moving it to another workspace or output, floating it, exiting fullscreen or resizing a column narrower — the view scrolls to eliminate empty space.
+
+Note that the `center-focused-column "always"` option takes precedence.
+
+```kdl
+layout {
+    fill-empty-space
 }
 ```
 

--- a/niri-config/src/layout.rs
+++ b/niri-config/src/layout.rs
@@ -19,6 +19,7 @@ pub struct Layout {
     pub preset_window_heights: Vec<PresetSize>,
     pub center_focused_column: CenterFocusedColumn,
     pub always_center_single_column: bool,
+    pub fill_empty_space: bool,
     pub empty_workspace_above_first: bool,
     pub default_column_display: ColumnDisplay,
     pub gaps: f64,
@@ -42,6 +43,7 @@ impl Default for Layout {
             default_column_width: Some(PresetSize::Proportion(0.5)),
             center_focused_column: CenterFocusedColumn::Never,
             always_center_single_column: false,
+            fill_empty_space: false,
             empty_workspace_above_first: false,
             default_column_display: ColumnDisplay::Normal,
             gaps: 16.,
@@ -66,6 +68,7 @@ impl MergeWith<LayoutPart> for Layout {
             tab_indicator,
             insert_hint,
             always_center_single_column,
+            fill_empty_space,
             empty_workspace_above_first,
             gaps,
         );
@@ -116,6 +119,8 @@ pub struct LayoutPart {
     pub center_focused_column: Option<CenterFocusedColumn>,
     #[knuffel(child)]
     pub always_center_single_column: Option<Flag>,
+    #[knuffel(child)]
+    pub fill_empty_space: Option<Flag>,
     #[knuffel(child)]
     pub empty_workspace_above_first: Option<Flag>,
     #[knuffel(child, unwrap(argument, str))]

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1458,6 +1458,7 @@ mod tests {
                 ],
                 center_focused_column: OnOverflow,
                 always_center_single_column: false,
+                fill_empty_space: false,
                 empty_workspace_above_first: false,
                 default_column_display: Tabbed,
                 gaps: 8.0,

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -560,9 +560,16 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         };
 
         let target_x = target_x.unwrap_or_else(|| self.target_view_pos());
-
-        let new_offset =
-            compute_new_view_offset(target_x + area.loc.x, area.size.w, col_x, width, padding);
+        let content_right = self.column_x(self.columns.len()) - self.options.layout.gaps;
+        let new_offset = compute_new_view_offset(
+            target_x + area.loc.x,
+            area.size.w,
+            col_x,
+            width,
+            padding,
+            content_right,
+            self.options.layout.fill_empty_space,
+        );
 
         // Non-fullscreen windows are always offset at least by the working area position.
         new_offset - area.loc.x
@@ -1207,6 +1214,8 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let view_config = anim_config.unwrap_or(self.options.animations.horizontal_view_movement.0);
 
+        let mut move_view = self.options.layout.fill_empty_space;
+
         if column_idx < self.active_column_idx {
             // A column to the left was removed; preserve the current position.
             // FIXME: preserve activate_prev_column_on_removal.
@@ -1228,16 +1237,21 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     prev_offset,
                     view_config,
                 );
-                self.animate_view_offset_to_column_with_config(
-                    None,
-                    self.active_column_idx,
-                    None,
-                    view_config,
-                );
+
+                move_view = true;
             }
         } else {
             self.activate_column_with_anim_config(
                 min(self.active_column_idx, self.columns.len() - 1),
+                view_config,
+            );
+        }
+
+        if move_view {
+            self.animate_view_offset_to_column_with_config(
+                None,
+                self.active_column_idx,
+                None,
                 view_config,
             );
         }
@@ -1335,6 +1349,9 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             }
         }
 
+        let mut move_view = false;
+        let mut unfullscreen_offset = None;
+
         if col_idx == self.active_column_idx {
             // If offset == 0, then don't mess with the view or the gesture. Some clients (Firefox,
             // Chromium, Electron) currently don't commit after the ack of a configure that drops
@@ -1375,35 +1392,43 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             // will unfullscreen one by one, and the column width will shrink only when the
             // last tile unfullscreens. This is when we want to restore the view offset,
             // otherwise it will immediately reset back by the animate_view_offset below.
-            let unfullscreen_offset = if !was_normal && is_normal {
+            if !was_normal && is_normal {
                 // Take the value unconditionally, even if the view is currently frozen by
                 // a view gesture. It shouldn't linger around because it's only valid for this
                 // particular unfullscreen.
-                self.view_offset_to_restore.take()
+                unfullscreen_offset = self.view_offset_to_restore.take();
+            }
+            move_view = true;
+        } else if self.options.layout.fill_empty_space && offset != 0. {
+            // Remove empty space when a non-active column changes width. This covers both
+            // resizes and fullscreen transitions.
+            move_view = true;
+        }
+
+        // We might need to move the view to ensure the resized window is still visible. But
+        // only do it when the view isn't frozen by an interactive resize or a view gesture.
+        if move_view && self.interactive_resize.is_none() && !self.view_offset.is_gesture() {
+            // Synchronize the horizontal view movement with the resize so that it looks nice.
+            // This is especially important for always-centered view.
+            let config = if ongoing_resize_anim {
+                self.options.animations.window_resize.anim
             } else {
-                None
+                self.options.animations.horizontal_view_movement.0
             };
 
-            // We might need to move the view to ensure the resized window is still visible. But
-            // only do it when the view isn't frozen by an interactive resize or a view gesture.
-            if self.interactive_resize.is_none() && !self.view_offset.is_gesture() {
-                // Synchronize the horizontal view movement with the resize so that it looks nice.
-                // This is especially important for always-centered view.
-                let config = if ongoing_resize_anim {
-                    self.options.animations.window_resize.anim
-                } else {
-                    self.options.animations.horizontal_view_movement.0
-                };
-
-                // Restore the view offset upon unfullscreening if needed.
-                if let Some(prev_offset) = unfullscreen_offset {
-                    self.animate_view_offset_with_config(col_idx, prev_offset, config);
-                }
-
-                // FIXME: we will want to skip the animation in some cases here to make continuously
-                // resizing windows not look janky.
-                self.animate_view_offset_to_column_with_config(None, col_idx, None, config);
+            // Restore the view offset upon unfullscreening if needed.
+            if let Some(prev_offset) = unfullscreen_offset {
+                self.animate_view_offset_with_config(self.active_column_idx, prev_offset, config);
             }
+
+            // FIXME: we will want to skip the animation in some cases here to make continuously
+            // resizing windows not look janky.
+            self.animate_view_offset_to_column_with_config(
+                None,
+                self.active_column_idx,
+                None,
+                config,
+            );
         }
     }
 
@@ -5460,6 +5485,8 @@ fn compute_new_view_offset(
     new_col_x: f64,
     new_col_width: f64,
     gaps: f64,
+    content_right: f64,
+    fill_empty_space: bool,
 ) -> f64 {
     // If the column is wider than the view, always left-align it.
     if view_width <= new_col_width {
@@ -5473,19 +5500,37 @@ fn compute_new_view_offset(
     let new_x = new_col_x - padding;
     let new_right_x = new_col_x + new_col_width + padding;
 
-    // If the column is already fully visible, leave the view as is.
-    if cur_x <= new_x && new_right_x <= cur_x + view_width {
-        return -(new_col_x - cur_x);
+    let mut offset = if cur_x <= new_x && new_right_x <= cur_x + view_width {
+        // If the column is already fully visible, leave the view as is.
+        -(new_col_x - cur_x)
+    } else {
+        // Otherwise, prefer the alignment that results in less motion from the current position.
+        let dist_to_left = (cur_x - new_x).abs();
+        let dist_to_right = ((cur_x + view_width) - new_right_x).abs();
+        if dist_to_left <= dist_to_right {
+            -padding
+        } else {
+            -(view_width - padding - new_col_width)
+        }
+    };
+
+    // Don't leave empty space past the ends of the view: keep the view within the content, pulling
+    // off-screen columns in rather than showing a blank gap at either edge.
+    if fill_empty_space {
+        let view_left = new_col_x + offset;
+        let clips_left = 0. < view_left;
+        let clips_right = view_left + view_width < content_right;
+
+        // Only act when some content is actually off screen.
+        if clips_left || clips_right {
+            let min_view_left = -padding;
+            let max_view_left = f64::max(content_right - view_width + padding, min_view_left);
+            let clamped = view_left.clamp(min_view_left, max_view_left);
+            offset += clamped - view_left;
+        }
     }
 
-    // Otherwise, prefer the alignment that results in less motion from the current position.
-    let dist_to_left = (cur_x - new_x).abs();
-    let dist_to_right = ((cur_x + view_width) - new_right_x).abs();
-    if dist_to_left <= dist_to_right {
-        -padding
-    } else {
-        -(view_width - padding - new_col_width)
-    }
+    offset
 }
 
 fn compute_working_area(

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -3630,6 +3630,568 @@ fn move_window_to_workspace_maximize_and_fullscreen() {
     assert_eq!(win.pending_sizing_mode(), SizingMode::Normal);
 }
 
+/// Create layout of `cols` columns `width` pixels wide on a 1280px output with the given layout
+/// settings.
+fn fill_empty_space_layout(
+    cols: usize,
+    width: i32,
+    fill_empty_space: bool,
+    layout: Option<niri_config::Layout>,
+) -> Layout<TestWindow> {
+    let mut ops = vec![Op::AddOutput(1)];
+    for id in 1..=cols {
+        ops.push(Op::AddWindow {
+            params: TestWindowParams::new(id),
+        });
+        ops.push(Op::SetColumnWidth(SizeChange::SetFixed(width)));
+        ops.push(Op::Communicate(id));
+    }
+
+    // Leave the last column focused, having focused away and back so that
+    // activate_prev_column_on_removal is cleared — otherwise removing the focused column would
+    // restore the pre-open view offset, independently of the fill-empty-space option.
+    if 1 < cols {
+        ops.push(Op::FocusColumn(cols - 1));
+    }
+    ops.push(Op::FocusColumn(cols));
+    ops.push(Op::CompleteAnimations);
+
+    let options = Options {
+        layout: niri_config::Layout {
+            fill_empty_space,
+            ..layout.unwrap_or_default()
+        },
+        ..Default::default()
+    };
+    check_ops_with_options(options, ops)
+}
+
+fn view_pos(layout: &Layout<TestWindow>) -> f64 {
+    layout.active_workspace().unwrap().scrolling().view_pos()
+}
+
+#[test]
+fn fill_empty_space_close_last_focused() {
+    let close = [Op::CloseWindow(5), Op::CompleteAnimations];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, close.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, close);
+    insta::assert_snapshot!(view_pos(&layout), @"384");
+}
+
+#[test]
+fn fill_empty_space_close_last_unfocused() {
+    let close = [
+        Op::FocusColumn(4),
+        Op::CloseWindow(5),
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, close.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, close);
+    insta::assert_snapshot!(view_pos(&layout), @"384");
+}
+
+#[test]
+fn fill_empty_space_close_first_unfocused() {
+    // Move focus to the far left, so the leftmost column is visible when it is closed.
+    let focus = [
+        Op::FocusColumn(1),
+        Op::FocusColumn(2),
+        Op::CompleteAnimations,
+    ];
+    let close = [Op::CloseWindow(1), Op::CompleteAnimations];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    check_ops_on_layout(&mut layout, focus.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+    check_ops_on_layout(&mut layout, close.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-432");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    check_ops_on_layout(&mut layout, focus);
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+    check_ops_on_layout(&mut layout, close);
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+}
+
+#[test]
+fn fill_empty_space_move_last_focused() {
+    let move_away = [
+        Op::MoveWindowToWorkspaceDown(true),
+        Op::FocusWorkspaceUp,
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, move_away.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, move_away);
+    insta::assert_snapshot!(view_pos(&layout), @"384");
+}
+
+#[test]
+fn fill_empty_space_move_last_unfocused() {
+    let move_away = [
+        Op::FocusColumn(4),
+        Op::MoveWindowToWorkspace {
+            window_id: Some(5),
+            workspace_idx: 1,
+        },
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, move_away.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, move_away);
+    insta::assert_snapshot!(view_pos(&layout), @"384");
+}
+
+#[test]
+fn fill_empty_space_move_first_unfocused() {
+    // Move focus to the far left, so the leftmost column is visible when it is moved away.
+    let setup = [
+        Op::AddOutput(2),
+        Op::FocusColumn(1),
+        Op::FocusColumn(2),
+        Op::CompleteAnimations,
+    ];
+    let move_away = [
+        Op::MoveWindowToOutput {
+            window_id: Some(1),
+            output_id: 2,
+            target_ws_idx: None,
+        },
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    check_ops_on_layout(&mut layout, setup.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+    check_ops_on_layout(&mut layout, move_away.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-432");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    check_ops_on_layout(&mut layout, setup);
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+    check_ops_on_layout(&mut layout, move_away);
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+}
+
+#[test]
+fn fill_empty_space_float_last_focused() {
+    let float = [
+        Op::ToggleWindowFloating { id: None },
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, float.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, float);
+    insta::assert_snapshot!(view_pos(&layout), @"384");
+}
+
+#[test]
+fn fill_empty_space_float_last_unfocused() {
+    let float = [
+        Op::FocusColumn(4),
+        Op::ToggleWindowFloating { id: Some(5) },
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, float.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, float);
+    insta::assert_snapshot!(view_pos(&layout), @"384");
+}
+
+#[test]
+fn fill_empty_space_float_first() {
+    // Move focus to the far left, so the leftmost column is visible when it is floated.
+    let focus = [
+        Op::FocusColumn(1),
+        Op::FocusColumn(2),
+        Op::CompleteAnimations,
+    ];
+    let float = [
+        Op::ToggleWindowFloating { id: Some(1) },
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    check_ops_on_layout(&mut layout, focus.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+    check_ops_on_layout(&mut layout, float.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-432");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    check_ops_on_layout(&mut layout, focus);
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+    check_ops_on_layout(&mut layout, float);
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+}
+
+#[test]
+fn fill_empty_space_consume_last() {
+    let consume = [
+        Op::FocusColumn(4),
+        Op::ConsumeWindowIntoColumn,
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, consume.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, consume);
+    insta::assert_snapshot!(view_pos(&layout), @"384");
+}
+
+#[test]
+fn fill_empty_space_consume_first() {
+    let focus = [
+        Op::FocusColumn(1),
+        Op::FocusColumn(2),
+        Op::CompleteAnimations,
+    ];
+    let consume = [
+        Op::ConsumeOrExpelWindowRight { id: Some(1) },
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space where the window was.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    check_ops_on_layout(&mut layout, focus.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+    check_ops_on_layout(&mut layout, consume.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-432");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    check_ops_on_layout(&mut layout, focus);
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+    check_ops_on_layout(&mut layout, consume);
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+}
+
+#[test]
+fn fill_empty_space_unfullscreen_focused() {
+    // Fullscreening the active column stashes the view offset, and unfullscreening puts it back as
+    // long as nothing else moved the end of the strip in the meantime.
+    let fullscreen = [
+        Op::FullscreenWindow(5),
+        Op::Communicate(5),
+        Op::CompleteAnimations,
+        Op::FullscreenWindow(5),
+        Op::Communicate(5),
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, fullscreen.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, fullscreen);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+}
+
+#[test]
+fn fill_empty_space_unfullscreen_focused_after_content_shrank() {
+    // Same round trip, but the window shrinks while the fullscreen is up. That has no visible
+    // effect until it unfullscreens, at which point the strip is shorter than when the offset was
+    // stashed, causing the view to scroll. Resizing a non-active column yields the same result.
+    let fullscreen = [
+        Op::FullscreenWindow(5),
+        Op::Communicate(5),
+        Op::SetColumnWidth(SizeChange::SetFixed(200)),
+        Op::Communicate(5),
+        Op::CompleteAnimations,
+    ];
+    let unfullscreen = [
+        Op::FullscreenWindow(5),
+        Op::Communicate(5),
+        Op::CompleteAnimations,
+    ];
+
+    // Off: view restored to where it was, which now leaves some empty space to the right.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    check_ops_on_layout(&mut layout, fullscreen.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"1664");
+    check_ops_on_layout(&mut layout, unfullscreen.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    check_ops_on_layout(&mut layout, fullscreen);
+    insta::assert_snapshot!(view_pos(&layout), @"1664");
+    check_ops_on_layout(&mut layout, unfullscreen);
+    insta::assert_snapshot!(view_pos(&layout), @"600");
+}
+
+#[test]
+fn fill_empty_space_unfullscreen_unfocused_after_content_shrank() {
+    // Same round trip, but a window shrinks while the fullscreen is up. That has no visible
+    // effect until it unfullscreens, at which point the strip is shorter than when the offset was
+    // stashed, causing the view to scroll.
+    let fullscreen = [
+        Op::FullscreenWindow(5),
+        Op::Communicate(5),
+        Op::FocusColumn(4),
+        Op::SetColumnWidth(SizeChange::SetFixed(200)),
+        Op::Communicate(4),
+        Op::CompleteAnimations,
+    ];
+    let unfullscreen = [
+        Op::SetFullscreenWindow {
+            window: 5,
+            is_fullscreen: false,
+        },
+        Op::Communicate(5),
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space that the fullscreen window was occupying.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    check_ops_on_layout(&mut layout, fullscreen.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"1232");
+    check_ops_on_layout(&mut layout, unfullscreen.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"1232");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    check_ops_on_layout(&mut layout, fullscreen);
+    insta::assert_snapshot!(view_pos(&layout), @"1232");
+    check_ops_on_layout(&mut layout, unfullscreen);
+    insta::assert_snapshot!(view_pos(&layout), @"600");
+}
+
+#[test]
+fn fill_empty_space_shrink_last_focused() {
+    // Narrowing a column frees space next to it.
+    let shrink = [
+        Op::SetColumnWidth(SizeChange::SetFixed(200)),
+        Op::Communicate(5),
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space to the right of the narrowed column.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, shrink.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, shrink);
+    insta::assert_snapshot!(view_pos(&layout), @"600");
+}
+
+#[test]
+fn fill_empty_space_shrink_last_unfocused() {
+    // Narrowing a column frees space next to it.
+    let shrink = [
+        Op::FocusColumn(4),
+        Op::SetWindowWidth {
+            id: Some(5),
+            change: SizeChange::SetFixed(200),
+        },
+        Op::Communicate(5),
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space to the right of the narrowed column.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, shrink.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, shrink);
+    insta::assert_snapshot!(view_pos(&layout), @"600");
+}
+
+#[test]
+fn fill_empty_space_shrink_last_interactive() {
+    // Same as above, but through an interactive resize. The view is deliberately left alone while
+    // the drag is in progress, so the fill only happens once the resize ends.
+    let drag = [
+        Op::InteractiveResizeBegin {
+            window: 5,
+            edges: ResizeEdge::RIGHT,
+        },
+        Op::InteractiveResizeUpdate {
+            window: 5,
+            dx: -200.,
+            dy: 0.,
+        },
+        Op::Communicate(5),
+        Op::InteractiveResizeEnd { window: 5 },
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space to the right of the narrowed column.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, drag.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    insta::assert_snapshot!(view_pos(&layout), @"800");
+    check_ops_on_layout(&mut layout, drag);
+    insta::assert_snapshot!(view_pos(&layout), @"600");
+}
+
+#[test]
+fn fill_empty_space_shrink_first() {
+    // Shrinking the first column on the left edge leaves a gap to the left.
+    let focus = [
+        Op::FocusColumn(1),
+        Op::FocusColumn(2),
+        Op::CompleteAnimations,
+    ];
+    let shrink = [
+        Op::SetWindowWidth {
+            id: Some(1),
+            change: SizeChange::SetFixed(200),
+        },
+        Op::Communicate(1),
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space to the left of the narrowed column.
+    let mut layout = fill_empty_space_layout(5, 400, false, None);
+    check_ops_on_layout(&mut layout, focus.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+    check_ops_on_layout(&mut layout, shrink.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-216");
+
+    // On: the view scrolls, leaving no empty space.
+    let mut layout = fill_empty_space_layout(5, 400, true, None);
+    check_ops_on_layout(&mut layout, focus);
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+    check_ops_on_layout(&mut layout, shrink);
+    insta::assert_snapshot!(view_pos(&layout), @"-16");
+}
+
+#[test]
+fn fill_empty_space_center_focused_column_takes_precedence() {
+    // With center-focused-column "always" the focused column is centered, and that wins.
+    let config = niri_config::Layout {
+        center_focused_column: CenterFocusedColumn::Always,
+        ..Default::default()
+    };
+
+    let close = [Op::CloseWindow(5), Op::CompleteAnimations];
+
+    // Off: the focused column is centered.
+    let mut layout = fill_empty_space_layout(5, 400, false, Some(config.clone()));
+    insta::assert_snapshot!(view_pos(&layout), @"1224");
+    check_ops_on_layout(&mut layout, close.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"808");
+
+    // On: the focused column is centered.
+    let mut layout = fill_empty_space_layout(5, 400, true, Some(config));
+    insta::assert_snapshot!(view_pos(&layout), @"1224");
+    check_ops_on_layout(&mut layout, close);
+    insta::assert_snapshot!(view_pos(&layout), @"808");
+}
+
+#[test]
+fn fill_empty_space_center_single_column_keeps_view() {
+    // always-center-single-column parks a lone column in the middle of the view, leaving blank
+    // space on both sides deliberately. Adding a second column drops the centering, but both
+    // columns are still fully on screen — so there is no empty space to reclaim and the view
+    // must not jump.
+    let config = niri_config::Layout {
+        always_center_single_column: true,
+        ..Default::default()
+    };
+
+    let add_second = [
+        Op::AddWindow {
+            params: TestWindowParams::new(2),
+        },
+        Op::SetColumnWidth(SizeChange::SetFixed(400)),
+        Op::Communicate(2),
+        Op::CompleteAnimations,
+    ];
+
+    // Off: the view stays put, leaving empty space to the left.
+    let mut layout = fill_empty_space_layout(1, 400, false, Some(config.clone()));
+    insta::assert_snapshot!(view_pos(&layout), @"-440");
+    check_ops_on_layout(&mut layout, add_second.clone());
+    insta::assert_snapshot!(view_pos(&layout), @"-440");
+
+    // On: the view stays put, leaving empty space to the left.
+    let mut layout = fill_empty_space_layout(1, 400, true, Some(config));
+    insta::assert_snapshot!(view_pos(&layout), @"-440");
+    check_ops_on_layout(&mut layout, add_second);
+    insta::assert_snapshot!(view_pos(&layout), @"-440");
+}
+
 #[test]
 fn tabs_with_different_border() {
     let ops = [
@@ -3887,6 +4449,7 @@ prop_compose! {
         tab_indicator in prop::option::of(arbitrary_tab_indicator()),
         center_focused_column in prop::option::of(arbitrary_center_focused_column()),
         always_center_single_column in prop::option::of(any::<bool>().prop_map(Flag)),
+        fill_empty_space in prop::option::of(any::<bool>().prop_map(Flag)),
         empty_workspace_above_first in prop::option::of(any::<bool>().prop_map(Flag)),
     ) -> niri_config::LayoutPart {
         niri_config::LayoutPart {
@@ -3894,6 +4457,7 @@ prop_compose! {
             struts,
             center_focused_column,
             always_center_single_column,
+            fill_empty_space,
             empty_workspace_above_first,
             focus_ring,
             border,


### PR DESCRIPTION
When the content that fills the view shrinks, niri mostly keeps the view where it is, which can leave parts of the screen blank even though there are more columns off-screen. Closing the rightmost window is the clearest case: the view stays put and the space the closed window occupied is empty, instead of pulling off-screen columns in.

This adds an opt-in `fill-empty-space` flag under `layout`. When set, the view scrolls to eliminate empty space as long as there is off-screen content to pull. That covers closing a window, moving it to another workspace or output, floating it, consuming it into a column, exiting fullscreen, and resizing a column narrower.

Three touchpoints:

- `compute_new_view_offset` clamps the view inside the content. This alone covers close, move, float, consume, resize on the active window.
- `remove_column_by_idx` re-fits the active column after any removal (by default it does so only for the active column). This covers closing, moving, floating and consuming a non-active window.
- `update_window` re-fits the active column when a non-active column changes width. This covers resizing and unfullscreening a non-active window.

Centering via `center-focused-column "always"` takes precedence.

This is a recurring topic, discussed or mentioned in: https://github.com/niri-wm/niri/discussions/156, https://github.com/niri-wm/niri/discussions/466, https://github.com/niri-wm/niri/discussions/637, https://github.com/niri-wm/niri/discussions/1642, https://github.com/niri-wm/niri/discussions/1799, https://github.com/niri-wm/niri/discussions/2815, https://github.com/niri-wm/niri/discussions/3289, https://github.com/niri-wm/niri/discussions/4251, https://github.com/niri-wm/niri/discussions/4327, https://github.com/niri-wm/niri/issues/2416, https://github.com/niri-wm/niri/issues/4308, https://github.com/niri-wm/niri/issues/4321

### Before/after:

#### Closing a window

https://github.com/user-attachments/assets/718499f6-8cb9-435a-b2f6-29042ba0caab

https://github.com/user-attachments/assets/9a62497f-1e7b-4949-8744-7bc6a999c8d9

#### Moving a window to another workspace

https://github.com/user-attachments/assets/d14cbeff-c742-4ea6-ab9b-411fe2bde9ab

https://github.com/user-attachments/assets/4f7f0aea-6142-4876-8393-7f34d260b647

#### Consuming a window into a column

https://github.com/user-attachments/assets/4ac63589-f182-48df-b34d-f1600f8f963e

https://github.com/user-attachments/assets/cb12d2e2-6cfd-47e7-8e15-3d71b7db3645

#### Floating a window

https://github.com/user-attachments/assets/281333a7-735a-4bd6-b8ee-55d406df7005

https://github.com/user-attachments/assets/5d8483b7-dfb3-4d63-b3db-92bc7c6a63ac

#### Resizing a column narrower

https://github.com/user-attachments/assets/92d81fa9-8ad5-4bff-8360-8dd3d0c451ca

https://github.com/user-attachments/assets/fa82ef59-c065-425d-98cb-ae13d983a699



