### PR TITLE
Keep pointer constraints in sync with keyboard focus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,7 +3232,7 @@ checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/Vantrongs/smithay.git?rev=fe0320bc4586383dd774fd1768775e7d941e1e47#fe0320bc4586383dd774fd1768775e7d941e1e47"
+source = "git+https://github.com/Vantrongs/smithay.git?rev=1b0e75abb473847c08ed83b1d18519c06fed9a47#1b0e75abb473847c08ed83b1d18519c06fed9a47"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Vantrongs/smithay.git?rev=fe0320bc4586383dd774fd1768775e7d941e1e47#fe0320bc4586383dd774fd1768775e7d941e1e47"
+source = "git+https://github.com/Vantrongs/smithay.git?rev=1b0e75abb473847c08ed83b1d18519c06fed9a47#1b0e75abb473847c08ed83b1d18519c06fed9a47"
 dependencies = [
  "drm",
  "libdisplay-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,7 +3232,7 @@ checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/Smithay/smithay.git?rev=7609ab82f002436188ebd4df1d8f7e1905f90c4a#7609ab82f002436188ebd4df1d8f7e1905f90c4a"
+source = "git+https://github.com/Vantrongs/smithay.git?rev=fe0320bc4586383dd774fd1768775e7d941e1e47#fe0320bc4586383dd774fd1768775e7d941e1e47"
 dependencies = [
  "aliasable",
  "appendlist",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git?rev=7609ab82f002436188ebd4df1d8f7e1905f90c4a#7609ab82f002436188ebd4df1d8f7e1905f90c4a"
+source = "git+https://github.com/Vantrongs/smithay.git?rev=fe0320bc4586383dd774fd1768775e7d941e1e47#fe0320bc4586383dd774fd1768775e7d941e1e47"
 dependencies = [
  "drm",
  "libdisplay-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,15 +27,14 @@ tracy-client = { version = "0.18.4", default-features = false }
 
 [workspace.dependencies.smithay]
 # version = "0.4.1"
-git = "https://github.com/Smithay/smithay.git"
-rev = "7609ab82f002436188ebd4df1d8f7e1905f90c4a"
+git = "https://github.com/Vantrongs/smithay.git"
+rev = "fe0320bc4586383dd774fd1768775e7d941e1e47"
 default-features = false
 
 [workspace.dependencies.smithay-drm-extras]
 # version = "0.1.0"
-git = "https://github.com/Smithay/smithay.git"
-rev = "7609ab82f002436188ebd4df1d8f7e1905f90c4a"
-# path = "../smithay/smithay-drm-extras"
+git = "https://github.com/Vantrongs/smithay.git"
+rev = "fe0320bc4586383dd774fd1768775e7d941e1e47"
 
 [package]
 name = "niri"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,13 @@ tracy-client = { version = "0.18.4", default-features = false }
 [workspace.dependencies.smithay]
 # version = "0.4.1"
 git = "https://github.com/Vantrongs/smithay.git"
-rev = "fe0320bc4586383dd774fd1768775e7d941e1e47"
+rev = "1b0e75abb473847c08ed83b1d18519c06fed9a47"
 default-features = false
 
 [workspace.dependencies.smithay-drm-extras]
 # version = "0.1.0"
 git = "https://github.com/Vantrongs/smithay.git"
-rev = "fe0320bc4586383dd774fd1768775e7d941e1e47"
+rev = "1b0e75abb473847c08ed83b1d18519c06fed9a47"
 
 [package]
 name = "niri"

--- a/docs/wiki/Configuration:-Debug-Options.md
+++ b/docs/wiki/Configuration:-Debug-Options.md
@@ -283,6 +283,8 @@ Most of the time, these fresh tokens will have invalid serials, because the app 
 By default, niri ignores xdg-activation tokens with invalid serials, to prevent windows from randomly stealing focus.
 This debug flag makes niri honor such tokens, making the aforementioned widely-used apps get focus when clicking on their tray icon or notification.
 
+Use the [`on-xdg-activate` window rule](./Configuration:-Window-Rules.md#on-xdg-activate) to control what niri does for individual windows when it accepts an xdg-activation request.
+
 Amusingly, clicking on a notification sends the app a perfectly valid activation token from the notification daemon, but these apps seem to simply ignore it.
 Maybe in the future these apps/toolkits (Electron, Qt) are fixed, making this debug flag unnecessary.
 

--- a/docs/wiki/Configuration:-Window-Rules.md
+++ b/docs/wiki/Configuration:-Window-Rules.md
@@ -58,6 +58,7 @@ window-rule {
     default-column-display "tabbed"
     default-floating-position x=100 y=200 relative-to="bottom-left"
     scroll-factor 0.75
+    on-xdg-activate "focus"
 
     focus-ring {
         // off
@@ -593,6 +594,35 @@ window-rule {
 >
 > This is because window title (and app ID) are not double-buffered in the Wayland protocol, so they are not tied to specific window contents.
 > There's no robust way for Firefox to synchronize visibly showing a different tab and changing the window title.
+
+#### `on-xdg-activate`
+
+<sup>Since: next release</sup>
+
+Set what niri does when a window requests activation through [xdg-activation](https://wayland.app/protocols/xdg-activation-v1).
+
+Values:
+
+- `"ignore"`: do nothing: neither focus the window nor mark it urgent.
+- `"set-urgent"`: always mark the window urgent instead of focusing it.
+- `"focus"`: always focus the window, even for activation requests without a serial.
+
+The default behavior, when this rule is unset, picks between focusing and marking the window urgent based on the serial that the application provides when creating the activation token.
+Requests with a valid serial focus the target window, and requests without a serial mark it urgent.
+
+Requests with a set, but invalid, serial, are always ignored, which you can change with the [`honor-xdg-activation-with-invalid-serial`](https://niri-wm.github.io/niri/Configuration%3A-Debug-Options.html#honor-xdg-activation-with-invalid-serial) debug flag.
+
+This is useful for apps that steal focus on incoming messages or when opening popup windows like Picture-in-Picture.
+
+```kdl
+// Don't let Firefox PiP steal focus.
+window-rule {
+    match title="^Picture-in-Picture$"
+
+    open-floating true
+    on-xdg-activate "set-urgent"
+}
+```
 
 #### `opacity`
 

--- a/docs/wiki/Window-Geometry-IPC.md
+++ b/docs/wiki/Window-Geometry-IPC.md
@@ -1,0 +1,19 @@
+# On-demand window geometry (local fork)
+
+`niri msg --json window-geometry --id <window-id>` returns the exact focused
+window's current global logical visual rectangle and the logical output layout
+from the same compositor callback. It uses rendered placement, including the
+client geometry offset; it does not derive tiled positions from cached IPC
+layout data and does not emit per-frame window-layout events.
+
+The request fails while locked, in overview/screenshot/MRU/exit UI, during output
+layout animations or screen transitions, for a dragged window, or if actual
+keyboard focus belongs to another window or a layer-shell surface.
+Consumers must handle these errors instead of guessing coordinates. Geometry
+is a snapshot, not a lock: validate it around capture and again after input
+backend preparation, immediately before dispatch. Never replay an input operation
+after failure. A compositor restart is required after installing
+this fork update; replacing only the `niri msg` CLI is insufficient.
+
+Regression: `cargo test -p niri live_window_geometry` exercises tiled and moved
+floating windows against the real headless compositor's pointer hit-testing.

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
               ./src
               ./Cargo.toml
               ./Cargo.lock
+              ./build.rs
             ];
           };
 
@@ -164,6 +165,11 @@
     in
     {
       checks = forAllSystems (system: {
+        niri-source = nixpkgsFor.${system}.runCommand "niri-source-contract" { } ''
+          # Cargo must discover the libinput capability probe in the filtered source.
+          cmp ${./build.rs} ${self.packages.${system}.niri.src}/build.rs
+          touch "$out"
+        '';
         # We use the debug build here to save a bit of time
         inherit (self.packages.${system}) niri-debug;
       });

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -60,7 +60,7 @@ pub use crate::recent_windows::{MruDirection, MruFilter, MruPreviews, MruScope, 
 pub use crate::utils::FloatOrInt;
 use crate::utils::{Flag, MergeWith as _};
 pub use crate::window_rule::{
-    FloatingPosition, PopupsRule, RelativeTo, ResolvedPopupsRules, WindowRule,
+    FloatingPosition, OnXdgActivate, PopupsRule, RelativeTo, ResolvedPopupsRules, WindowRule,
 };
 pub use crate::workspace::{Workspace, WorkspaceLayoutPart};
 
@@ -656,6 +656,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_on_xdg_activate() {
+        let parsed = do_parse(
+            r#"
+            window-rule { on-xdg-activate "ignore"; }
+            window-rule { on-xdg-activate "set-urgent"; }
+            window-rule { on-xdg-activate "focus"; }
+            "#,
+        );
+
+        assert_eq!(
+            parsed
+                .window_rules
+                .iter()
+                .map(|rule| rule.on_xdg_activate)
+                .collect::<Vec<_>>(),
+            vec![
+                Some(OnXdgActivate::Ignore),
+                Some(OnXdgActivate::SetUrgent),
+                Some(OnXdgActivate::Focus),
+            ]
+        );
+    }
+
+    #[test]
     fn parse() {
         let parsed = do_parse(
             r##"
@@ -891,6 +915,7 @@ mod tests {
                 default-window-height { fixed 500; }
                 default-column-display "tabbed"
                 default-floating-position x=100 y=-200 relative-to="bottom-left"
+                on-xdg-activate "ignore"
 
                 focus-ring {
                     off
@@ -1799,6 +1824,9 @@ mod tests {
                     ),
                     open_focused: Some(
                         true,
+                    ),
+                    on_xdg_activate: Some(
+                        Ignore,
                     ),
                     min_width: None,
                     min_height: None,

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -34,6 +34,8 @@ pub struct WindowRule {
     pub open_floating: Option<bool>,
     #[knuffel(child, unwrap(argument))]
     pub open_focused: Option<bool>,
+    #[knuffel(child, unwrap(argument))]
+    pub on_xdg_activate: Option<OnXdgActivate>,
 
     // Rules applied dynamically.
     #[knuffel(child, unwrap(argument))]
@@ -147,6 +149,13 @@ pub struct FloatingPosition {
     pub y: FloatOrInt<-65535, 65535>,
     #[knuffel(property, default)]
     pub relative_to: RelativeTo,
+}
+
+#[derive(knuffel::DecodeScalar, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnXdgActivate {
+    Ignore,
+    SetUrgent,
+    Focus,
 }
 
 #[derive(knuffel::DecodeScalar, Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -73,6 +73,11 @@ pub enum Request {
     Workspaces,
     /// Request information about open windows.
     Windows,
+    /// Query current global logical geometry of an exactly focused, stationary window.
+    WindowGeometry {
+        /// Window ID. Geometry is refused for unfocused or transitioning windows.
+        id: u64,
+    },
     /// Request information about layer-shell surfaces.
     Layers,
     /// Request information about the configured keyboard layouts.
@@ -147,6 +152,8 @@ pub enum Response {
     Workspaces(Vec<Workspace>),
     /// Information about open windows.
     Windows(Vec<Window>),
+    /// Current window geometry, queried on demand rather than streamed per frame.
+    WindowGeometry(WindowGeometry),
     /// Information about layer-shell surfaces.
     Layers(Vec<LayerSurface>),
     /// Information about the keyboard layout.
@@ -165,6 +172,24 @@ pub enum Response {
     OverviewState(Overview),
     /// Information about screencasts.
     Casts(Vec<Cast>),
+}
+
+/// Global logical window geometry for targeted desktop interaction.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct WindowGeometry {
+    /// Exact focused window ID.
+    pub id: u64,
+    /// Left coordinate in global logical desktop space.
+    pub x: f64,
+    /// Top coordinate in global logical desktop space.
+    pub y: f64,
+    /// Visual window width, excluding compositor decorations.
+    pub width: i32,
+    /// Visual window height, excluding compositor decorations.
+    pub height: i32,
+    /// Logical output rectangles from the same compositor snapshot: x, y, width, height.
+    pub outputs: Vec<(i32, i32, i32, i32)>,
 }
 
 /// Overview information.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,12 @@ pub enum Msg {
     Workspaces,
     /// List open windows.
     Windows,
+    /// Query live geometry of an exactly focused, stationary window.
+    WindowGeometry {
+        /// Window ID.
+        #[arg(long)]
+        id: u64,
+    },
     /// List open layer-shell surfaces.
     Layers,
     /// Get the configured keyboard layouts.

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -21,11 +21,12 @@ use smithay::input::{keyboard, Seat, SeatHandler, SeatState};
 use smithay::output::Output;
 use smithay::reexports::rustix::fs::{fcntl_setfl, OFlags};
 use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1;
+use smithay::reexports::wayland_protocols::wp::pointer_constraints::zv1::server::zwp_pointer_constraints_v1::Lifetime;
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
-use smithay::reexports::wayland_server::Resource;
+use smithay::reexports::wayland_server::{Resource, WEnum};
 use smithay::utils::{Logical, Point, Rectangle, Serial};
-use smithay::wayland::compositor::{get_parent, with_states};
+use smithay::wayland::compositor::with_states;
 use smithay::wayland::dmabuf::{DmabufGlobal, DmabufHandler, DmabufState, ImportNotifier};
 use smithay::wayland::drm_lease::{
     DrmLease, DrmLeaseBuilder, DrmLeaseHandler, DrmLeaseRequest, DrmLeaseState, LeaseRejected,
@@ -68,7 +69,7 @@ pub use crate::handlers::xdg_shell::KdeDecorationsModeState;
 use crate::input::click_grab::ClickGrab;
 use crate::layout::workspace::WorkspaceId;
 use crate::layout::ActivateWindow;
-use crate::niri::{DndIcon, NewClient, State};
+use crate::niri::{DndIcon, NewClient, PointerConstraintPositionHint, State};
 use crate::protocols::ext_workspace::{self, ExtWorkspaceHandler, ExtWorkspaceManagerState};
 use crate::protocols::foreign_toplevel::{
     self, ForeignToplevelHandler, ForeignToplevelManagerState,
@@ -85,6 +86,21 @@ use crate::protocols::virtual_pointer::{
 use crate::utils::{output_size, send_scale_transform};
 
 pub const XDG_ACTIVATION_TOKEN_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn committed_pointer_constraint_hint(
+    surface: &WlSurface,
+    constraint: &PointerConstraint,
+) -> Option<PointerConstraintPositionHint> {
+    let PointerConstraint::Locked(locked) = constraint else {
+        return None;
+    };
+    locked
+        .cursor_position_hint()
+        .map(|location| PointerConstraintPositionHint {
+            surface: surface.clone(),
+            location,
+        })
+}
 
 impl SeatHandler for State {
     type KeyboardFocus = WlSurface;
@@ -158,82 +174,79 @@ impl PointerConstraintsHandler for State {
         &mut self,
         surface: &WlSurface,
         pointer: &PointerHandle<Self>,
-        location: Point<f64, Logical>,
+        _location: Point<f64, Logical>,
     ) {
-        let is_constraint_active = with_pointer_constraint(surface, pointer, |constraint| {
-            constraint.is_some_and(|c| c.is_active())
+        let constraint_id = with_pointer_constraint(surface, pointer, |constraint| {
+            constraint.map(|constraint| constraint.id())
         });
 
-        if !is_constraint_active {
-            return;
-        }
-
-        // Note: this is surface under pointer, not pointer focus. So if you start, say, a
-        // middle-drag in Blender, then touchpad-swipe the window away, the surface under pointer
-        // will change, even though the real pointer focus remains on the Blender surface due to
-        // the click grab.
-        //
-        // Ideally we would just use the constraint surface, but we need its origin. So this is
-        // more of a hack because pointer contents has the surface origin available.
-        //
-        // FIXME: use the constraint surface somehow, don't use pointer contents.
-        let Some((ref surface_under_pointer, origin)) = self.niri.pointer_contents.surface else {
+        let Some(constraint_id) = constraint_id else {
             return;
         };
 
-        if surface_under_pointer != surface {
-            return;
-        }
-
-        let mut root = surface.clone();
-        while let Some(parent) = get_parent(&root) {
-            root = parent;
-        }
-
-        let target = self
+        if let Some(placement) = self
             .niri
-            .output_for_root(&root)
-            .and_then(|output| self.niri.global_space.output_geometry(output))
-            .map_or(origin + location, |mut output_geometry| {
-                // i32 sizes are exclusive, but f64 sizes are inclusive.
-                output_geometry.size -= (1, 1).into();
-                (origin + location).constrain(output_geometry.to_f64())
-            });
-        self.niri.pointer_constraint_position_hint = Some(target);
+            .pointer_constraint_surface_placement(surface)
+            .or_else(|| {
+                self.niri
+                    .pointer_constraint_surface_placement_from_contents(surface)
+            })
+        {
+            self.niri
+                .pointer_constraint_placements
+                .insert(constraint_id.clone(), placement);
+        }
     }
 
     fn remove_constraint(
         &mut self,
-        _surface: &WlSurface,
+        surface: &WlSurface,
         pointer: &PointerHandle<Self>,
-        _constraint: Option<&PointerConstraint>,
+        constraint: &PointerConstraint,
     ) {
-        // Since a pointer constraint is broken when a surface loses pointer focus, and one surface
-        // can only have a single pointer constraint at once, assume there can be only one
-        // constraint active at once, and therefore the global position hint should come from that
-        // one constraint that just got removed.
-        let Some(target) = self.niri.pointer_constraint_position_hint.take() else {
-            // The client never sent a position hint.
-            return;
-        };
+        let id = constraint.id();
+        let hint = committed_pointer_constraint_hint(surface, constraint);
+        let fallback_placement = self.niri.pointer_constraint_placements.remove(&id);
+        self.niri
+            .suspended_pointer_constraints
+            .retain(|_, suspended| suspended.id != id);
 
-        // If the constraint was broken by the pointer forcibly leaving the surface (e.g. the user
-        // opened the overview), then it doesn't make much sense to warp it.
+        // An inactive persistent constraint has already gone through
+        // constraint_deactivated(), which queued its one permitted hint warp. Do not replace that
+        // pending work with an empty terminal-removal update.
         //
-        // Furthermore, when the constraint is removed as part of the pointer leaving the surface,
-        // this call happens with locked pointer data, and calling set_location() will try to lock
-        // it again and deadlock.
+        // If the pointer already left the surface (for example, when opening the overview), the
+        // upstream behavior is to skip the hint warp. The split Smithay callback makes this path
+        // safe from the old re-entrant pointer lock, while retaining that policy.
+        if constraint.is_active() && pointer.last_enter().is_some() {
+            self.finish_pointer_constraint_change_later(pointer, id, hint, fallback_placement);
+        }
+    }
+
+    fn constraint_deactivated(
+        &mut self,
+        surface: &WlSurface,
+        pointer: &PointerHandle<Self>,
+        constraint: &PointerConstraint,
+    ) {
+        let id = constraint.id();
+        let hint = committed_pointer_constraint_hint(surface, constraint);
+        let fallback_placement = if constraint.lifetime() == WEnum::Value(Lifetime::Oneshot) {
+            self.niri.pointer_constraint_placements.remove(&id)
+        } else {
+            self.niri.pointer_constraint_placements.get(&id).cloned()
+        };
+        // A pointer-focus leave already establishes the new pointer position. Do not override it
+        // with the old surface's hint; explicit keyboard-focus deactivation still has an enter.
         if pointer.last_enter().is_none() {
             return;
         }
-
-        pointer.set_location(target);
-
-        // Redraw to update the cursor position if it's visible.
-        if self.niri.pointer_visibility.is_visible() {
-            // FIXME: redraw only outputs overlapping the cursor.
-            self.niri.queue_redraw_all();
-        }
+        self.finish_pointer_constraint_change_later(
+            pointer,
+            constraint.id(),
+            hint,
+            fallback_placement,
+        );
     }
 }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -68,7 +68,7 @@ use smithay::wayland::xdg_activation::{
 pub use crate::handlers::xdg_shell::KdeDecorationsModeState;
 use crate::input::click_grab::ClickGrab;
 use crate::layout::workspace::WorkspaceId;
-use crate::layout::ActivateWindow;
+use crate::layout::{ActivateWindow, LayoutElement};
 use crate::niri::{DndIcon, NewClient, PointerConstraintPositionHint, State};
 use crate::protocols::ext_workspace::{self, ExtWorkspaceHandler, ExtWorkspaceManagerState};
 use crate::protocols::foreign_toplevel::{
@@ -828,13 +828,27 @@ impl XdgActivationHandler for State {
         if token_data.timestamp.elapsed() < XDG_ACTIVATION_TOKEN_TIMEOUT {
             if let Some((mapped, _)) = self.niri.layout.find_window_and_output_mut(&surface) {
                 let window = mapped.window.clone();
-                if token_data.user_data.get::<UrgentOnlyMarker>().is_some() {
-                    mapped.set_urgent(true);
-                    self.niri.queue_redraw_all();
-                } else {
-                    self.niri.layout.activate_window(&window);
-                    self.niri.layer_shell_on_demand_focus = None;
-                    self.niri.queue_redraw_all();
+                match mapped.rules().on_xdg_activate {
+                    Some(niri_config::OnXdgActivate::Ignore) => {}
+                    Some(niri_config::OnXdgActivate::SetUrgent) => {
+                        mapped.set_urgent(true);
+                        self.niri.queue_redraw_all();
+                    }
+                    Some(niri_config::OnXdgActivate::Focus) => {
+                        self.niri.layout.activate_window(&window);
+                        self.niri.layer_shell_on_demand_focus = None;
+                        self.niri.queue_redraw_all();
+                    }
+                    None => {
+                        if token_data.user_data.get::<UrgentOnlyMarker>().is_some() {
+                            mapped.set_urgent(true);
+                            self.niri.queue_redraw_all();
+                        } else {
+                            self.niri.layout.activate_window(&window);
+                            self.niri.layer_shell_on_demand_focus = None;
+                            self.niri.queue_redraw_all();
+                        }
+                    }
                 }
             } else if let Some(unmapped) = self.niri.unmapped_windows.get_mut(&surface) {
                 unmapped.activation_token_data = Some(token_data);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2699,6 +2699,12 @@ impl State {
 
         let pointer = self.niri.seat.get_pointer().unwrap();
 
+        // Absolute pointer input must not move focus away from an active pointer lock. Unlike
+        // relative motion, it has no meaningful delta to forward to the locked client.
+        if self.niri.has_active_pointer_lock() {
+            return;
+        }
+
         if let Some(output) = self.niri.screenshot_ui.selection_output() {
             let geom = self.niri.global_space.output_geometry(output).unwrap();
             let point = (pos - geom.loc.to_f64())
@@ -2916,7 +2922,13 @@ impl State {
                 }
             }
 
-            if let Some(mapped) = self.niri.window_under_cursor() {
+            // A locked pointer keeps delivering button events to the locked surface. Do not use
+            // its stored global location to focus or manipulate a different window behind it.
+            let allow_pointer_focus_change = !self.niri.has_active_pointer_lock();
+            if let Some(mapped) = allow_pointer_focus_change
+                .then(|| self.niri.window_under_cursor())
+                .flatten()
+            {
                 let window = mapped.window.clone();
 
                 // Check if we need to start an interactive move.
@@ -3028,7 +3040,7 @@ impl State {
 
                 // FIXME: granular.
                 self.niri.queue_redraw_all();
-            } else if let Some((output, ws)) = is_overview_open
+            } else if let Some((output, ws)) = (allow_pointer_focus_change && is_overview_open)
                 .then(|| self.niri.workspace_under_cursor(false))
                 .flatten()
             {
@@ -3039,7 +3051,10 @@ impl State {
 
                 // FIXME: granular.
                 self.niri.queue_redraw_all();
-            } else if let Some(output) = self.niri.output_under_cursor() {
+            } else if let Some(output) = allow_pointer_focus_change
+                .then(|| self.niri.output_under_cursor())
+                .flatten()
+            {
                 self.niri.layout.focus_output(&output);
 
                 // FIXME: granular.
@@ -3049,7 +3064,7 @@ impl State {
 
         self.update_pointer_contents();
 
-        if ButtonState::Pressed == button_state {
+        if ButtonState::Pressed == button_state && !self.niri.has_active_pointer_lock() {
             let layer_under = self.niri.pointer_contents.layer.clone();
             self.niri.focus_layer_surface_if_on_demand(layer_under);
         }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -43,6 +43,7 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
         },
         Msg::Workspaces => Request::Workspaces,
         Msg::Windows => Request::Windows,
+        Msg::WindowGeometry { id } => Request::WindowGeometry { id: *id },
         Msg::Layers => Request::Layers,
         Msg::KeyboardLayouts => Request::KeyboardLayouts,
         Msg::EventStream => Request::EventStream,
@@ -111,6 +112,12 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
     let response = reply.map_err(|err_msg| anyhow!(err_msg).context("niri returned an error"))?;
 
     match msg {
+        Msg::WindowGeometry { .. } => {
+            let Response::WindowGeometry(geometry) = response else {
+                bail!("unexpected response: expected WindowGeometry, got {response:?}");
+            };
+            println!("{}", serde_json::to_string(&geometry)?);
+        }
         Msg::RequestError => {
             bail!("unexpected response: expected an error, got {response:?}");
         }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -287,6 +287,17 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let windows = state.windows.windows.values().cloned().collect();
             Response::Windows(windows)
         }
+        Request::WindowGeometry { id } => {
+            let (tx, rx) = async_channel::bounded(1);
+            ctx.event_loop.insert_idle(move |state| {
+                let _ = tx.send_blocking(window_geometry(state, id));
+            });
+            Response::WindowGeometry(
+                rx.recv()
+                    .await
+                    .map_err(|_| "error querying window geometry".to_string())??,
+            )
+        }
         Request::Layers => {
             let (tx, rx) = async_channel::bounded(1);
             ctx.event_loop.insert_idle(move |state| {
@@ -458,6 +469,76 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
     };
 
     Ok(response)
+}
+
+pub(crate) fn window_geometry(state: &State, id: u64) -> Result<niri_ipc::WindowGeometry, String> {
+    let niri = &state.niri;
+    if niri.is_locked()
+        || niri.layout.is_overview_open()
+        || niri.screenshot_ui.is_open()
+        || niri.exit_confirm_dialog.is_open()
+        || niri.window_mru_ui.is_open()
+    {
+        return Err("window geometry is unavailable while locked or an overlay is open".into());
+    }
+    let mut target = None;
+    niri.layout.with_windows(|mapped, _, workspace, _| {
+        if mapped.id().get() == id && mapped.is_focused() && workspace.is_some() {
+            target = Some(mapped.window.clone());
+        }
+    });
+    let window = target.ok_or("window geometry requires the exact focused, non-dragged window")?;
+    if !matches!(&niri.keyboard_focus, crate::niri::KeyboardFocus::Layout { surface: Some(surface) }
+        if surface == window.toplevel().unwrap().wl_surface())
+    {
+        return Err("window geometry requires actual input focus, not layer-shell focus".into());
+    }
+    let (output, buffer_origin, zoom) = niri
+        .layout
+        .window_render_location(&window)
+        .ok_or("focused window has no current render placement")?;
+    if niri
+        .output_state
+        .get(&output)
+        .is_some_and(|state| state.screen_transition.is_some())
+    {
+        return Err("window geometry is unavailable during a screen transition".into());
+    }
+    if zoom != 1.0 || niri.layout.are_animations_ongoing(Some(&output)) {
+        return Err(
+            "window geometry is unavailable during layout transitions; retry when settled".into(),
+        );
+    }
+    let output_geometry = niri
+        .global_space
+        .output_geometry(&output)
+        .ok_or("window output has no global geometry")?;
+    let geometry = window.geometry();
+    let origin = output_geometry.loc.to_f64() + buffer_origin + geometry.loc.to_f64();
+    if !origin.x.is_finite()
+        || !origin.y.is_finite()
+        || geometry.size.w <= 0
+        || geometry.size.h <= 0
+    {
+        return Err("window geometry is invalid".into());
+    }
+    let outputs = niri
+        .global_space
+        .outputs()
+        .filter_map(|output| {
+            niri.global_space
+                .output_geometry(output)
+                .map(|r| (r.loc.x, r.loc.y, r.size.w, r.size.h))
+        })
+        .collect();
+    Ok(niri_ipc::WindowGeometry {
+        id,
+        x: origin.x,
+        y: origin.y,
+        width: geometry.size.w,
+        height: geometry.size.h,
+        outputs,
+    })
 }
 
 fn validate_action(action: &Action) -> Result<(), String> {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1410,6 +1410,49 @@ impl<W: LayoutElement> Layout<W> {
         None
     }
 
+    /// Returns the current output-local buffer origin and render scale for a visible window.
+    ///
+    /// Unlike IPC layout positions, this includes workspace, tile, and interactive-move render
+    /// offsets. Input protocols that use surface-local coordinates need this current placement
+    /// rather than a location cached by an earlier pointer hit.
+    pub fn window_render_location(
+        &self,
+        window: &W::Id,
+    ) -> Option<(Output, Point<f64, Logical>, f64)> {
+        if let Some(InteractiveMoveState::Moving(move_)) = &self.interactive_move {
+            if move_.tile.window().id() == window {
+                let zoom = self
+                    .monitor_for_output(&move_.output)
+                    .map(Monitor::overview_zoom)
+                    .unwrap_or(1.);
+                let location = move_.tile_render_location(zoom)
+                    + (move_.tile.buf_loc() + move_.tile.bob_offset()).upscale(zoom);
+                return Some((move_.output.clone(), location, zoom));
+            }
+        }
+
+        let MonitorSet::Normal { monitors, .. } = &self.monitor_set else {
+            return None;
+        };
+        for mon in monitors {
+            let zoom = mon.overview_zoom();
+            for (workspace, workspace_geometry) in mon.workspaces_with_render_geo() {
+                let Some((tile, tile_location, _visible)) = workspace
+                    .tiles_with_render_positions()
+                    .find(|(tile, _, _)| tile.window().id() == window)
+                else {
+                    continue;
+                };
+
+                let location = workspace_geometry.loc
+                    + (tile_location + tile.buf_loc() + tile.bob_offset()).upscale(zoom);
+                return Some((mon.output.clone(), location, zoom));
+            }
+        }
+
+        None
+    }
+
     pub fn find_window_and_output_mut(
         &mut self,
         wl_surface: &WlSurface,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -88,7 +88,9 @@ use smithay::wayland::keyboard_shortcuts_inhibit::{
     KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
 };
 use smithay::wayland::output::OutputManagerState;
-use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerConstraintsState};
+use smithay::wayland::pointer_constraints::{
+    with_pointer_constraint, PointerConstraint, PointerConstraintsState,
+};
 use smithay::wayland::pointer_gestures::PointerGesturesState;
 use smithay::wayland::presentation::PresentationState;
 use smithay::wayland::relative_pointer::RelativePointerManagerState;
@@ -1071,6 +1073,14 @@ impl State {
 
     pub fn update_pointer_contents(&mut self) -> bool {
         let _span = tracy_client::span!("Niri::update_pointer_contents");
+
+        // A cursor position hint describes where the pointer should appear after a lock is
+        // deactivated. Applying it must not change pointer focus while the lock is still active.
+        // Otherwise a hint outside the focused surface makes pointer.motion() send a leave,
+        // which deactivates the lock before the client destroys it.
+        if self.niri.has_active_pointer_lock() {
+            return false;
+        }
 
         let pointer = &self.niri.seat.get_pointer().unwrap();
         let location = pointer.current_location();
@@ -6121,6 +6131,19 @@ impl Niri {
 
             constraint.activate();
         });
+    }
+
+    pub(crate) fn has_active_pointer_lock(&self) -> bool {
+        let pointer = self.seat.get_pointer().unwrap();
+        let Some(surface) = pointer.current_focus() else {
+            return false;
+        };
+
+        with_pointer_constraint(&surface, &pointer, |constraint| {
+            constraint.is_some_and(|constraint| {
+                constraint.is_active() && matches!(&*constraint, PointerConstraint::Locked(_))
+            })
+        })
     }
 
     pub fn focus_layer_surface_if_on_demand(&mut self, surface: Option<LayerSurface>) {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -49,7 +49,7 @@ use smithay::desktop::{
 use smithay::input::keyboard::{Layout as KeyboardLayout, XkbConfig};
 use smithay::input::pointer::{
     CursorIcon, CursorImageStatus, CursorImageSurfaceData, Focus,
-    GrabStartData as PointerGrabStartData, MotionEvent,
+    GrabStartData as PointerGrabStartData, MotionEvent, PointerHandle,
 };
 use smithay::input::tablet::TabletSeatTrait;
 use smithay::input::{Seat, SeatState};
@@ -60,15 +60,16 @@ use smithay::reexports::calloop::{
     Interest, LoopHandle, LoopSignal, Mode, PostAction, RegistrationToken,
 };
 use smithay::reexports::wayland_protocols::ext::session_lock::v1::server::ext_session_lock_v1::ExtSessionLockV1;
+use smithay::reexports::wayland_protocols::wp::pointer_constraints::zv1::server::zwp_pointer_constraints_v1::Lifetime;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel::WmCapabilities;
 use smithay::reexports::wayland_protocols_misc::server_decoration as _server_decoration;
 use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1;
 use smithay::reexports::wayland_server::backend::{
-    ClientData, ClientId, DisconnectReason, GlobalId,
+    ClientData, ClientId, DisconnectReason, GlobalId, ObjectId,
 };
 use smithay::reexports::wayland_server::protocol::wl_shm;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
-use smithay::reexports::wayland_server::{Client, Display, DisplayHandle, Resource};
+use smithay::reexports::wayland_server::{Client, Display, DisplayHandle, Resource, WEnum};
 use smithay::utils::{
     ClockSource, IsAlive as _, Logical, Monotonic, Physical, Point, Rectangle, Scale, Size,
     Transform, SERIAL_COUNTER,
@@ -76,7 +77,7 @@ use smithay::utils::{
 use smithay::wayland::background_effect::BackgroundEffectState;
 use smithay::wayland::compositor::{
     with_states, with_surface_tree_downward, CompositorClientState, CompositorHandler,
-    CompositorState, HookId, SurfaceData, TraversalAction,
+    CompositorState, HookId, SurfaceAttributes, SurfaceData, TraversalAction,
 };
 use smithay::wayland::cursor_shape::CursorShapeManagerState;
 use smithay::wayland::dmabuf::DmabufState;
@@ -183,7 +184,7 @@ use crate::utils::xwayland::satellite::Satellite;
 use crate::utils::{
     center, center_f64, expand_home, get_monotonic_time, ipc_transform_to_smithay, is_mapped,
     logical_output, make_screenshot_path, output_matches_name, output_size, panel_orientation,
-    send_scale_transform, write_png_rgba8, xwayland,
+    send_scale_transform, surface_geo, write_png_rgba8, xwayland,
 };
 use crate::window::mapped::MappedId;
 use crate::window::{InitialConfigureState, Mapped, ResolvedWindowRules, Unmapped, WindowRef};
@@ -372,7 +373,11 @@ pub struct Niri {
     /// resolution mice.
     pub notified_activity_this_iteration: bool,
     pub pointer_inside_hot_corner: bool,
-    pub pointer_constraint_position_hint: Option<Point<f64, Logical>>,
+    pub(crate) pointer_constraint_placements: HashMap<ObjectId, PointerConstraintSurfacePlacement>,
+    pub suspended_pointer_constraints:
+        HashMap<(PointerHandle<State>, ObjectId), SuspendedPointerConstraint>,
+    pub pending_pointer_constraint_warps:
+        HashMap<PointerHandle<State>, PendingPointerConstraintWarp>,
     pub tablet_cursor_location: Option<Point<f64, Logical>>,
     pub gesture_swipe_3f_cumulative: Option<(f64, f64)>,
     pub overview_scroll_swipe_gesture: ScrollSwipeGesture,
@@ -547,6 +552,36 @@ pub struct PointContents {
     pub hot_corner: bool,
 }
 
+#[derive(Clone)]
+pub struct SuspendedPointerConstraint {
+    pub id: ObjectId,
+    pub surface: WlSurface,
+    pub position_within_surface: Option<Point<f64, Logical>>,
+    fallback_placement: Option<PointerConstraintSurfacePlacement>,
+}
+
+#[derive(Clone)]
+pub struct PendingPointerConstraintWarp {
+    pub id: ObjectId,
+    pub hint: Option<PointerConstraintPositionHint>,
+    fallback_placement: Option<PointerConstraintSurfacePlacement>,
+}
+
+#[derive(Clone)]
+pub struct PointerConstraintPositionHint {
+    pub surface: WlSurface,
+    pub location: Point<f64, Logical>,
+}
+
+#[derive(Clone)]
+pub(crate) struct PointerConstraintSurfacePlacement {
+    output: Output,
+    window: Option<(Window, Point<f64, Logical>)>,
+    layer: Option<LayerSurface>,
+    surface_origin: Point<f64, Logical>,
+    scale: f64,
+}
+
 #[derive(Debug, Default)]
 pub enum LockState {
     #[default]
@@ -707,6 +742,214 @@ pub struct State {
 }
 
 impl State {
+    pub(crate) fn finish_pointer_constraint_change_later(
+        &mut self,
+        pointer: &PointerHandle<Self>,
+        id: ObjectId,
+        hint: Option<PointerConstraintPositionHint>,
+        fallback_placement: Option<PointerConstraintSurfacePlacement>,
+    ) {
+        self.niri.pending_pointer_constraint_warps.insert(
+            pointer.clone(),
+            PendingPointerConstraintWarp {
+                id: id.clone(),
+                hint,
+                fallback_placement,
+            },
+        );
+
+        let pointer = pointer.clone();
+        self.niri.event_loop.insert_idle(move |state| {
+            let is_current = state
+                .niri
+                .pending_pointer_constraint_warps
+                .get(&pointer)
+                .is_some_and(|pending| pending.id == id);
+            if !is_current {
+                return;
+            }
+            let pending = state
+                .niri
+                .pending_pointer_constraint_warps
+                .remove(&pointer)
+                .unwrap();
+
+            let target = pending.hint.and_then(|hint| {
+                state.niri.pointer_constraint_hint_target(
+                    &hint.surface,
+                    hint.location,
+                    pending.fallback_placement.as_ref(),
+                )
+            });
+            if let Some(target) = target {
+                pointer.set_location(target);
+            }
+
+            // A cursor-position hint is part of the constraint lifecycle, not an ordinary
+            // geometry refresh. Reconcile pointer focus even while a layout transition is
+            // running; otherwise the location changes but focus remains on the unlocked surface.
+            if state.update_pointer_contents() {
+                pointer.frame(state);
+            }
+
+            if state.niri.pointer_visibility.is_visible() {
+                // FIXME: redraw only outputs overlapping the cursor.
+                state.niri.queue_redraw_all();
+            }
+        });
+    }
+
+    fn deactivate_pointer_constraint_for_keyboard_focus(&mut self, focus: &KeyboardFocus) {
+        let pointer = self.niri.seat.get_pointer().unwrap();
+        let Some(surface) = pointer.current_focus() else {
+            return;
+        };
+
+        let constraint_root = self.niri.find_root_shell_surface(&surface);
+        let focus_root = focus
+            .surface()
+            .map(|surface| self.niri.find_root_shell_surface(surface));
+        if focus_root.as_ref() == Some(&constraint_root) {
+            return;
+        }
+
+        let fallback_placement = self
+            .niri
+            .pointer_constraint_surface_placement(&surface)
+            .or_else(|| {
+                self.niri
+                    .pointer_constraint_surface_placement_from_contents(&surface)
+            });
+
+        with_pointer_constraint(&surface, &pointer, |constraint| {
+            if let Some(constraint) = constraint.filter(|constraint| constraint.is_active()) {
+                if let Some(placement) = fallback_placement.clone() {
+                    self.niri
+                        .pointer_constraint_placements
+                        .insert(constraint.id(), placement);
+                }
+                if constraint.lifetime() == WEnum::Value(Lifetime::Persistent) {
+                    let position_within_surface = self
+                        .niri
+                        .pointer_contents
+                        .surface
+                        .as_ref()
+                        .filter(|(focused_surface, _)| focused_surface == &surface)
+                        .map(|(_, origin)| pointer.current_location() - *origin);
+                    self.niri.suspended_pointer_constraints.insert(
+                        (pointer.clone(), constraint.id()),
+                        SuspendedPointerConstraint {
+                            id: constraint.id(),
+                            surface: surface.clone(),
+                            position_within_surface,
+                            fallback_placement: fallback_placement.clone(),
+                        },
+                    );
+                }
+                constraint.deactivate(self);
+            }
+        });
+    }
+
+    fn reactivate_pointer_constraint_for_keyboard_focus(&mut self, focus: &KeyboardFocus) {
+        let Some(focus_surface) = focus.surface() else {
+            return;
+        };
+        let focus_root = self.niri.find_root_shell_surface(focus_surface);
+
+        let Some((key, suspended)) = self
+            .niri
+            .suspended_pointer_constraints
+            .iter()
+            .find(|(_, suspended)| {
+                suspended.surface.alive()
+                    && self.niri.find_root_shell_surface(&suspended.surface) == focus_root
+            })
+            .map(|((pointer, id), suspended)| ((pointer.clone(), id.clone()), suspended.clone()))
+        else {
+            return;
+        };
+        let pointer = &key.0;
+        // Overview and other layout animations can render a surface at a non-unit scale. Smithay
+        // pointer focus only carries an origin, so it cannot represent the inverse scale needed to
+        // keep protocol coordinates surface-local. Leave the persistent constraint suspended
+        // until normal hit-testing resumes at unit scale.
+        if self
+            .niri
+            .pointer_constraint_surface_placement(&suspended.surface)
+            .is_some_and(|placement| placement.scale != 1.)
+        {
+            return;
+        }
+        let current_position = self.niri.pointer_constraint_local_position(
+            &suspended.surface,
+            pointer.current_location(),
+            suspended.fallback_placement.as_ref(),
+        );
+        let position_within_surface = current_position.or(suspended.position_within_surface);
+        let Some(position_within_surface) = position_within_surface else {
+            self.niri.suspended_pointer_constraints.remove(&key);
+            return;
+        };
+        let Some((pointer_location, pointer_contents)) = self.niri.pointer_constraint_contents_at(
+            &suspended.surface,
+            position_within_surface,
+            suspended.fallback_placement.as_ref(),
+        ) else {
+            self.niri.suspended_pointer_constraints.remove(&key);
+            return;
+        };
+
+        let can_reactivate = with_pointer_constraint(&suspended.surface, pointer, |constraint| {
+            constraint.is_some_and(|constraint| {
+                constraint.id() == suspended.id
+                    && !constraint.is_active()
+                    && constraint.lifetime() == WEnum::Value(Lifetime::Persistent)
+                    && constraint.region().is_none_or(|region| {
+                        region.contains(position_within_surface.to_i32_round())
+                    })
+            })
+        });
+        if !can_reactivate {
+            self.niri.suspended_pointer_constraints.remove(&key);
+            return;
+        }
+
+        self.niri.pending_pointer_constraint_warps.remove(pointer);
+        self.niri.pointer_contents.clone_from(&pointer_contents);
+        pointer.motion(
+            self,
+            pointer_contents.surface,
+            &MotionEvent {
+                location: pointer_location,
+                serial: SERIAL_COUNTER.next_serial(),
+                time: get_monotonic_time().as_millis() as u32,
+            },
+        );
+        pointer.frame(self);
+
+        with_pointer_constraint(&suspended.surface, pointer, |constraint| {
+            if let Some(constraint) =
+                constraint.filter(|constraint| constraint.id() == suspended.id)
+            {
+                constraint.activate();
+            }
+        });
+        if let Some(placement) = self
+            .niri
+            .pointer_constraint_surface_placement(&suspended.surface)
+            .or_else(|| {
+                self.niri
+                    .pointer_constraint_surface_placement_from_contents(&suspended.surface)
+            })
+        {
+            self.niri
+                .pointer_constraint_placements
+                .insert(suspended.id.clone(), placement);
+        }
+        self.niri.suspended_pointer_constraints.remove(&key);
+    }
+
     pub fn new(
         config: Config,
         event_loop: LoopHandle<'static, State>,
@@ -822,6 +1065,11 @@ impl State {
         self.niri.global_space.refresh();
         self.niri.refresh_idle_inhibit();
         self.refresh_pointer_contents();
+        // A persistent constraint can remain suspended while its surface has animated, non-unit
+        // geometry. Retry after layout and pointer refresh so animation completion can restore it
+        // even when cursor visibility disables ordinary hit-testing.
+        let keyboard_focus = self.niri.keyboard_focus.clone();
+        self.reactivate_pointer_constraint_for_keyboard_focus(&keyboard_focus);
         foreign_toplevel::refresh(self);
         ext_workspace::refresh(self);
 
@@ -858,6 +1106,24 @@ impl State {
             _ => self.niri.contents_under(location),
         };
 
+        let pointer = self.niri.seat.get_pointer().unwrap();
+        let current_focus = pointer.current_focus();
+        let new_focus = under.surface.as_ref().map(|(surface, _)| surface);
+        if current_focus.as_ref() != new_focus {
+            if let Some(surface) = current_focus {
+                with_pointer_constraint(&surface, &pointer, |constraint| {
+                    if let Some(constraint) = constraint.filter(|constraint| constraint.is_active())
+                    {
+                        constraint.deactivate(self);
+                    }
+                });
+            }
+        }
+
+        // Any compositor-selected destination takes precedence over a cursor-position hint,
+        // including a newer warp within the same focused surface.
+        self.niri.pending_pointer_constraint_warps.remove(&pointer);
+
         // Disable the hidden pointer if the contents underneath have changed.
         if !self.niri.pointer_visibility.is_visible() && self.niri.pointer_contents != under {
             self.niri.pointer_visibility = PointerVisibility::Disabled;
@@ -870,7 +1136,6 @@ impl State {
 
         self.niri.pointer_contents.clone_from(&under);
 
-        let pointer = &self.niri.seat.get_pointer().unwrap();
         pointer.motion(
             self,
             under.surface,
@@ -1139,6 +1404,23 @@ impl State {
     }
 
     pub fn update_keyboard_focus(&mut self) {
+        let mut dead_constraint_ids = Vec::new();
+        self.niri
+            .suspended_pointer_constraints
+            .retain(|_, suspended| {
+                let alive = suspended.surface.alive();
+                if !alive {
+                    dead_constraint_ids.push(suspended.id.clone());
+                }
+                alive
+            });
+        for id in dead_constraint_ids {
+            self.niri.pointer_constraint_placements.remove(&id);
+            self.niri
+                .pending_pointer_constraint_warps
+                .retain(|_, pending| pending.id != id);
+        }
+
         // Clean up on-demand layer surface focus if necessary.
         if let Some(surface) = &self.niri.layer_shell_on_demand_focus {
             // Still alive and has on-demand interactivity.
@@ -1387,8 +1669,15 @@ impl State {
                 }
             }
 
+            self.deactivate_pointer_constraint_for_keyboard_focus(&focus);
+
             self.niri.keyboard_focus.clone_from(&focus);
-            keyboard.set_focus(self, focus.into_surface(), SERIAL_COUNTER.next_serial());
+            keyboard.set_focus(
+                self,
+                focus.clone().into_surface(),
+                SERIAL_COUNTER.next_serial(),
+            );
+            self.reactivate_pointer_constraint_for_keyboard_focus(&focus);
 
             // FIXME: can be more granular.
             self.niri.queue_redraw_all();
@@ -2617,7 +2906,9 @@ impl Niri {
             pointer_inactivity_timer_got_reset: false,
             notified_activity_this_iteration: false,
             pointer_inside_hot_corner: false,
-            pointer_constraint_position_hint: None,
+            pointer_constraint_placements: HashMap::new(),
+            suspended_pointer_constraints: HashMap::new(),
+            pending_pointer_constraint_warps: HashMap::new(),
             tablet_cursor_location: None,
             gesture_swipe_3f_cumulative: None,
             overview_scroll_swipe_gesture: ScrollSwipeGesture::new(),
@@ -6103,34 +6394,60 @@ impl Niri {
     /// Activates the pointer constraint if necessary according to the current pointer contents.
     ///
     /// Make sure the pointer location and contents are up to date before calling this.
-    pub fn maybe_activate_pointer_constraint(&self) {
-        let Some((surface, surface_loc)) = &self.pointer_contents.surface else {
+    pub fn maybe_activate_pointer_constraint(&mut self) {
+        let Some((surface, surface_loc)) = self.pointer_contents.surface.clone() else {
             return;
         };
 
-        let pointer = self.seat.get_pointer().unwrap();
-        if Some(surface) != pointer.current_focus().as_ref() {
+        let constraint_root = self.find_root_shell_surface(&surface);
+        let keyboard_root = self
+            .keyboard_focus
+            .surface()
+            .map(|surface| self.find_root_shell_surface(surface));
+        if keyboard_root.as_ref() != Some(&constraint_root) {
             return;
         }
 
-        with_pointer_constraint(surface, &pointer, |constraint| {
-            let Some(constraint) = constraint else { return };
+        let pointer = self.seat.get_pointer().unwrap();
+        if Some(&surface) != pointer.current_focus().as_ref() {
+            return;
+        }
+
+        let activated = with_pointer_constraint(&surface, &pointer, |constraint| {
+            let constraint = constraint?;
 
             if constraint.is_active() {
-                return;
+                return None;
             }
 
             // Constraint does not apply if not within region.
             if let Some(region) = constraint.region() {
                 let pointer_pos = pointer.current_location();
-                let pos_within_surface = pointer_pos - *surface_loc;
+                let pos_within_surface = pointer_pos - surface_loc;
                 if !region.contains(pos_within_surface.to_i32_round()) {
-                    return;
+                    return None;
                 }
             }
 
+            let id = constraint.id();
             constraint.activate();
+            Some(id)
         });
+
+        if let Some(id) = activated {
+            if let Some(placement) = self
+                .pointer_constraint_surface_placement(&surface)
+                .or_else(|| self.pointer_constraint_surface_placement_from_contents(&surface))
+            {
+                self.pointer_constraint_placements
+                    .insert(id.clone(), placement);
+            }
+            // Once any constraint owns this pointer, an older unlock hint must not move its global
+            // location or focus. Remove only the matching suspended entry; other persistent
+            // constraints remain available for later keyboard-focus returns.
+            self.pending_pointer_constraint_warps.remove(&pointer);
+            self.suspended_pointer_constraints.remove(&(pointer, id));
+        }
     }
 
     pub(crate) fn has_active_pointer_lock(&self) -> bool {
@@ -6144,6 +6461,256 @@ impl Niri {
                 constraint.is_active() && matches!(&*constraint, PointerConstraint::Locked(_))
             })
         })
+    }
+
+    fn surface_offset_from_root(
+        &self,
+        root: &WlSurface,
+        surface: &WlSurface,
+    ) -> Option<Point<f64, Logical>> {
+        let offset = Cell::new(None);
+        with_surface_tree_downward(
+            root,
+            Point::from((0, 0)),
+            |_, states, parent_offset| {
+                let Some(geometry) = surface_geo(states) else {
+                    return TraversalAction::SkipChildren;
+                };
+                TraversalAction::DoChildren(*parent_offset + geometry.loc)
+            },
+            |candidate, states, parent_offset| {
+                if candidate != surface {
+                    return;
+                }
+                if let Some(geometry) = surface_geo(states) {
+                    offset.set(Some((*parent_offset + geometry.loc).to_f64()));
+                }
+            },
+            |_, _, _| offset.get().is_none(),
+        );
+        offset.get()
+    }
+
+    fn surface_offset_from_shell_root(
+        &self,
+        root: &WlSurface,
+        surface: &WlSurface,
+        popup_root_offset: Point<i32, Logical>,
+    ) -> Option<Point<f64, Logical>> {
+        if let Some(offset) = self.surface_offset_from_root(root, surface) {
+            return Some(offset);
+        }
+
+        PopupManager::popups_for_surface(root).find_map(|(popup, popup_offset)| {
+            let surface_offset = self.surface_offset_from_root(popup.wl_surface(), surface)?;
+            let popup_origin = popup_root_offset + popup_offset - popup.geometry().loc;
+            Some(popup_origin.to_f64() + surface_offset)
+        })
+    }
+
+    pub(crate) fn pointer_constraint_surface_placement(
+        &self,
+        surface: &WlSurface,
+    ) -> Option<PointerConstraintSurfacePlacement> {
+        let root = self.find_root_shell_surface(surface);
+
+        if let Some((mapped, _)) = self.layout.find_window_and_output(&root) {
+            let window = mapped.window.clone();
+            let (output, window_origin, scale) = self.layout.window_render_location(&window)?;
+            let surface_offset =
+                self.surface_offset_from_shell_root(&root, surface, mapped.window.geometry().loc)?;
+            return Some(PointerConstraintSurfacePlacement {
+                output,
+                window: Some((window, window_origin)),
+                layer: None,
+                surface_origin: window_origin + surface_offset.upscale(scale),
+                scale,
+            });
+        }
+
+        for output in self.global_space.outputs() {
+            let layers = layer_map_for_output(output);
+            let Some(layer) = layers
+                .layer_for_surface(&root, WindowSurfaceType::TOPLEVEL)
+                .cloned()
+            else {
+                continue;
+            };
+            let mapped = self.mapped_layer_surfaces.get(&layer)?;
+
+            // Background and bottom layers move with the workspace stack. Their last exact input
+            // placement is retained when the constraint activates; unlike top and overlay layers,
+            // there is no single current workspace offset when the surface is off-screen.
+            if matches!(layer.layer(), Layer::Background | Layer::Bottom) {
+                return None;
+            }
+
+            let layer_origin = layers.layer_geometry(&layer)?.loc.to_f64() + mapped.bob_offset();
+            let surface_offset =
+                self.surface_offset_from_shell_root(&root, surface, Point::from((0, 0)))?;
+            return Some(PointerConstraintSurfacePlacement {
+                output: output.clone(),
+                window: None,
+                layer: Some(layer),
+                surface_origin: layer_origin + surface_offset,
+                scale: 1.,
+            });
+        }
+
+        for (output, state) in &self.output_state {
+            let Some(lock_surface) = state
+                .lock_surface
+                .as_ref()
+                .filter(|lock_surface| lock_surface.wl_surface() == &root)
+            else {
+                continue;
+            };
+            let surface_offset =
+                self.surface_offset_from_root(lock_surface.wl_surface(), surface)?;
+            return Some(PointerConstraintSurfacePlacement {
+                output: output.clone(),
+                window: None,
+                layer: None,
+                surface_origin: surface_offset,
+                scale: 1.,
+            });
+        }
+
+        None
+    }
+
+    pub(crate) fn pointer_constraint_surface_placement_from_contents(
+        &self,
+        surface: &WlSurface,
+    ) -> Option<PointerConstraintSurfacePlacement> {
+        let output = self.pointer_contents.output.clone()?;
+        let (focused_surface, global_surface_origin) = self.pointer_contents.surface.as_ref()?;
+        if focused_surface != surface {
+            return None;
+        }
+
+        let output_origin = self.global_space.output_geometry(&output)?.loc.to_f64();
+        let window = self
+            .pointer_contents
+            .window
+            .as_ref()
+            .and_then(|(window, hit)| match hit {
+                HitType::Input { win_pos } => Some((window.clone(), *win_pos - output_origin)),
+                _ => None,
+            });
+
+        Some(PointerConstraintSurfacePlacement {
+            output,
+            window,
+            layer: self.pointer_contents.layer.clone(),
+            surface_origin: *global_surface_origin - output_origin,
+            scale: 1.,
+        })
+    }
+
+    fn surface_accepts_input_at(&self, surface: &WlSurface, location: Point<f64, Logical>) -> bool {
+        with_states(surface, |states| {
+            let Some(size) = surface_geo(states).map(|geo| geo.size) else {
+                return false;
+            };
+            if !Rectangle::from_size(size.to_f64()).contains(location) {
+                return false;
+            }
+
+            states
+                .cached_state
+                .get::<SurfaceAttributes>()
+                .current()
+                .input_region
+                .as_ref()
+                .is_none_or(|region| region.contains(location.to_i32_floor()))
+        })
+    }
+
+    fn pointer_constraint_contents_at(
+        &self,
+        surface: &WlSurface,
+        location: Point<f64, Logical>,
+        fallback_placement: Option<&PointerConstraintSurfacePlacement>,
+    ) -> Option<(Point<f64, Logical>, PointContents)> {
+        if !self.surface_accepts_input_at(surface, location) {
+            return None;
+        }
+        let placement = self
+            .pointer_constraint_surface_placement(surface)
+            .or_else(|| fallback_placement.cloned())?;
+        let output_geometry = self.global_space.output_geometry(&placement.output)?;
+        let output_origin = output_geometry.loc.to_f64();
+        let target = output_origin + placement.surface_origin + location.upscale(placement.scale);
+        if !output_geometry.to_f64().contains(target) {
+            return None;
+        }
+
+        Some((
+            target,
+            PointContents {
+                output: Some(placement.output),
+                surface: Some((surface.clone(), output_origin + placement.surface_origin)),
+                window: placement.window.map(|(window, window_origin)| {
+                    (
+                        window,
+                        HitType::Input {
+                            win_pos: output_origin + window_origin,
+                        },
+                    )
+                }),
+                layer: placement.layer,
+                hot_corner: false,
+            },
+        ))
+    }
+
+    fn pointer_constraint_local_position(
+        &self,
+        surface: &WlSurface,
+        global_location: Point<f64, Logical>,
+        fallback_placement: Option<&PointerConstraintSurfacePlacement>,
+    ) -> Option<Point<f64, Logical>> {
+        let placement = self
+            .pointer_constraint_surface_placement(surface)
+            .or_else(|| fallback_placement.cloned())?;
+        let output_origin = self
+            .global_space
+            .output_geometry(&placement.output)?
+            .loc
+            .to_f64();
+        let local =
+            (global_location - output_origin - placement.surface_origin).downscale(placement.scale);
+        let size = with_states(surface, |states| surface_geo(states).map(|geo| geo.size))?;
+        Rectangle::from_size(size.to_f64())
+            .contains(local)
+            .then_some(local)
+    }
+
+    pub(crate) fn pointer_constraint_surface_target(
+        &self,
+        surface: &WlSurface,
+        location: Point<f64, Logical>,
+        fallback_placement: Option<&PointerConstraintSurfacePlacement>,
+    ) -> Option<Point<f64, Logical>> {
+        let placement = self
+            .pointer_constraint_surface_placement(surface)
+            .or_else(|| fallback_placement.cloned())?;
+        let mut output_geometry = self.global_space.output_geometry(&placement.output)?;
+        // i32 sizes are exclusive, but f64 sizes are inclusive.
+        output_geometry.size -= (1, 1).into();
+        let output_origin = output_geometry.loc.to_f64();
+        let target = output_origin + placement.surface_origin + location.upscale(placement.scale);
+        Some(target.constrain(output_geometry.to_f64()))
+    }
+
+    pub(crate) fn pointer_constraint_hint_target(
+        &self,
+        surface: &WlSurface,
+        location: Point<f64, Logical>,
+        fallback_placement: Option<&PointerConstraintSurfacePlacement>,
+    ) -> Option<Point<f64, Logical>> {
+        self.pointer_constraint_surface_target(surface, location, fallback_placement)
     }
 
     pub fn focus_layer_surface_if_on_demand(&mut self, surface: Option<LayerSurface>) {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1357,6 +1357,9 @@ impl State {
         // We're not changing the global cursor location here, so if the contents did not change,
         // then nothing changed.
         if self.niri.pointer_contents == under {
+            // Keyboard focus may have changed since these pointer contents were last computed.
+            // Reconsider an inactive constraint now, after hit-testing the current geometry.
+            self.niri.maybe_activate_pointer_constraint();
             return false;
         }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -494,7 +494,7 @@ pub struct OutputState {
     pub lock_render_state: LockRenderState,
     pub lock_surface: Option<LockSurface>,
     pub lock_color_buffer: SolidColorBuffer,
-    screen_transition: Option<ScreenTransition>,
+    pub(crate) screen_transition: Option<ScreenTransition>,
     /// Damage tracker used for the debug damage visualization.
     pub debug_damage_tracker: OutputDamageTracker,
 }

--- a/src/tests/activation.rs
+++ b/src/tests/activation.rs
@@ -1,0 +1,166 @@
+use std::time::Duration;
+
+use niri_config::Config;
+use smithay::reexports::wayland_server::Resource as _;
+use smithay::wayland::xdg_activation::XdgActivationHandler as _;
+use wayland_client::Proxy as _;
+
+use super::client::ClientId;
+use super::Fixture;
+
+fn map_window(
+    f: &mut Fixture,
+    client: ClientId,
+    app_id: &str,
+) -> wayland_client::protocol::wl_surface::WlSurface {
+    let window = f.client(client).create_window();
+    let surface = window.surface.clone();
+    window.xdg_toplevel.set_app_id(app_id.to_owned());
+    window.commit();
+    f.roundtrip(client);
+    let window = f.client(client).window(&surface);
+    window.attach_new_buffer();
+    window.set_size(400, 300);
+    window.ack_last_and_commit();
+    f.double_roundtrip(client);
+    surface
+}
+
+fn check_activation(
+    app_id: &str,
+    action: Option<&str>,
+    urgency_only: bool,
+    expired: bool,
+    should_focus: bool,
+    should_be_urgent: bool,
+) {
+    let mut config = Config::parse_mem(
+        r#"
+        debug { honor-xdg-activation-with-invalid-serial; }
+        "#,
+    )
+    .unwrap();
+    if let Some(action) = action {
+        let rule_config = Config::parse_mem(&format!(
+            r#"window-rule {{ match app-id="(?i)^google-chrome$"; on-xdg-activate "{action}"; }}"#,
+        ))
+        .unwrap();
+        config.window_rules = rule_config.window_rules;
+    }
+    let mut f = Fixture::with_config(config);
+    f.add_output(1, (1920, 1080));
+    f.add_output(2, (1920, 1080));
+    let client = f.add_client();
+    f.niri_focus_output(1);
+    let target = map_window(&mut f, client, app_id);
+    let server_surface = f
+        .niri()
+        .layout
+        .windows()
+        .find(|(_, mapped)| {
+            mapped.toplevel().wl_surface().id().protocol_id() == target.id().protocol_id()
+        })
+        .unwrap()
+        .1
+        .toplevel()
+        .wl_surface()
+        .clone();
+
+    f.niri_focus_output(2);
+    let editor = map_window(&mut f, client, "codex-desktop");
+    f.niri_complete_animations();
+    assert_eq!(f.client(client).keyboard_focus(), Some(&editor));
+    let user_output = f.niri_output(2);
+    assert_eq!(f.niri().layout.active_output(), Some(&user_output));
+
+    // Exercise the real handler after token acceptance, the boundary changed by
+    // this backport. The global compatibility flag remains enabled throughout.
+    let (token, mut data) = {
+        let (token, data) = f.niri().activation_state.create_external_token(None);
+        (token.clone(), data.clone())
+    };
+    if urgency_only {
+        assert!(f.niri_state().token_created(token.clone(), data.clone()));
+    }
+    if expired {
+        data.timestamp -= Duration::from_secs(20);
+    }
+    f.niri_state()
+        .request_activation(token.clone(), data, server_surface.clone());
+    f.double_roundtrip(client);
+    f.niri_complete_animations();
+
+    let expected_output = if should_focus {
+        f.niri_output(1)
+    } else {
+        user_output
+    };
+    assert_eq!(
+        f.niri().layout.active_output(),
+        Some(&expected_output),
+        "{app_id}"
+    );
+    let expected_focus = if should_focus { &target } else { &editor };
+    assert_eq!(
+        f.client(client).keyboard_focus(),
+        Some(expected_focus),
+        "{app_id}"
+    );
+    let urgent = f
+        .niri()
+        .layout
+        .windows()
+        .find(|(_, mapped)| mapped.toplevel().wl_surface() == &server_surface)
+        .unwrap()
+        .1
+        .is_urgent();
+    assert_eq!(urgent, should_be_urgent, "{app_id}");
+    assert!(f.niri().activation_state.data_for_token(&token).is_none());
+
+    // Explicit user/compositor focus must still work even when the application
+    // is not allowed to focus itself through xdg-activation.
+    if !should_focus {
+        let window = f
+            .niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface() == &server_surface)
+            .unwrap()
+            .1
+            .window
+            .clone();
+        f.niri().layout.activate_window(&window);
+        f.double_roundtrip(client);
+        assert_eq!(f.client(client).keyboard_focus(), Some(&target));
+    }
+}
+
+#[test]
+fn chrome_activation_keeps_user_focus_with_compatibility_enabled() {
+    for app_id in ["Google-chrome", "google-chrome"] {
+        check_activation(app_id, Some("set-urgent"), false, false, false, true);
+    }
+}
+
+#[test]
+fn chrome_rule_preserves_other_apps_and_default_activation() {
+    for app_id in ["firefox", "org.telegram.desktop", "Google-chrome-other"] {
+        check_activation(app_id, Some("set-urgent"), false, false, true, false);
+    }
+    check_activation("Google-chrome", None, false, false, true, false);
+    check_activation("firefox", Some("set-urgent"), true, false, false, true);
+}
+
+#[test]
+fn activation_actions_and_expiry_keep_upstream_semantics() {
+    check_activation("Google-chrome", Some("ignore"), false, false, false, false);
+    check_activation("Google-chrome", Some("focus"), true, false, true, false);
+    check_activation(
+        "Google-chrome",
+        Some("set-urgent"),
+        false,
+        true,
+        false,
+        false,
+    );
+}

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -11,6 +11,10 @@ use calloop::EventLoop;
 use calloop_wayland_source::WaylandSource;
 use single_pixel_buffer::v1::client::wp_single_pixel_buffer_manager_v1::WpSinglePixelBufferManagerV1;
 use smithay::reexports::wayland_protocols::wp::single_pixel_buffer;
+use smithay::reexports::wayland_protocols::wp::pointer_constraints::zv1::client::{
+    zwp_locked_pointer_v1::{self, ZwpLockedPointerV1},
+    zwp_pointer_constraints_v1::{self, ZwpPointerConstraintsV1},
+};
 use smithay::reexports::wayland_protocols::wp::viewporter::client::wp_viewport::WpViewport;
 use smithay::reexports::wayland_protocols::wp::viewporter::client::wp_viewporter::WpViewporter;
 use smithay::reexports::wayland_protocols::xdg::shell::client::xdg_surface::{self, XdgSurface};
@@ -29,7 +33,9 @@ use wayland_client::protocol::wl_callback::{self, WlCallback};
 use wayland_client::protocol::wl_compositor::WlCompositor;
 use wayland_client::protocol::wl_display::WlDisplay;
 use wayland_client::protocol::wl_output::{self, WlOutput};
+use wayland_client::protocol::wl_pointer::{self, WlPointer};
 use wayland_client::protocol::wl_registry::{self, WlRegistry};
+use wayland_client::protocol::wl_seat::WlSeat;
 use wayland_client::protocol::wl_surface::{self, WlSurface};
 use wayland_client::{Connection, Dispatch, Proxy as _, QueueHandle};
 
@@ -55,6 +61,10 @@ pub struct State {
     pub layer_shell: Option<ZwlrLayerShellV1>,
     pub spbm: Option<WpSinglePixelBufferManagerV1>,
     pub viewporter: Option<WpViewporter>,
+    pub seat: Option<WlSeat>,
+    pub pointer: Option<WlPointer>,
+    pub pointer_constraints: Option<ZwpPointerConstraintsV1>,
+    pub pointer_focus: Option<WlSurface>,
 
     pub windows: Vec<Window>,
     pub layers: Vec<LayerSurface>,
@@ -124,6 +134,12 @@ pub struct SyncData {
     pub done: AtomicBool,
 }
 
+#[derive(Default)]
+pub struct PointerLockStatus {
+    pub locked: AtomicBool,
+    pub unlocked: AtomicBool,
+}
+
 static CLIENT_ID_COUNTER: IdCounter = IdCounter::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -181,6 +197,10 @@ impl Client {
             layer_shell: None,
             spbm: None,
             viewporter: None,
+            seat: None,
+            pointer: None,
+            pointer_constraints: None,
+            pointer_focus: None,
             windows: Vec::new(),
             layers: Vec::new(),
         };
@@ -241,6 +261,31 @@ impl Client {
             .unwrap()
             .0
             .clone()
+    }
+    pub fn lock_pointer(
+        &self,
+        surface: &WlSurface,
+    ) -> (ZwpLockedPointerV1, Arc<PointerLockStatus>) {
+        let data = Arc::new(PointerLockStatus::default());
+        let locked_pointer = self
+            .state
+            .pointer_constraints
+            .as_ref()
+            .unwrap()
+            .lock_pointer(
+                surface,
+                self.state.pointer.as_ref().unwrap(),
+                None,
+                zwp_pointer_constraints_v1::Lifetime::Persistent,
+                &self.qh,
+                data.clone(),
+            );
+        self.connection.flush().unwrap();
+        (locked_pointer, data)
+    }
+
+    pub fn pointer_focus(&self) -> Option<&WlSurface> {
+        self.state.pointer_focus.as_ref()
     }
 }
 
@@ -518,6 +563,14 @@ impl Dispatch<WlRegistry, ()> for State {
                 } else if interface == WpViewporter::interface().name {
                     let version = min(version, WpViewporter::interface().version);
                     state.viewporter = Some(registry.bind(name, version, qh, ()));
+                } else if interface == WlSeat::interface().name {
+                    let version = min(version, WlSeat::interface().version);
+                    let seat: WlSeat = registry.bind(name, version, qh, ());
+                    state.pointer = Some(seat.get_pointer(qh, ()));
+                    state.seat = Some(seat);
+                } else if interface == ZwpPointerConstraintsV1::interface().name {
+                    let version = min(version, ZwpPointerConstraintsV1::interface().version);
+                    state.pointer_constraints = Some(registry.bind(name, version, qh, ()));
                 } else if interface == WlOutput::interface().name {
                     let version = min(version, WlOutput::interface().version);
                     let output = registry.bind(name, version, qh, ());
@@ -532,6 +585,76 @@ impl Dispatch<WlRegistry, ()> for State {
                 state.globals.push(global);
             }
             wl_registry::Event::GlobalRemove { .. } => (),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Dispatch<WlSeat, ()> for State {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlSeat,
+        _event: <WlSeat as wayland_client::Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<WlPointer, ()> for State {
+    fn event(
+        state: &mut Self,
+        _proxy: &WlPointer,
+        event: <WlPointer as wayland_client::Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        match event {
+            wl_pointer::Event::Enter { surface, .. } => {
+                state.pointer_focus = Some(surface);
+            }
+            wl_pointer::Event::Leave { surface, .. }
+                if state.pointer_focus.as_ref() == Some(&surface) =>
+            {
+                state.pointer_focus = None;
+            }
+            _ => (),
+        }
+    }
+}
+
+impl Dispatch<ZwpPointerConstraintsV1, ()> for State {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ZwpPointerConstraintsV1,
+        _event: <ZwpPointerConstraintsV1 as wayland_client::Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        unreachable!()
+    }
+}
+
+impl Dispatch<ZwpLockedPointerV1, Arc<PointerLockStatus>> for State {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ZwpLockedPointerV1,
+        event: <ZwpLockedPointerV1 as wayland_client::Proxy>::Event,
+        data: &Arc<PointerLockStatus>,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        match event {
+            zwp_locked_pointer_v1::Event::Locked => {
+                data.locked.store(true, Ordering::Relaxed);
+            }
+            zwp_locked_pointer_v1::Event::Unlocked => {
+                data.locked.store(false, Ordering::Relaxed);
+                data.unlocked.store(true, Ordering::Relaxed);
+            }
             _ => unreachable!(),
         }
     }

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -11,6 +11,7 @@ use calloop::EventLoop;
 use calloop_wayland_source::WaylandSource;
 use single_pixel_buffer::v1::client::wp_single_pixel_buffer_manager_v1::WpSinglePixelBufferManagerV1;
 use smithay::reexports::wayland_protocols::wp::pointer_constraints::zv1::client::{
+    zwp_confined_pointer_v1::{self, ZwpConfinedPointerV1},
     zwp_locked_pointer_v1::{self, ZwpLockedPointerV1},
     zwp_pointer_constraints_v1::{self, ZwpPointerConstraintsV1},
 };
@@ -153,6 +154,8 @@ pub enum ClientEvent {
     KeyboardLeave(u32),
     PointerLocked,
     PointerUnlocked,
+    PointerConfined,
+    PointerUnconfined,
 }
 
 static CLIENT_ID_COUNTER: IdCounter = IdCounter::new();
@@ -317,6 +320,28 @@ impl Client {
             );
         self.connection.flush().unwrap();
         (locked_pointer, data)
+    }
+
+    pub fn confine_pointer(
+        &self,
+        surface: &WlSurface,
+    ) -> (ZwpConfinedPointerV1, Arc<PointerLockStatus>) {
+        let data = Arc::new(PointerLockStatus::default());
+        let confined_pointer = self
+            .state
+            .pointer_constraints
+            .as_ref()
+            .unwrap()
+            .confine_pointer(
+                surface,
+                self.state.pointer.as_ref().unwrap(),
+                None,
+                zwp_pointer_constraints_v1::Lifetime::Persistent,
+                &self.qh,
+                data.clone(),
+            );
+        self.connection.flush().unwrap();
+        (confined_pointer, data)
     }
 
     pub fn create_region(&self, x: i32, y: i32, width: i32, height: i32) -> WlRegion {
@@ -765,6 +790,32 @@ impl Dispatch<ZwpLockedPointerV1, Arc<PointerLockStatus>> for State {
             }
             zwp_locked_pointer_v1::Event::Unlocked => {
                 state.events.push(ClientEvent::PointerUnlocked);
+                data.locked.store(false, Ordering::Relaxed);
+                data.unlocked.store(true, Ordering::Relaxed);
+                data.unlocked_count.fetch_add(1, Ordering::Relaxed);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Dispatch<ZwpConfinedPointerV1, Arc<PointerLockStatus>> for State {
+    fn event(
+        state: &mut Self,
+        _proxy: &ZwpConfinedPointerV1,
+        event: <ZwpConfinedPointerV1 as wayland_client::Proxy>::Event,
+        data: &Arc<PointerLockStatus>,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        match event {
+            zwp_confined_pointer_v1::Event::Confined => {
+                state.events.push(ClientEvent::PointerConfined);
+                data.locked.store(true, Ordering::Relaxed);
+                data.locked_count.fetch_add(1, Ordering::Relaxed);
+            }
+            zwp_confined_pointer_v1::Event::Unconfined => {
+                state.events.push(ClientEvent::PointerUnconfined);
                 data.locked.store(false, Ordering::Relaxed);
                 data.unlocked.store(true, Ordering::Relaxed);
                 data.unlocked_count.fetch_add(1, Ordering::Relaxed);

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -3,18 +3,18 @@ use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Write as _;
 use std::os::unix::net::UnixStream;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use calloop::EventLoop;
 use calloop_wayland_source::WaylandSource;
 use single_pixel_buffer::v1::client::wp_single_pixel_buffer_manager_v1::WpSinglePixelBufferManagerV1;
-use smithay::reexports::wayland_protocols::wp::single_pixel_buffer;
 use smithay::reexports::wayland_protocols::wp::pointer_constraints::zv1::client::{
     zwp_locked_pointer_v1::{self, ZwpLockedPointerV1},
     zwp_pointer_constraints_v1::{self, ZwpPointerConstraintsV1},
 };
+use smithay::reexports::wayland_protocols::wp::single_pixel_buffer;
 use smithay::reexports::wayland_protocols::wp::viewporter::client::wp_viewport::WpViewport;
 use smithay::reexports::wayland_protocols::wp::viewporter::client::wp_viewporter::WpViewporter;
 use smithay::reexports::wayland_protocols::xdg::shell::client::xdg_surface::{self, XdgSurface};
@@ -32,8 +32,10 @@ use wayland_client::protocol::wl_buffer::{self, WlBuffer};
 use wayland_client::protocol::wl_callback::{self, WlCallback};
 use wayland_client::protocol::wl_compositor::WlCompositor;
 use wayland_client::protocol::wl_display::WlDisplay;
+use wayland_client::protocol::wl_keyboard::{self, WlKeyboard};
 use wayland_client::protocol::wl_output::{self, WlOutput};
 use wayland_client::protocol::wl_pointer::{self, WlPointer};
+use wayland_client::protocol::wl_region::WlRegion;
 use wayland_client::protocol::wl_registry::{self, WlRegistry};
 use wayland_client::protocol::wl_seat::WlSeat;
 use wayland_client::protocol::wl_surface::{self, WlSurface};
@@ -62,9 +64,12 @@ pub struct State {
     pub spbm: Option<WpSinglePixelBufferManagerV1>,
     pub viewporter: Option<WpViewporter>,
     pub seat: Option<WlSeat>,
+    pub keyboard: Option<WlKeyboard>,
     pub pointer: Option<WlPointer>,
     pub pointer_constraints: Option<ZwpPointerConstraintsV1>,
     pub pointer_focus: Option<WlSurface>,
+    pub keyboard_focus: Option<WlSurface>,
+    pub events: Vec<ClientEvent>,
 
     pub windows: Vec<Window>,
     pub layers: Vec<LayerSurface>,
@@ -138,6 +143,16 @@ pub struct SyncData {
 pub struct PointerLockStatus {
     pub locked: AtomicBool,
     pub unlocked: AtomicBool,
+    pub locked_count: AtomicUsize,
+    pub unlocked_count: AtomicUsize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientEvent {
+    KeyboardEnter(u32),
+    KeyboardLeave(u32),
+    PointerLocked,
+    PointerUnlocked,
 }
 
 static CLIENT_ID_COUNTER: IdCounter = IdCounter::new();
@@ -198,9 +213,12 @@ impl Client {
             spbm: None,
             viewporter: None,
             seat: None,
+            keyboard: None,
             pointer: None,
             pointer_constraints: None,
             pointer_focus: None,
+            keyboard_focus: None,
+            events: Vec::new(),
             windows: Vec::new(),
             layers: Vec::new(),
         };
@@ -266,6 +284,23 @@ impl Client {
         &self,
         surface: &WlSurface,
     ) -> (ZwpLockedPointerV1, Arc<PointerLockStatus>) {
+        self.lock_pointer_with_lifetime(surface, zwp_pointer_constraints_v1::Lifetime::Persistent)
+    }
+
+    pub fn lock_pointer_with_lifetime(
+        &self,
+        surface: &WlSurface,
+        lifetime: zwp_pointer_constraints_v1::Lifetime,
+    ) -> (ZwpLockedPointerV1, Arc<PointerLockStatus>) {
+        self.lock_pointer_with_region(surface, None, lifetime)
+    }
+
+    pub fn lock_pointer_with_region(
+        &self,
+        surface: &WlSurface,
+        region: Option<&WlRegion>,
+        lifetime: zwp_pointer_constraints_v1::Lifetime,
+    ) -> (ZwpLockedPointerV1, Arc<PointerLockStatus>) {
         let data = Arc::new(PointerLockStatus::default());
         let locked_pointer = self
             .state
@@ -275,8 +310,8 @@ impl Client {
             .lock_pointer(
                 surface,
                 self.state.pointer.as_ref().unwrap(),
-                None,
-                zwp_pointer_constraints_v1::Lifetime::Persistent,
+                region,
+                lifetime,
                 &self.qh,
                 data.clone(),
             );
@@ -284,8 +319,27 @@ impl Client {
         (locked_pointer, data)
     }
 
+    pub fn create_region(&self, x: i32, y: i32, width: i32, height: i32) -> WlRegion {
+        let region = self
+            .state
+            .compositor
+            .as_ref()
+            .unwrap()
+            .create_region(&self.qh, ());
+        region.add(x, y, width, height);
+        region
+    }
+
     pub fn pointer_focus(&self) -> Option<&WlSurface> {
         self.state.pointer_focus.as_ref()
+    }
+
+    pub fn keyboard_focus(&self) -> Option<&WlSurface> {
+        self.state.keyboard_focus.as_ref()
+    }
+
+    pub fn take_events(&mut self) -> Vec<ClientEvent> {
+        std::mem::take(&mut self.state.events)
     }
 }
 
@@ -324,6 +378,19 @@ impl State {
             .iter_mut()
             .find(|w| w.surface == *surface)
             .unwrap()
+    }
+
+    pub fn destroy_window(&mut self, surface: &WlSurface) {
+        let index = self
+            .windows
+            .iter()
+            .position(|window| window.surface == *surface)
+            .unwrap();
+        let window = self.windows.remove(index);
+        window.viewport.destroy();
+        window.xdg_toplevel.destroy();
+        window.xdg_surface.destroy();
+        window.surface.destroy();
     }
 
     pub fn create_layer(
@@ -567,6 +634,7 @@ impl Dispatch<WlRegistry, ()> for State {
                     let version = min(version, WlSeat::interface().version);
                     let seat: WlSeat = registry.bind(name, version, qh, ());
                     state.pointer = Some(seat.get_pointer(qh, ()));
+                    state.keyboard = Some(seat.get_keyboard(qh, ()));
                     state.seat = Some(seat);
                 } else if interface == ZwpPointerConstraintsV1::interface().name {
                     let version = min(version, ZwpPointerConstraintsV1::interface().version);
@@ -625,6 +693,48 @@ impl Dispatch<WlPointer, ()> for State {
     }
 }
 
+impl Dispatch<WlRegion, ()> for State {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlRegion,
+        _event: <WlRegion as wayland_client::Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        unreachable!()
+    }
+}
+
+impl Dispatch<WlKeyboard, ()> for State {
+    fn event(
+        state: &mut Self,
+        _proxy: &WlKeyboard,
+        event: <WlKeyboard as wayland_client::Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        match event {
+            wl_keyboard::Event::Enter { surface, .. } => {
+                state
+                    .events
+                    .push(ClientEvent::KeyboardEnter(surface.id().protocol_id()));
+                state.keyboard_focus = Some(surface);
+            }
+            wl_keyboard::Event::Leave { surface, .. } => {
+                state
+                    .events
+                    .push(ClientEvent::KeyboardLeave(surface.id().protocol_id()));
+                if state.keyboard_focus.as_ref() == Some(&surface) {
+                    state.keyboard_focus = None;
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
 impl Dispatch<ZwpPointerConstraintsV1, ()> for State {
     fn event(
         _state: &mut Self,
@@ -640,7 +750,7 @@ impl Dispatch<ZwpPointerConstraintsV1, ()> for State {
 
 impl Dispatch<ZwpLockedPointerV1, Arc<PointerLockStatus>> for State {
     fn event(
-        _state: &mut Self,
+        state: &mut Self,
         _proxy: &ZwpLockedPointerV1,
         event: <ZwpLockedPointerV1 as wayland_client::Proxy>::Event,
         data: &Arc<PointerLockStatus>,
@@ -649,11 +759,15 @@ impl Dispatch<ZwpLockedPointerV1, Arc<PointerLockStatus>> for State {
     ) {
         match event {
             zwp_locked_pointer_v1::Event::Locked => {
+                state.events.push(ClientEvent::PointerLocked);
                 data.locked.store(true, Ordering::Relaxed);
+                data.locked_count.fetch_add(1, Ordering::Relaxed);
             }
             zwp_locked_pointer_v1::Event::Unlocked => {
+                state.events.push(ClientEvent::PointerUnlocked);
                 data.locked.store(false, Ordering::Relaxed);
                 data.unlocked.store(true, Ordering::Relaxed);
+                data.unlocked_count.fetch_add(1, Ordering::Relaxed);
             }
             _ => unreachable!(),
         }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod client;
 mod fixture;
 mod server;
 
+mod activation;
 mod animations;
 mod floating;
 mod fullscreen;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod animations;
 mod floating;
 mod fullscreen;
 mod layer_shell;
+mod pointer_constraints;
 mod remove_output;
 mod transactions;
 mod window_opening;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,3 +12,4 @@ mod pointer_constraints;
 mod remove_output;
 mod transactions;
 mod window_opening;
+mod window_geometry;

--- a/src/tests/pointer_constraints.rs
+++ b/src/tests/pointer_constraints.rs
@@ -15,6 +15,7 @@ use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::client::zwlr_lay
 };
 use smithay::reexports::wayland_server::Resource as _;
 use smithay::utils::Point;
+use smithay::wayland::pointer_constraints::with_pointer_constraint;
 use smithay::reexports::wayland_protocols::wp::pointer_constraints::zv1::client::zwp_pointer_constraints_v1::Lifetime as ClientConstraintLifetime;
 use wayland_client::protocol::wl_surface::WlSurface;
 use wayland_client::Proxy as _;
@@ -899,6 +900,67 @@ window-rule {
     assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
     assert!(!status.locked.load(Ordering::Relaxed));
     assert!(f.niri().pointer_constraint_placements.is_empty());
+}
+
+#[test]
+fn destroying_defunct_oneshot_constraint_keeps_replacement_constraint() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let game_window = {
+        let protocol_id = game_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+    let server_game_surface = game_window.toplevel().unwrap().wl_surface().clone();
+    let (old_lock, old_status) = f
+        .client(id)
+        .lock_pointer_with_lifetime(&game_surface, ClientConstraintLifetime::Oneshot);
+    f.double_roundtrip(id);
+    assert_eq!(old_status.locked_count.load(Ordering::Relaxed), 1);
+
+    let (_overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    assert_eq!(old_status.unlocked_count.load(Ordering::Relaxed), 1);
+
+    f.niri().layout.activate_window(&game_window);
+    f.double_roundtrip(id);
+    let (replacement_lock, _replacement_status) = f.client(id).lock_pointer(&game_surface);
+    let replacement_id = replacement_lock.id().protocol_id();
+    f.double_roundtrip(id);
+
+    let pointer = f.niri().seat.get_pointer().unwrap();
+    let current_id = with_pointer_constraint(&server_game_surface, &pointer, |constraint| {
+        constraint.map(|constraint| constraint.id().protocol_id())
+    });
+    assert_eq!(current_id, Some(replacement_id));
+
+    // The defunct one-shot protocol object can outlive its server-side constraint. Destroying it
+    // must not remove the newer constraint created for the same surface and pointer.
+    old_lock.destroy();
+    f.double_roundtrip(id);
+
+    let current_id = with_pointer_constraint(&server_game_surface, &pointer, |constraint| {
+        constraint.map(|constraint| constraint.id().protocol_id())
+    });
+    assert_eq!(current_id, Some(replacement_id));
 }
 
 #[test]

--- a/src/tests/pointer_constraints.rs
+++ b/src/tests/pointer_constraints.rs
@@ -1,22 +1,28 @@
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use niri_config::Config;
 use niri_ipc::PositionChange;
 use smithay::backend::input::{
     AbsolutePositionEvent, ButtonState, Device, DeviceCapability, Event, InputBackend, InputEvent,
-    PointerButtonEvent, PointerMotionAbsoluteEvent, UnusedEvent,
+    PointerButtonEvent, PointerMotionAbsoluteEvent, PointerMotionEvent, UnusedEvent,
 };
+use smithay::desktop::Window as DesktopWindow;
 use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::Layer;
-use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::Anchor;
+use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::{
+    Anchor, KeyboardInteractivity,
+};
 use smithay::reexports::wayland_server::Resource as _;
 use smithay::utils::Point;
+use smithay::reexports::wayland_protocols::wp::pointer_constraints::zv1::client::zwp_pointer_constraints_v1::Lifetime as ClientConstraintLifetime;
 use wayland_client::protocol::wl_surface::WlSurface;
 use wayland_client::Proxy as _;
 
 use super::*;
 use crate::input::backend_ext::NiriInputDevice;
-use crate::tests::client::{ClientId, LayerConfigureProps, LayerMargin};
+use crate::niri::PointerVisibility;
+use crate::tests::client::{ClientEvent, ClientId, LayerConfigureProps, LayerMargin};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 struct TestDevice;
@@ -108,12 +114,45 @@ impl AbsolutePositionEvent<TestInputBackend> for TestAbsoluteEvent {
 
 impl PointerMotionAbsoluteEvent<TestInputBackend> for TestAbsoluteEvent {}
 
+struct TestRelativeEvent {
+    dx: f64,
+    dy: f64,
+}
+
+impl Event<TestInputBackend> for TestRelativeEvent {
+    fn time(&self) -> u64 {
+        0
+    }
+
+    fn device(&self) -> TestDevice {
+        TestDevice
+    }
+}
+
+impl PointerMotionEvent<TestInputBackend> for TestRelativeEvent {
+    fn delta_x(&self) -> f64 {
+        self.dx
+    }
+
+    fn delta_y(&self) -> f64 {
+        self.dy
+    }
+
+    fn delta_x_unaccel(&self) -> f64 {
+        self.dx
+    }
+
+    fn delta_y_unaccel(&self) -> f64 {
+        self.dy
+    }
+}
+
 impl InputBackend for TestInputBackend {
     type Device = TestDevice;
     type KeyboardKeyEvent = UnusedEvent;
     type PointerAxisEvent = UnusedEvent;
     type PointerButtonEvent = TestButtonEvent;
-    type PointerMotionEvent = UnusedEvent;
+    type PointerMotionEvent = TestRelativeEvent;
     type PointerMotionAbsoluteEvent = TestAbsoluteEvent;
     type GestureSwipeBeginEvent = UnusedEvent;
     type GestureSwipeUpdateEvent = UnusedEvent;
@@ -162,6 +201,58 @@ fn fixture_with_window(config: Config) -> (Fixture, ClientId, WlSurface) {
     (f, id, surface)
 }
 
+fn fixture_with_floating_window() -> (Fixture, ClientId, WlSurface, DesktopWindow) {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^game$"
+    open-floating true
+    default-column-width { fixed 400; }
+    default-window-height { fixed 300; }
+}
+"#,
+    )
+    .unwrap();
+    let mut f = Fixture::with_config(config);
+    f.add_output(1, (1920, 1080));
+    let id = f.add_client();
+
+    let window = f.client(id).create_window();
+    let surface = window.surface.clone();
+    window.set_title("game");
+    window.commit();
+    f.roundtrip(id);
+
+    let window = f.client(id).window(&surface);
+    window.attach_new_buffer();
+    window.set_size(400, 300);
+    window.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    let protocol_id = surface.id().protocol_id();
+    let window = f
+        .niri()
+        .layout
+        .windows()
+        .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+        .unwrap()
+        .1
+        .window
+        .clone();
+    f.niri().layout.move_floating_window(
+        Some(&window),
+        PositionChange::SetFixed(100.),
+        PositionChange::SetFixed(100.),
+        false,
+    );
+    f.niri_state()
+        .move_cursor(Point::from((200.0_f64, 200.0_f64)));
+    f.double_roundtrip(id);
+    assert_eq!(f.client(id).pointer_focus(), Some(&surface));
+
+    (f, id, surface, window)
+}
+
 fn add_overlay_layer(f: &mut Fixture, id: ClientId, left: i32, top: i32) -> WlSurface {
     let layer = f.client(id).create_layer(None, Layer::Overlay, "");
     let surface = layer.surface.clone();
@@ -185,6 +276,40 @@ fn add_overlay_layer(f: &mut Fixture, id: ClientId, left: i32, top: i32) -> WlSu
     f.double_roundtrip(id);
 
     surface
+}
+
+fn add_floating_overlay_window(f: &mut Fixture, id: ClientId) -> (WlSurface, DesktopWindow) {
+    let overlay = f.client(id).create_window();
+    let surface = overlay.surface.clone();
+    overlay.set_title("overlay");
+    overlay.commit();
+    f.roundtrip(id);
+
+    let overlay = f.client(id).window(&surface);
+    overlay.attach_new_buffer();
+    overlay.set_size(200, 200);
+    overlay.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    let window = {
+        let protocol_id = surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+    f.niri().layout.move_floating_window(
+        Some(&window),
+        PositionChange::SetFixed(860.),
+        PositionChange::SetFixed(440.),
+        false,
+    );
+
+    (surface, window)
 }
 
 fn send_button(f: &mut Fixture, state: ButtonState) {
@@ -328,7 +453,6 @@ window-rule {
         PositionChange::SetFixed(440.),
         false,
     );
-
     assert_eq!(
         f.niri()
             .contents_under(Point::from((960.0_f64, 540.0_f64)))
@@ -369,4 +493,904 @@ window-rule {
     assert!(lock_status.locked.load(Ordering::Relaxed));
     assert!(!lock_status.unlocked.load(Ordering::Relaxed));
     assert_eq!(f.client(id).pointer_focus(), Some(&window_surface));
+}
+
+#[test]
+fn keyboard_focus_leave_deactivates_persistent_lock() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, window_surface) = fixture_with_window(config);
+
+    let game_window = {
+        let protocol_id = window_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+
+    let (_locked_pointer, lock_status) = f.client(id).lock_pointer(&window_surface);
+    f.double_roundtrip(id);
+    assert!(lock_status.locked.load(Ordering::Relaxed));
+
+    let overlay = f.client(id).create_window();
+    let overlay_surface = overlay.surface.clone();
+    overlay.set_title("overlay");
+    overlay.commit();
+    f.roundtrip(id);
+
+    let overlay = f.client(id).window(&overlay_surface);
+    overlay.attach_new_buffer();
+    overlay.set_size(200, 200);
+    overlay.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    let overlay_window = {
+        let protocol_id = overlay_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+
+    // This models Alt-Tab or a compositor focus keybind, not a pointer click.
+    f.client(id).take_events();
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+
+    assert!(!lock_status.locked.load(Ordering::Relaxed));
+    assert!(lock_status.unlocked.load(Ordering::Relaxed));
+    assert_eq!(f.client(id).keyboard_focus(), Some(&overlay_surface));
+    assert_eq!(
+        f.client(id).take_events(),
+        vec![
+            ClientEvent::PointerUnlocked,
+            ClientEvent::KeyboardLeave(window_surface.id().protocol_id()),
+            ClientEvent::KeyboardEnter(overlay_surface.id().protocol_id()),
+        ]
+    );
+
+    f.niri().layout.activate_window(&game_window);
+    f.double_roundtrip(id);
+
+    assert!(lock_status.locked.load(Ordering::Relaxed));
+    assert_eq!(f.client(id).keyboard_focus(), Some(&window_surface));
+    assert_eq!(
+        f.client(id).take_events(),
+        vec![
+            ClientEvent::KeyboardLeave(overlay_surface.id().protocol_id()),
+            ClientEvent::KeyboardEnter(window_surface.id().protocol_id()),
+            ClientEvent::PointerLocked,
+        ]
+    );
+}
+
+#[test]
+fn reactivation_cancels_pending_cursor_hint_warp() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, window_surface) = fixture_with_window(config);
+
+    let game_window = {
+        let protocol_id = window_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+
+    let (locked_pointer, lock_status) = f.client(id).lock_pointer(&window_surface);
+    f.double_roundtrip(id);
+    assert_eq!(lock_status.locked_count.load(Ordering::Relaxed), 1);
+
+    locked_pointer.set_cursor_position_hint(50.0, 50.0);
+    f.client(id).window(&window_surface).commit();
+    f.double_roundtrip(id);
+
+    let overlay = f.client(id).create_window();
+    let overlay_surface = overlay.surface.clone();
+    overlay.set_title("overlay");
+    overlay.commit();
+    f.roundtrip(id);
+
+    let overlay = f.client(id).window(&overlay_surface);
+    overlay.attach_new_buffer();
+    overlay.set_size(200, 200);
+    overlay.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    let overlay_window = {
+        let protocol_id = overlay_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+
+    // Exercise two keyboard-focus transitions in one compositor dispatch. The hint warp queued
+    // by the first transition must not run after the persistent constraint has reactivated.
+    f.niri().layout.activate_window(&overlay_window);
+    f.niri_state().update_keyboard_focus();
+    f.niri().layout.activate_window(&game_window);
+    f.niri_state().update_keyboard_focus();
+    f.double_roundtrip(id);
+
+    assert_eq!(lock_status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert_eq!(lock_status.locked_count.load(Ordering::Relaxed), 2);
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((960.0_f64, 540.0_f64))
+    );
+}
+
+#[test]
+fn inactive_constraint_does_not_consume_another_constraints_hint() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let (game_lock, game_status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+
+    let overlay = f.client(id).create_window();
+    let overlay_surface = overlay.surface.clone();
+    overlay.set_title("overlay");
+    overlay.commit();
+    f.roundtrip(id);
+
+    let overlay = f.client(id).window(&overlay_surface);
+    overlay.attach_new_buffer();
+    overlay.set_size(200, 200);
+    overlay.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    let overlay_window = {
+        let protocol_id = overlay_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+    f.niri().layout.move_floating_window(
+        Some(&overlay_window),
+        PositionChange::SetFixed(860.),
+        PositionChange::SetFixed(440.),
+        false,
+    );
+
+    // Keep the post-unlock pointer under the overlay, then explicitly focus it. This deactivates
+    // A while retaining its persistent protocol object.
+    assert_eq!(
+        f.niri()
+            .contents_under(Point::from((960.0_f64, 540.0_f64)))
+            .surface
+            .unwrap()
+            .0
+            .id()
+            .protocol_id(),
+        overlay_surface.id().protocol_id()
+    );
+    game_lock.set_cursor_position_hint(960.0, 540.0);
+    f.client(id).window(&game_surface).commit();
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    f.dispatch();
+    f.double_roundtrip(id);
+    assert!(!game_status.locked.load(Ordering::Relaxed));
+    assert_eq!(
+        f.niri()
+            .seat
+            .get_pointer()
+            .unwrap()
+            .current_focus()
+            .unwrap()
+            .id()
+            .protocol_id(),
+        overlay_surface.id().protocol_id()
+    );
+    assert_eq!(f.client(id).pointer_focus(), Some(&overlay_surface));
+
+    let (overlay_lock, overlay_status) = f.client(id).lock_pointer(&overlay_surface);
+    f.double_roundtrip(id);
+    assert!(overlay_status.locked.load(Ordering::Relaxed));
+
+    overlay_lock.set_cursor_position_hint(25.0, 25.0);
+    f.client(id).window(&overlay_surface).commit();
+    f.double_roundtrip(id);
+
+    // Destroying inactive A must not consume or apply active B's committed hint.
+    game_lock.destroy();
+    f.double_roundtrip(id);
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((960.0_f64, 540.0_f64))
+    );
+    assert!(overlay_status.locked.load(Ordering::Relaxed));
+}
+
+#[test]
+fn oneshot_constraint_does_not_reactivate_after_keyboard_focus_returns() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let game_window = {
+        let protocol_id = game_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+    let (_lock, status) = f
+        .client(id)
+        .lock_pointer_with_lifetime(&game_surface, ClientConstraintLifetime::Oneshot);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+
+    let (_overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+
+    f.niri().layout.activate_window(&game_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+    assert!(!status.locked.load(Ordering::Relaxed));
+    assert!(f.niri().pointer_constraint_placements.is_empty());
+}
+
+#[test]
+fn destroying_inactive_persistent_constraint_does_not_warp_or_leave_tracking() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let (lock, status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+    lock.set_cursor_position_hint(50.0, 50.0);
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+
+    let (_overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((50.0_f64, 50.0_f64))
+    );
+
+    f.niri_state()
+        .move_cursor(Point::from((960.0_f64, 540.0_f64)));
+    f.double_roundtrip(id);
+    lock.destroy();
+    f.double_roundtrip(id);
+
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((960.0_f64, 540.0_f64))
+    );
+    assert!(f.niri().suspended_pointer_constraints.is_empty());
+    assert!(f.niri().pointer_constraint_placements.is_empty());
+}
+
+#[test]
+fn programmatic_cursor_warp_wins_over_unlock_hint() {
+    let (mut f, id, game_surface) = fixture_with_window(Config::default());
+    let overlay_surface = add_overlay_layer(&mut f, id, 0, 0);
+    let (lock, status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+
+    lock.set_cursor_position_hint(20.0, 20.0);
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+
+    // A compositor-initiated warp is an explicit focus transition. It must deactivate the lock
+    // before pointer.motion() and cancel the resulting deferred hint, otherwise the hint races the
+    // intentional destination and can move the cursor a second time.
+    f.niri_state()
+        .move_cursor(Point::from((50.0_f64, 50.0_f64)));
+    f.double_roundtrip(id);
+
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((50.0_f64, 50.0_f64))
+    );
+    assert_eq!(f.client(id).pointer_focus(), Some(&overlay_surface));
+}
+
+#[test]
+fn multiple_persistent_constraints_resume_independently() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let game_window = {
+        let protocol_id = game_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+    let (game_lock, game_status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+    game_lock.set_cursor_position_hint(960.0, 540.0);
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+
+    let (overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    let (_overlay_lock, overlay_status) = f.client(id).lock_pointer(&overlay_surface);
+    f.double_roundtrip(id);
+    assert_eq!(overlay_status.locked_count.load(Ordering::Relaxed), 0);
+
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    assert_eq!(game_status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert_eq!(overlay_status.locked_count.load(Ordering::Relaxed), 1);
+
+    f.niri().layout.activate_window(&game_window);
+    f.double_roundtrip(id);
+    assert_eq!(overlay_status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert_eq!(game_status.locked_count.load(Ordering::Relaxed), 2);
+}
+
+#[test]
+fn persistent_constraint_reactivation_respects_updated_region() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let game_window = {
+        let protocol_id = game_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+    f.niri_state()
+        .move_cursor(Point::from((50.0_f64, 50.0_f64)));
+    f.double_roundtrip(id);
+
+    let initial_region = f.client(id).create_region(0, 0, 100, 100);
+    let (lock, status) = f.client(id).lock_pointer_with_region(
+        &game_surface,
+        Some(&initial_region),
+        ClientConstraintLifetime::Persistent,
+    );
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+
+    lock.set_cursor_position_hint(960.0, 540.0);
+    f.client(id).window(&game_surface).commit();
+    let (_overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+
+    let updated_region = f.client(id).create_region(1000, 1000, 100, 100);
+    lock.set_region(Some(&updated_region));
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+
+    f.niri().layout.activate_window(&game_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn persistent_constraint_reactivation_respects_updated_surface_input_region() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let game_window = {
+        let protocol_id = game_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+    let (_lock, status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+
+    let (_overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+
+    // The saved position is the center of the game surface. Exclude it from the surface input
+    // region while the persistent constraint is inactive.
+    let input_region = f.client(id).create_region(0, 0, 100, 100);
+    game_surface.set_input_region(Some(&input_region));
+    game_surface.commit();
+    f.double_roundtrip(id);
+
+    f.niri().layout.activate_window(&game_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn layer_surface_cursor_position_hint_is_applied_after_unlock() {
+    let mut f = Fixture::with_config(Config::default());
+    f.add_output(1, (1920, 1080));
+    let id = f.add_client();
+
+    let layer = f.client(id).create_layer(None, Layer::Overlay, "");
+    let surface = layer.surface.clone();
+    layer.set_configure_props(LayerConfigureProps {
+        anchor: Some(Anchor::Top | Anchor::Left),
+        size: Some((100, 100)),
+        margin: Some(LayerMargin {
+            top: 100,
+            left: 100,
+            ..Default::default()
+        }),
+        kb_interactivity: Some(KeyboardInteractivity::Exclusive),
+        ..Default::default()
+    });
+    layer.commit();
+    f.roundtrip(id);
+
+    let layer = f.client(id).layer(&surface);
+    layer.attach_new_buffer();
+    layer.set_size(100, 100);
+    layer.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    f.niri_state()
+        .move_cursor(Point::from((150.0_f64, 150.0_f64)));
+    f.double_roundtrip(id);
+    assert_eq!(f.client(id).pointer_focus(), Some(&surface));
+
+    let (lock, status) = f.client(id).lock_pointer(&surface);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+
+    lock.set_cursor_position_hint(20.0, 20.0);
+    f.client(id).layer(&surface).commit();
+    f.double_roundtrip(id);
+    lock.destroy();
+    f.double_roundtrip(id);
+
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((120.0_f64, 120.0_f64))
+    );
+}
+
+#[test]
+fn destroyed_surface_drops_suspended_constraint_tracking() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let (_lock, status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+
+    let (_overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert_eq!(f.niri().suspended_pointer_constraints.len(), 1);
+
+    f.client(id).state.destroy_window(&game_surface);
+    f.double_roundtrip(id);
+
+    assert!(f.niri().suspended_pointer_constraints.is_empty());
+    assert!(f.niri().pointer_constraint_placements.is_empty());
+}
+
+#[test]
+fn destroying_just_deactivated_constraint_keeps_one_pending_hint() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let (lock, _status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+    lock.set_cursor_position_hint(50.0, 50.0);
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+
+    let (_overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.niri().layout.activate_window(&overlay_window);
+    f.niri_state().update_keyboard_focus();
+    assert_eq!(f.niri().pending_pointer_constraint_warps.len(), 1);
+
+    // The terminal removal is processed before the compositor's idle callback. It must clean
+    // tracking without replacing the already queued deactivation hint with an empty update.
+    lock.destroy();
+    f.double_roundtrip(id);
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((50.0_f64, 50.0_f64))
+    );
+    assert!(f.niri().pending_pointer_constraint_warps.is_empty());
+    assert!(f.niri().suspended_pointer_constraints.is_empty());
+    assert!(f.niri().pointer_constraint_placements.is_empty());
+}
+
+#[test]
+fn persistent_constraint_uses_hint_committed_while_inactive_on_next_unlock() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let game_window = {
+        let protocol_id = game_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+    let (lock, status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+    lock.set_cursor_position_hint(960.0, 540.0);
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+
+    let (_overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+
+    lock.set_cursor_position_hint(100.0, 100.0);
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+
+    f.niri().layout.activate_window(&game_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 2);
+
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 2);
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((100.0_f64, 100.0_f64))
+    );
+}
+
+#[test]
+fn moved_locked_surface_uses_current_geometry_for_hint_and_reactivation() {
+    let (mut f, id, game_surface, game_window) = fixture_with_floating_window();
+    let (lock, status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+
+    lock.set_cursor_position_hint(20.0, 20.0);
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+
+    f.niri().layout.move_floating_window(
+        Some(&game_window),
+        PositionChange::SetFixed(600.),
+        PositionChange::SetFixed(400.),
+        false,
+    );
+
+    let point_in_moved_window = Point::from((700.0_f64, 500.0_f64));
+    let (surface, current_origin) = f
+        .niri()
+        .contents_under(point_in_moved_window)
+        .surface
+        .unwrap();
+    assert_eq!(surface.id().protocol_id(), game_surface.id().protocol_id());
+    let expected_hint_target = current_origin + Point::from((20.0_f64, 20.0_f64));
+
+    let (_overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        expected_hint_target
+    );
+
+    f.niri().layout.activate_window(&game_window);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 2);
+    assert_eq!(f.client(id).pointer_focus(), Some(&game_surface));
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        expected_hint_target
+    );
+}
+
+#[test]
+fn bobbing_locked_surface_uses_rendered_geometry_for_hint() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    baba-is-float true
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+
+    // Freeze the adjustable clock at a deterministic point where the bob offset is non-zero.
+    let now = f.niri().clock.now();
+    f.niri().clock.set_unadjusted(now);
+    let _ = f.niri().clock.now();
+    f.niri().clock.set_unadjusted(Duration::ZERO);
+    f.niri().clock.set_rate(1.);
+    let _ = f.niri().clock.now();
+    f.niri().clock.set_rate(0.);
+
+    let (_, surface_origin) = f
+        .niri()
+        .contents_under(Point::from((960.0_f64, 540.0_f64)))
+        .surface
+        .unwrap();
+    assert_ne!(surface_origin.y, 0.);
+
+    let (lock, _status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+    lock.set_cursor_position_hint(50.0, 50.0);
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+    lock.destroy();
+    f.double_roundtrip(id);
+
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        surface_origin + Point::from((50.0_f64, 50.0_f64))
+    );
+}
+
+#[test]
+fn offscreen_workspace_constraint_uses_last_valid_placement() {
+    let mut config = Config::default();
+    config.animations.off = true;
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let (lock, status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+
+    lock.set_cursor_position_hint(40.0, 40.0);
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+
+    // With animations disabled the old workspace is immediately culled, so current layout
+    // geometry can no longer locate its window by the time keyboard focus leaves it.
+    f.niri().layout.switch_workspace_down();
+    f.double_roundtrip(id);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((40.0_f64, 40.0_f64))
+    );
+
+    f.niri().layout.switch_workspace_up();
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 2);
+    assert_eq!(f.client(id).pointer_focus(), Some(&game_surface));
+}
+
+#[test]
+fn overview_close_reactivation_preserves_surface_local_position() {
+    let (mut f, id, game_surface) = fixture_with_window(Config::default());
+    let region = f.client(id).create_region(950, 530, 20, 20);
+    let (_lock, status) = f.client(id).lock_pointer_with_region(
+        &game_surface,
+        Some(&region),
+        ClientConstraintLifetime::Persistent,
+    );
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+
+    assert!(f.niri().layout.open_overview());
+    f.niri_state().update_keyboard_focus();
+    f.double_roundtrip(id);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+    f.niri_complete_animations();
+
+    assert!(f.niri().layout.close_overview());
+    f.niri_state().update_keyboard_focus();
+    f.double_roundtrip(id);
+    // Pointer focus cannot express the inverse transform of a scaled overview surface, so keep
+    // the constraint suspended until the close animation reaches its normal scale.
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+
+    // hide-when-typing may disable ordinary pointer hit-testing while the overview keybind runs.
+    // Suspended constraints still need a lifecycle retry once stable geometry returns.
+    f.niri().pointer_visibility = PointerVisibility::Disabled;
+    f.niri_complete_animations();
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 2);
+
+    f.niri_state()
+        .process_input_event(InputEvent::<TestInputBackend>::PointerMotion {
+            event: TestRelativeEvent { dx: 1., dy: 1. },
+        });
+    f.double_roundtrip(id);
+
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 2);
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert_eq!(f.client(id).pointer_focus(), Some(&game_surface));
+}
+
+#[test]
+fn same_surface_compositor_warp_cancels_pending_hint() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let (lock, status) = f.client(id).lock_pointer(&game_surface);
+    f.double_roundtrip(id);
+    lock.set_cursor_position_hint(20.0, 20.0);
+    f.client(id).window(&game_surface).commit();
+    f.double_roundtrip(id);
+
+    let (_overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.niri().layout.activate_window(&overlay_window);
+    f.niri_state().update_keyboard_focus();
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 0);
+    assert_eq!(f.niri().pending_pointer_constraint_warps.len(), 1);
+
+    // This point is still on the fullscreen game surface, so pointer focus does not change. The
+    // compositor warp is nevertheless newer than the queued client hint and must win.
+    let compositor_target = Point::from((500.0_f64, 500.0_f64));
+    f.niri_state().move_cursor(compositor_target);
+    assert!(f.niri().pending_pointer_constraint_warps.is_empty());
+    f.double_roundtrip(id);
+
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        compositor_target
+    );
 }

--- a/src/tests/pointer_constraints.rs
+++ b/src/tests/pointer_constraints.rs
@@ -278,6 +278,41 @@ fn add_overlay_layer(f: &mut Fixture, id: ClientId, left: i32, top: i32) -> WlSu
     surface
 }
 
+fn add_pointer_focused_layer(
+    f: &mut Fixture,
+    id: ClientId,
+    kb_interactivity: KeyboardInteractivity,
+) -> WlSurface {
+    let layer = f.client(id).create_layer(None, Layer::Overlay, "");
+    let surface = layer.surface.clone();
+    layer.set_configure_props(LayerConfigureProps {
+        anchor: Some(Anchor::Top | Anchor::Left),
+        size: Some((100, 100)),
+        margin: Some(LayerMargin {
+            top: 100,
+            left: 100,
+            ..Default::default()
+        }),
+        kb_interactivity: Some(kb_interactivity),
+        ..Default::default()
+    });
+    layer.commit();
+    f.roundtrip(id);
+
+    let layer = f.client(id).layer(&surface);
+    layer.attach_new_buffer();
+    layer.set_size(100, 100);
+    layer.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    f.niri_state()
+        .move_cursor(Point::from((150.0_f64, 150.0_f64)));
+    f.double_roundtrip(id);
+    assert_eq!(f.client(id).pointer_focus(), Some(&surface));
+
+    surface
+}
+
 fn add_floating_overlay_window(f: &mut Fixture, id: ClientId) -> (WlSurface, DesktopWindow) {
     let overlay = f.client(id).create_window();
     let surface = overlay.surface.clone();
@@ -579,6 +614,71 @@ window-rule {
             ClientEvent::KeyboardLeave(overlay_surface.id().protocol_id()),
             ClientEvent::KeyboardEnter(window_surface.id().protocol_id()),
             ClientEvent::PointerLocked,
+        ]
+    );
+}
+
+#[test]
+fn keyboard_focus_leave_deactivates_and_reactivates_persistent_confine() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, game_surface) = fixture_with_window(config);
+    let game_window = {
+        let protocol_id = game_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+
+    let (_confined_pointer, status) = f.client(id).confine_pointer(&game_surface);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+    assert!(status.locked.load(Ordering::Relaxed));
+
+    let (overlay_surface, overlay_window) = add_floating_overlay_window(&mut f, id);
+    f.client(id).take_events();
+    f.niri().layout.activate_window(&overlay_window);
+    f.double_roundtrip(id);
+
+    assert_eq!(status.unlocked_count.load(Ordering::Relaxed), 1);
+    assert!(!status.locked.load(Ordering::Relaxed));
+    assert_eq!(f.client(id).keyboard_focus(), Some(&overlay_surface));
+    assert_eq!(
+        f.client(id).take_events(),
+        vec![
+            ClientEvent::PointerUnconfined,
+            ClientEvent::KeyboardLeave(game_surface.id().protocol_id()),
+            ClientEvent::KeyboardEnter(overlay_surface.id().protocol_id()),
+        ]
+    );
+
+    f.niri().layout.activate_window(&game_window);
+    f.double_roundtrip(id);
+
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 2);
+    assert!(status.locked.load(Ordering::Relaxed));
+    assert_eq!(f.client(id).keyboard_focus(), Some(&game_surface));
+    assert_eq!(
+        f.client(id).take_events(),
+        vec![
+            ClientEvent::KeyboardLeave(overlay_surface.id().protocol_id()),
+            ClientEvent::KeyboardEnter(game_surface.id().protocol_id()),
+            ClientEvent::PointerConfined,
         ]
     );
 }
@@ -1069,6 +1169,101 @@ fn layer_surface_cursor_position_hint_is_applied_after_unlock() {
         f.niri().seat.get_pointer().unwrap().current_location(),
         Point::from((120.0_f64, 120.0_f64))
     );
+}
+
+#[test]
+fn exclusive_layer_surface_can_lock_pointer_with_keyboard_focus() {
+    let (mut f, id, _window_surface) = fixture_with_window(Config::default());
+    let surface = add_pointer_focused_layer(&mut f, id, KeyboardInteractivity::Exclusive);
+
+    assert_eq!(f.client(id).keyboard_focus(), Some(&surface));
+    let (_lock, status) = f.client(id).lock_pointer(&surface);
+    f.double_roundtrip(id);
+
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+    assert!(status.locked.load(Ordering::Relaxed));
+}
+
+#[test]
+fn on_demand_layer_surface_locks_pointer_after_click_focus() {
+    let (mut f, id, window_surface) = fixture_with_window(Config::default());
+    let surface = add_pointer_focused_layer(&mut f, id, KeyboardInteractivity::OnDemand);
+
+    // Niri intentionally focuses newly mapped on-demand layers. Click the regular window first,
+    // then return the pointer to the layer without clicking to model an already-running desktop.
+    f.niri_state()
+        .move_cursor(Point::from((500.0_f64, 500.0_f64)));
+    send_button(&mut f, ButtonState::Pressed);
+    send_button(&mut f, ButtonState::Released);
+    f.double_roundtrip(id);
+    assert_eq!(f.client(id).keyboard_focus(), Some(&window_surface));
+
+    f.niri_state()
+        .move_cursor(Point::from((150.0_f64, 150.0_f64)));
+    f.double_roundtrip(id);
+    assert_eq!(f.client(id).pointer_focus(), Some(&surface));
+    assert_eq!(f.client(id).keyboard_focus(), Some(&window_surface));
+
+    let (_lock, status) = f.client(id).lock_pointer(&surface);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 0);
+
+    send_button(&mut f, ButtonState::Pressed);
+    send_button(&mut f, ButtonState::Released);
+    f.double_roundtrip(id);
+
+    assert_eq!(f.client(id).keyboard_focus(), Some(&surface));
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 1);
+    assert!(status.locked.load(Ordering::Relaxed));
+}
+
+#[test]
+fn noninteractive_layer_surface_cannot_lock_pointer_after_click() {
+    let (mut f, id, window_surface) = fixture_with_window(Config::default());
+    let surface = add_pointer_focused_layer(&mut f, id, KeyboardInteractivity::None);
+
+    assert_eq!(f.client(id).keyboard_focus(), Some(&window_surface));
+    let (_lock, status) = f.client(id).lock_pointer(&surface);
+    f.double_roundtrip(id);
+
+    send_button(&mut f, ButtonState::Pressed);
+    send_button(&mut f, ButtonState::Released);
+    f.double_roundtrip(id);
+
+    assert_eq!(f.client(id).keyboard_focus(), Some(&window_surface));
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 0);
+    assert!(!status.locked.load(Ordering::Relaxed));
+}
+
+#[test]
+fn layer_constraint_does_not_activate_from_stale_geometry_after_focus_change() {
+    let (mut f, id, _window_surface) = fixture_with_window(Config::default());
+    let surface = add_pointer_focused_layer(&mut f, id, KeyboardInteractivity::None);
+
+    let (_lock, status) = f.client(id).lock_pointer(&surface);
+    f.double_roundtrip(id);
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 0);
+
+    // Move the layer away from the pointer and make it keyboard-focusable in the same commit.
+    // Pointer-constraint eligibility must use the new placement, not the cached focus/origin from
+    // before this commit.
+    let layer = f.client(id).layer(&surface);
+    layer.set_configure_props(LayerConfigureProps {
+        margin: Some(LayerMargin {
+            top: 400,
+            left: 400,
+            ..Default::default()
+        }),
+        kb_interactivity: Some(KeyboardInteractivity::Exclusive),
+        ..Default::default()
+    });
+    layer.commit();
+    f.double_roundtrip(id);
+
+    assert_eq!(f.client(id).keyboard_focus(), Some(&surface));
+    assert_ne!(f.client(id).pointer_focus(), Some(&surface));
+    assert_eq!(status.locked_count.load(Ordering::Relaxed), 0);
+    assert!(!status.locked.load(Ordering::Relaxed));
 }
 
 #[test]

--- a/src/tests/pointer_constraints.rs
+++ b/src/tests/pointer_constraints.rs
@@ -1,0 +1,372 @@
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+
+use niri_config::Config;
+use niri_ipc::PositionChange;
+use smithay::backend::input::{
+    AbsolutePositionEvent, ButtonState, Device, DeviceCapability, Event, InputBackend, InputEvent,
+    PointerButtonEvent, PointerMotionAbsoluteEvent, UnusedEvent,
+};
+use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::Layer;
+use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::Anchor;
+use smithay::reexports::wayland_server::Resource as _;
+use smithay::utils::Point;
+use wayland_client::protocol::wl_surface::WlSurface;
+use wayland_client::Proxy as _;
+
+use super::*;
+use crate::input::backend_ext::NiriInputDevice;
+use crate::tests::client::{ClientId, LayerConfigureProps, LayerMargin};
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct TestDevice;
+
+impl Device for TestDevice {
+    fn id(&self) -> String {
+        "test-pointer".into()
+    }
+
+    fn name(&self) -> String {
+        "test pointer".into()
+    }
+
+    fn has_capability(&self, capability: DeviceCapability) -> bool {
+        capability == DeviceCapability::Pointer
+    }
+
+    fn usb_id(&self) -> Option<(u32, u32)> {
+        None
+    }
+
+    fn syspath(&self) -> Option<PathBuf> {
+        None
+    }
+}
+
+impl NiriInputDevice for TestDevice {
+    fn output(&self, _state: &crate::niri::State) -> Option<smithay::output::Output> {
+        None
+    }
+}
+
+struct TestInputBackend;
+
+struct TestButtonEvent(ButtonState);
+
+impl Event<TestInputBackend> for TestButtonEvent {
+    fn time(&self) -> u64 {
+        0
+    }
+
+    fn device(&self) -> TestDevice {
+        TestDevice
+    }
+}
+
+impl PointerButtonEvent<TestInputBackend> for TestButtonEvent {
+    fn button_code(&self) -> u32 {
+        0x110
+    }
+
+    fn state(&self) -> ButtonState {
+        self.0
+    }
+}
+
+struct TestAbsoluteEvent {
+    x: f64,
+    y: f64,
+}
+
+impl Event<TestInputBackend> for TestAbsoluteEvent {
+    fn time(&self) -> u64 {
+        0
+    }
+
+    fn device(&self) -> TestDevice {
+        TestDevice
+    }
+}
+
+impl AbsolutePositionEvent<TestInputBackend> for TestAbsoluteEvent {
+    fn x(&self) -> f64 {
+        self.x
+    }
+
+    fn y(&self) -> f64 {
+        self.y
+    }
+
+    fn x_transformed(&self, width: i32) -> f64 {
+        self.x * f64::from(width)
+    }
+
+    fn y_transformed(&self, height: i32) -> f64 {
+        self.y * f64::from(height)
+    }
+}
+
+impl PointerMotionAbsoluteEvent<TestInputBackend> for TestAbsoluteEvent {}
+
+impl InputBackend for TestInputBackend {
+    type Device = TestDevice;
+    type KeyboardKeyEvent = UnusedEvent;
+    type PointerAxisEvent = UnusedEvent;
+    type PointerButtonEvent = TestButtonEvent;
+    type PointerMotionEvent = UnusedEvent;
+    type PointerMotionAbsoluteEvent = TestAbsoluteEvent;
+    type GestureSwipeBeginEvent = UnusedEvent;
+    type GestureSwipeUpdateEvent = UnusedEvent;
+    type GestureSwipeEndEvent = UnusedEvent;
+    type GesturePinchBeginEvent = UnusedEvent;
+    type GesturePinchUpdateEvent = UnusedEvent;
+    type GesturePinchEndEvent = UnusedEvent;
+    type GestureHoldBeginEvent = UnusedEvent;
+    type GestureHoldEndEvent = UnusedEvent;
+    type TouchDownEvent = UnusedEvent;
+    type TouchUpEvent = UnusedEvent;
+    type TouchMotionEvent = UnusedEvent;
+    type TouchCancelEvent = UnusedEvent;
+    type TouchFrameEvent = UnusedEvent;
+    type TabletToolAxisEvent = UnusedEvent;
+    type TabletToolProximityEvent = UnusedEvent;
+    type TabletToolTipEvent = UnusedEvent;
+    type TabletToolButtonEvent = UnusedEvent;
+    type SwitchToggleEvent = UnusedEvent;
+    type SpecialEvent = ();
+}
+
+fn fixture_with_window(config: Config) -> (Fixture, ClientId, WlSurface) {
+    let mut f = Fixture::with_config(config);
+    f.add_output(1, (1920, 1080));
+    let id = f.add_client();
+
+    let window = f.client(id).create_window();
+    let surface = window.surface.clone();
+    window.set_maximized();
+    window.commit();
+    f.roundtrip(id);
+
+    let window = f.client(id).window(&surface);
+    window.attach_new_buffer();
+    window.set_size(1920, 1080);
+    window.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    f.niri_state()
+        .move_cursor(Point::from((960.0_f64, 540.0_f64)));
+    f.double_roundtrip(id);
+    f.niri_complete_animations();
+    assert_eq!(f.client(id).pointer_focus(), Some(&surface));
+
+    (f, id, surface)
+}
+
+fn add_overlay_layer(f: &mut Fixture, id: ClientId, left: i32, top: i32) -> WlSurface {
+    let layer = f.client(id).create_layer(None, Layer::Overlay, "");
+    let surface = layer.surface.clone();
+    layer.set_configure_props(LayerConfigureProps {
+        anchor: Some(Anchor::Top | Anchor::Left),
+        size: Some((100, 100)),
+        margin: Some(LayerMargin {
+            top,
+            left,
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    layer.commit();
+    f.roundtrip(id);
+
+    let layer = f.client(id).layer(&surface);
+    layer.attach_new_buffer();
+    layer.set_size(100, 100);
+    layer.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    surface
+}
+
+fn send_button(f: &mut Fixture, state: ButtonState) {
+    f.niri_state()
+        .process_input_event(InputEvent::<TestInputBackend>::PointerButton {
+            event: TestButtonEvent(state),
+        });
+}
+
+#[test]
+fn cursor_position_hint_is_applied_only_after_unlock() {
+    let (mut f, id, window_surface) = fixture_with_window(Config::default());
+    let layer_surface = add_overlay_layer(&mut f, id, 0, 0);
+
+    assert_eq!(f.client(id).pointer_focus(), Some(&window_surface));
+    let (locked_pointer, lock_status) = f.client(id).lock_pointer(&window_surface);
+    f.double_roundtrip(id);
+    assert!(lock_status.locked.load(Ordering::Relaxed));
+
+    locked_pointer.set_cursor_position_hint(50.0, 50.0);
+    f.client(id).window(&window_surface).commit();
+    f.double_roundtrip(id);
+
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((960.0_f64, 540.0_f64))
+    );
+    assert!(lock_status.locked.load(Ordering::Relaxed));
+    assert!(!lock_status.unlocked.load(Ordering::Relaxed));
+    assert_eq!(f.client(id).pointer_focus(), Some(&window_surface));
+
+    locked_pointer.destroy();
+    f.double_roundtrip(id);
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((50.0_f64, 50.0_f64))
+    );
+
+    f.niri_state().refresh_pointer_contents();
+    f.double_roundtrip(id);
+    assert_eq!(f.client(id).pointer_focus(), Some(&layer_surface));
+}
+
+#[test]
+fn new_surface_under_locked_pointer_does_not_end_lock() {
+    let (mut f, id, window_surface) = fixture_with_window(Config::default());
+    let (_locked_pointer, lock_status) = f.client(id).lock_pointer(&window_surface);
+    f.double_roundtrip(id);
+    assert!(lock_status.locked.load(Ordering::Relaxed));
+
+    let layer_surface = add_overlay_layer(&mut f, id, 910, 490);
+    assert_eq!(
+        f.niri()
+            .contents_under(Point::from((960.0_f64, 540.0_f64)))
+            .surface
+            .unwrap()
+            .0
+            .id()
+            .protocol_id(),
+        layer_surface.id().protocol_id()
+    );
+
+    assert!(!f.niri_state().update_pointer_contents());
+    f.double_roundtrip(id);
+    assert!(lock_status.locked.load(Ordering::Relaxed));
+    assert!(!lock_status.unlocked.load(Ordering::Relaxed));
+    assert_eq!(f.client(id).pointer_focus(), Some(&window_surface));
+    assert!(f.niri().pointer_contents.window.is_some());
+    assert!(f.niri().pointer_contents.layer.is_none());
+}
+
+#[test]
+fn absolute_motion_does_not_end_active_lock() {
+    let (mut f, id, window_surface) = fixture_with_window(Config::default());
+    let layer_surface = add_overlay_layer(&mut f, id, 0, 0);
+    let (_locked_pointer, lock_status) = f.client(id).lock_pointer(&window_surface);
+    f.double_roundtrip(id);
+    assert!(lock_status.locked.load(Ordering::Relaxed));
+
+    f.niri_state()
+        .process_input_event(InputEvent::<TestInputBackend>::PointerMotionAbsolute {
+            event: TestAbsoluteEvent { x: 0.025, y: 0.045 },
+        });
+    f.double_roundtrip(id);
+
+    assert_eq!(
+        f.niri().seat.get_pointer().unwrap().current_location(),
+        Point::from((960.0_f64, 540.0_f64))
+    );
+    assert!(lock_status.locked.load(Ordering::Relaxed));
+    assert!(!lock_status.unlocked.load(Ordering::Relaxed));
+    assert_eq!(f.client(id).pointer_focus(), Some(&window_surface));
+    assert_ne!(f.client(id).pointer_focus(), Some(&layer_surface));
+}
+
+#[test]
+fn clicking_window_under_locked_pointer_keeps_keyboard_focus() {
+    let config = Config::parse_mem(
+        r#"
+window-rule {
+    match title="^overlay$"
+    open-floating true
+    open-focused false
+    default-column-width { fixed 200; }
+    default-window-height { fixed 200; }
+}
+"#,
+    )
+    .unwrap();
+    let (mut f, id, window_surface) = fixture_with_window(config);
+    let (_locked_pointer, lock_status) = f.client(id).lock_pointer(&window_surface);
+    f.double_roundtrip(id);
+    assert!(lock_status.locked.load(Ordering::Relaxed));
+
+    let overlay = f.client(id).create_window();
+    let overlay_surface = overlay.surface.clone();
+    overlay.set_title("overlay");
+    overlay.commit();
+    f.roundtrip(id);
+
+    let overlay = f.client(id).window(&overlay_surface);
+    overlay.attach_new_buffer();
+    overlay.set_size(200, 200);
+    overlay.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    let overlay_window = {
+        let protocol_id = overlay_surface.id().protocol_id();
+        f.niri()
+            .layout
+            .windows()
+            .find(|(_, mapped)| mapped.toplevel().wl_surface().id().protocol_id() == protocol_id)
+            .unwrap()
+            .1
+            .window
+            .clone()
+    };
+    f.niri().layout.move_floating_window(
+        Some(&overlay_window),
+        PositionChange::SetFixed(860.),
+        PositionChange::SetFixed(440.),
+        false,
+    );
+
+    assert_eq!(
+        f.niri()
+            .contents_under(Point::from((960.0_f64, 540.0_f64)))
+            .surface
+            .unwrap()
+            .0
+            .id()
+            .protocol_id(),
+        overlay_surface.id().protocol_id()
+    );
+    assert_eq!(
+        f.niri()
+            .layout
+            .focus()
+            .unwrap()
+            .toplevel()
+            .wl_surface()
+            .id()
+            .protocol_id(),
+        window_surface.id().protocol_id()
+    );
+
+    send_button(&mut f, ButtonState::Pressed);
+    send_button(&mut f, ButtonState::Released);
+    f.double_roundtrip(id);
+
+    assert_eq!(
+        f.niri()
+            .layout
+            .focus()
+            .unwrap()
+            .toplevel()
+            .wl_surface()
+            .id()
+            .protocol_id(),
+        window_surface.id().protocol_id()
+    );
+    assert!(lock_status.locked.load(Ordering::Relaxed));
+    assert!(!lock_status.unlocked.load(Ordering::Relaxed));
+    assert_eq!(f.client(id).pointer_focus(), Some(&window_surface));
+}

--- a/src/tests/window_geometry.rs
+++ b/src/tests/window_geometry.rs
@@ -1,0 +1,100 @@
+use niri_ipc::PositionChange;
+use smithay::reexports::wayland_server::Resource as _;
+use smithay::utils::Point;
+use wayland_client::Proxy as _;
+
+use super::*;
+use crate::ipc::server::window_geometry;
+
+#[test]
+fn live_window_geometry_is_targeted_and_independent_of_null_ipc_tile_positions() {
+    let mut f = Fixture::new();
+    f.add_output(1, (1920, 1080));
+    let client = f.add_client();
+    let window = f.client(client).create_window();
+    let surface = window.surface.clone();
+    window.commit();
+    f.roundtrip(client);
+    let window = f.client(client).window(&surface);
+    window.attach_new_buffer();
+    window.set_size(400, 300);
+    window.ack_last_and_commit();
+    f.double_roundtrip(client);
+    f.niri_complete_animations();
+    let mut target = None;
+    f.niri().layout.with_windows(|mapped, _, _, layout| {
+        assert!(layout.tile_pos_in_workspace_view.is_none());
+        target = Some(mapped.id().get());
+    });
+    let target = target.unwrap();
+    let geometry = window_geometry(f.niri_state(), target).unwrap();
+    assert_eq!((geometry.width, geometry.height), (400, 300));
+    assert!(geometry.x >= 0.0 && geometry.y >= 0.0);
+    assert!(geometry.x + 400.0 <= 1920.0 && geometry.y + 300.0 <= 1080.0);
+    assert_eq!(geometry.outputs, vec![(0, 0, 1920, 1080)]);
+    assert!(window_geometry(f.niri_state(), target + 100).is_err());
+    f.niri().layout.toggle_window_floating(None);
+    f.double_roundtrip(client);
+    f.niri_complete_animations();
+    f.niri().layout.move_floating_window(
+        None,
+        PositionChange::SetFixed(600.0),
+        PositionChange::SetFixed(400.0),
+        false,
+    );
+    f.niri_complete_animations();
+    let moved = window_geometry(f.niri_state(), target).unwrap();
+    assert!(moved.x > geometry.x || moved.y > geometry.y);
+    let hit = f
+        .niri()
+        .contents_under(Point::from((moved.x + 20.0, moved.y + 20.0)))
+        .surface
+        .unwrap()
+        .0;
+    assert_eq!(hit.id().protocol_id(), surface.id().protocol_id());
+    // Layout activity alone must not authorize input through compositor overlays.
+    let saved_focus = f.niri().keyboard_focus.clone();
+    for focus in [
+        crate::niri::KeyboardFocus::Mru,
+        crate::niri::KeyboardFocus::ExitConfirmDialog,
+        crate::niri::KeyboardFocus::LayerShell {
+            surface: hit.clone(),
+        },
+    ] {
+        f.niri().keyboard_focus = focus;
+        assert!(window_geometry(f.niri_state(), target).is_err());
+    }
+    f.niri().keyboard_focus = saved_focus;
+    assert!(window_geometry(f.niri_state(), target).is_ok());
+    f.add_output(2, (1280, 720));
+    f.niri_focus_output(2);
+    f.double_roundtrip(client);
+    assert!(window_geometry(f.niri_state(), target).is_err());
+    f.niri_focus_output(1);
+    f.double_roundtrip(client);
+    f.niri().layout.open_overview();
+    assert!(window_geometry(f.niri_state(), target).is_err());
+    f.niri().layout.close_overview();
+    f.niri_complete_animations();
+    use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::Layer;
+    use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::{Anchor, KeyboardInteractivity};
+    let layer = f
+        .client(client)
+        .create_layer(None, Layer::Overlay, "geometry-test");
+    let layer_surface = layer.surface.clone();
+    layer.set_configure_props(super::client::LayerConfigureProps {
+        anchor: Some(Anchor::Top | Anchor::Left),
+        size: Some((100, 100)),
+        kb_interactivity: Some(KeyboardInteractivity::Exclusive),
+        ..Default::default()
+    });
+    layer.commit();
+    f.roundtrip(client);
+    let layer = f.client(client).layer(&layer_surface);
+    layer.attach_new_buffer();
+    layer.set_size(100, 100);
+    layer.ack_last_and_commit();
+    f.double_roundtrip(client);
+    assert_eq!(f.client(client).keyboard_focus(), Some(&layer_surface));
+    assert!(window_geometry(f.niri_state(), target).is_err());
+}

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1,7 +1,7 @@
 use std::cmp::{max, min};
 
 use niri_config::utils::MergeWith as _;
-use niri_config::window_rule::{Match, WindowRule};
+use niri_config::window_rule::{Match, OnXdgActivate, WindowRule};
 use niri_config::{
     BackgroundEffect, BlockOutFrom, BorderRule, CornerRadius, FloatingPosition, PresetSize,
     ResolvedPopupsRules, ShadowRule, TabIndicatorRule,
@@ -72,6 +72,9 @@ pub struct ResolvedWindowRules {
 
     /// Whether the window should open focused.
     pub open_focused: Option<bool>,
+
+    /// What to do on xdg-activation requests.
+    pub on_xdg_activate: Option<OnXdgActivate>,
 
     /// Extra bound on the minimum window width.
     pub min_width: Option<u16>,
@@ -255,6 +258,10 @@ impl ResolvedWindowRules {
 
                 if let Some(x) = rule.open_focused {
                     resolved.open_focused = Some(x);
+                }
+
+                if let Some(x) = rule.on_xdg_activate {
+                    resolved.on_xdg_activate = Some(x);
                 }
 
                 if let Some(x) = rule.min_width {


### PR DESCRIPTION
Fixes #3729.
Fixes #4121.
Fixes #4430.

## Behavior

Pointer constraints now follow both pointer and keyboard focus:

- activation requires pointer and keyboard focus to resolve to the same root shell surface;
- an active lock or confinement is released when an explicit focus action moves keyboard focus away;
- a persistent constraint is restored when keyboard focus returns, while a one-shot constraint is not;
- a committed cursor-position hint remains deferred while locked and is applied at most once after deactivation/removal;
- overlapping surfaces, ordinary clicks, absolute input, and pointer refreshes do not steal focus from an active lock;
- layer-shell surfaces follow their keyboard-interactivity policy: `exclusive` can activate, `on-demand` activates after receiving keyboard focus, and `none` cannot activate.

The lifecycle also accounts for current surface geometry, input/constraint regions, workspace/output changes, popups and subsurfaces, layer surfaces, overview animation, hidden cursors, and multiple persistent constraints.

## Smithay prerequisite

This branch pins [`1b0e75ab`](https://github.com/Vantrongs/smithay/commit/1b0e75abb473847c08ed83b1d18519c06fed9a47), which is exactly one commit on top of Niri's current Smithay revision `7609ab82`. Therefore it includes the already merged Smithay [#2107](https://github.com/Smithay/smithay/pull/2107) and does not drop any of Niri's existing Smithay changes.

The additional commit separates temporary constraint deactivation from final protocol-object removal, carries the concrete surface/pointer/constraint identity through both callbacks, exposes the lifetime/object identity needed for cleanup, and documents that pointer operations must be deferred outside the pointer-motion callback. Terminal removal is matched against the exact Wayland object identity, so destroying an old defunct one-shot object cannot remove a newer constraint created for the same surface and pointer. Deferring pointer operations avoids re-entering `PointerHandle`'s mutex when focus loss deactivates a constraint during motion dispatch.

This history matters because the earlier #2107 head (`46a875`) was older than the Smithay revision Niri's update work already used (`5fb12b`); pinning that old head directly would have dropped four unrelated fixes. The present fork is based on the newer upstream `7609ab82`, not that older branch. Its single lifecycle commit still needs separate Smithay upstream review before this Niri PR can merge without a fork.

## Validation

On exact PR head [`5532ed92`](https://github.com/Vantrongs/niri/commit/5532ed925b03165d4cbefd19afb721594c0c66f4), using Smithay `1b0e75ab`:

- all 28 pointer-constraint regression tests pass, including the defunct one-shot/replacement-constraint lifecycle regression;
- all 223 Niri tests pass;
- `cargo fmt --all -- --check`;
- `git diff --check`.

The preceding implementation head also passed `cargo clippy --locked --all-targets --all-features -- -D warnings`. The final head changes only the Smithay pin/lockfile and adds the lifecycle regression test described above.

The core lock/focus lifecycle was also tested successfully with the native Linux War Thunder client on NixOS 26.05, NVIDIA, and one physical display in generation 449. That manual generation used the pre-final-rebase implementation (`b902a70b`); the later changes cover layer-shell, overview animation, hidden-cursor, and lifecycle edge cases with automated regressions on the exact PR head. Proton titles and multi-display behavior still benefit from independent testing.
