### PR TITLE
Add option to disable screenshot notification

### DIFF
--- a/docs/wiki/Configuration:-Key-Bindings.md
+++ b/docs/wiki/Configuration:-Key-Bindings.md
@@ -358,6 +358,8 @@ Actions for taking screenshots.
 
 The screenshot is both stored to the clipboard and saved to disk, according to the [`screenshot-path` option](./Configuration:-Miscellaneous.md#screenshot-path).
 
+You can disable the notification shown after taking a screenshot with the [`screenshot-notification` option](./Configuration:-Miscellaneous.md#screenshot-notification).
+
 <sup>Since: 25.02</sup> You can disable saving to disk for a specific bind with the `write-to-disk=false` property:
 
 ```kdl

--- a/docs/wiki/Configuration:-Miscellaneous.md
+++ b/docs/wiki/Configuration:-Miscellaneous.md
@@ -11,6 +11,10 @@ prefer-no-csd
 
 screenshot-path "~/Pictures/Screenshots/Screenshot from %Y-%m-%d %H-%M-%S.png"
 
+screenshot-notification {
+    disable
+}
+
 environment {
     QT_QPA_PLATFORM "wayland"
     DISPLAY null
@@ -133,6 +137,21 @@ You can also set this option to `null` to disable saving screenshots to disk.
 
 ```kdl
 screenshot-path null
+```
+
+### `screenshot-notification`
+
+<sup>Since: 26.05</sup>
+
+Settings for the screenshot taken notification.
+
+By default, niri shows a notification when a screenshot is taken.
+Set the `disable` flag to turn it off.
+
+```kdl
+screenshot-notification {
+    disable
+}
 ```
 
 ### `environment`

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -76,6 +76,7 @@ pub struct Config {
     pub prefer_no_csd: bool,
     pub cursor: Cursor,
     pub screenshot_path: ScreenshotPath,
+    pub screenshot_notification: ScreenshotNotification,
     pub clipboard: Clipboard,
     pub hotkey_overlay: HotkeyOverlay,
     pub config_notification: ConfigNotification,
@@ -242,6 +243,7 @@ where
                     let part = knuffel::Decode::decode_node(node, ctx)?;
                     config.borrow_mut().screenshot_path = part;
                 }
+                "screenshot-notification" => m_merge!(screenshot_notification),
 
                 "layout" => {
                     let mut part = LayoutPart::decode_node(node, ctx)?;
@@ -1496,6 +1498,9 @@ mod tests {
                     "~/Screenshots/screenshot.png",
                 ),
             ),
+            screenshot_notification: ScreenshotNotification {
+                disable: false,
+            },
             clipboard: Clipboard {
                 disable_primary: true,
             },

--- a/niri-config/src/misc.rs
+++ b/niri-config/src/misc.rs
@@ -65,6 +65,23 @@ impl Default for ScreenshotPath {
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ScreenshotNotification {
+    pub disable: bool,
+}
+
+#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ScreenshotNotificationPart {
+    #[knuffel(child)]
+    pub disable: Option<Flag>,
+}
+
+impl MergeWith<ScreenshotNotificationPart> for ScreenshotNotification {
+    fn merge_with(&mut self, part: &ScreenshotNotificationPart) {
+        merge!((self, part), disable);
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct HotkeyOverlay {
     pub skip_at_startup: bool,
     pub hide_not_bound: bool,

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -5703,6 +5703,9 @@ impl Niri {
             })
             .unwrap();
 
+        // Borrow notification flag here so that thread can move it
+        let show_notification = !self.config.borrow().screenshot_notification.disable;
+
         // Encode and save the image in a thread as it's slow.
         thread::spawn(move || {
             let mut buf = vec![];
@@ -5743,10 +5746,12 @@ impl Niri {
             } else {
                 debug!("not saving screenshot to disk");
             }
-
-            #[cfg(feature = "dbus")]
-            if let Err(err) = crate::utils::show_screenshot_notification(image_path.as_deref()) {
-                warn!("error showing screenshot notification: {err:?}");
+            if show_notification {
+                #[cfg(feature = "dbus")]
+                if let Err(err) = crate::utils::show_screenshot_notification(image_path.as_deref())
+                {
+                    warn!("error showing screenshot notification: {err:?}");
+                }
             }
 
             // Send screenshot completion event.


### PR DESCRIPTION
Currently, niri always sends a screenshot notification. This PR adds a config option to disable said notification. 