### PR TITLE
feat: align-window (vert+horz) and align-column (horz) keybinding and ipc actions

### DIFF
--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -506,6 +506,17 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::CenterColumn {} => Self::CenterColumn,
             niri_ipc::Action::CenterWindow { id: None } => Self::CenterWindow,
             niri_ipc::Action::CenterWindow { id: Some(id) } => Self::CenterWindowById(id),
+            niri_ipc::Action::AlignWindow {
+                id: None,
+                horizontal: _,
+                vertical: _,
+            } => todo!(),
+            niri_ipc::Action::AlignWindow {
+                id: Some(_id),
+                horizontal: _,
+                vertical: _,
+            } => todo!(),
+            niri_ipc::Action::AlignColumn { horizontal: _ } => todo!(),
             niri_ipc::Action::CenterVisibleColumns {} => Self::CenterVisibleColumns,
             niri_ipc::Action::FocusWorkspaceDown {} => Self::FocusWorkspaceDown,
             niri_ipc::Action::FocusWorkspaceUp {} => Self::FocusWorkspaceUp,

--- a/niri-config/src/binds.rs
+++ b/niri-config/src/binds.rs
@@ -7,7 +7,8 @@ use bitflags::bitflags;
 use knuffel::errors::DecodeError;
 use miette::miette;
 use niri_ipc::{
-    ColumnDisplay, LayoutSwitchTarget, PositionChange, SizeChange, WorkspaceReferenceArg,
+    ColumnDisplay, HorizontalAlignment, LayoutSwitchTarget, PositionChange, SizeChange,
+    VerticalAlignment, WorkspaceReferenceArg,
 };
 use smithay::input::keyboard::keysyms::KEY_NoSymbol;
 use smithay::input::keyboard::xkb::{keysym_from_name, KEYSYM_CASE_INSENSITIVE, KEYSYM_NO_FLAGS};
@@ -215,6 +216,14 @@ pub enum Action {
     CenterWindow,
     #[knuffel(skip)]
     CenterWindowById(u64),
+    AlignColumn(#[knuffel(property(name = "horizontal"), str)] Option<HorizontalAlignment>),
+    // bare `align-window` parses and means "reset this column's alignment".
+    AlignWindow(
+        #[knuffel(property(name = "horizontal"), str)] Option<HorizontalAlignment>,
+        #[knuffel(property(name = "vertical"), str)] Option<VerticalAlignment>,
+    ),
+    #[knuffel(skip)]
+    AlignWindowById(u64, Option<HorizontalAlignment>, Option<VerticalAlignment>),
     CenterVisibleColumns,
     FocusWorkspaceDown,
     #[knuffel(skip)]
@@ -508,15 +517,15 @@ impl From<niri_ipc::Action> for Action {
             niri_ipc::Action::CenterWindow { id: Some(id) } => Self::CenterWindowById(id),
             niri_ipc::Action::AlignWindow {
                 id: None,
-                horizontal: _,
-                vertical: _,
-            } => todo!(),
+                horizontal,
+                vertical,
+            } => Self::AlignWindow(horizontal, vertical),
             niri_ipc::Action::AlignWindow {
-                id: Some(_id),
-                horizontal: _,
-                vertical: _,
-            } => todo!(),
-            niri_ipc::Action::AlignColumn { horizontal: _ } => todo!(),
+                id: Some(id),
+                horizontal,
+                vertical,
+            } => Self::AlignWindowById(id, horizontal, vertical),
+            niri_ipc::Action::AlignColumn { horizontal } => Self::AlignColumn(horizontal),
             niri_ipc::Action::CenterVisibleColumns {} => Self::CenterVisibleColumns,
             niri_ipc::Action::FocusWorkspaceDown {} => Self::FocusWorkspaceDown,
             niri_ipc::Action::FocusWorkspaceUp {} => Self::FocusWorkspaceUp,

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -468,6 +468,37 @@ pub enum Action {
         #[cfg_attr(feature = "clap", arg(long))]
         id: Option<u64>,
     },
+    /// Align a window to an edge of the screen, or center it.
+    ///
+    /// If neither `horizontal` nor `vertical` is given, resets the column's alignment to
+    /// the default behavior.
+    #[cfg_attr(
+        feature = "clap",
+        clap(about = "Set the desired alignment for the focussed window")
+    )]
+    AlignWindow {
+        /// Id of the window to align.
+        ///
+        /// If `None`, uses the focused window.
+        #[cfg_attr(feature = "clap", arg(long))]
+        id: Option<u64>,
+        /// Desired horizontal alignment
+        #[cfg_attr(feature = "clap", arg(long))]
+        horizontal: Option<HorizontalAlignment>,
+        /// Desired vertical alignment
+        #[cfg_attr(feature = "clap", arg(long))]
+        vertical: Option<VerticalAlignment>,
+    },
+    /// Align a column to either edge of the screen, or center. `None` resets alignment.
+    #[cfg_attr(
+        feature = "clap",
+        clap(about = "Set the desired alignment for the focussed column")
+    )]
+    AlignColumn {
+        /// Desired horizontal alignment.
+        #[cfg_attr(feature = "clap", arg(long))]
+        horizontal: Option<HorizontalAlignment>,
+    },
     /// Center all fully visible columns on the screen.
     CenterVisibleColumns {},
     /// Focus the workspace below.
@@ -995,6 +1026,28 @@ pub enum LayoutSwitchTarget {
     Prev,
     /// The specific layout by index.
     Index(u8),
+}
+
+/// How to horizontally align a window or column
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HorizontalAlignment {
+    /// Align center of the window to center of the working area
+    Center,
+    /// Align left edge of the window to left edge of the working area
+    Left,
+    /// Align right edge of the window to right edge of the working area
+    Right,
+}
+
+/// How to vertically align a window or column
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerticalAlignment {
+    /// Align center of the window to center of the working area
+    Center,
+    /// Align top edge of the window to top edge of the working area
+    Top,
+    /// Align bottom edge of the window to bottom edge of the working area
+    Bottom,
 }
 
 /// How windows display in a column.
@@ -1865,6 +1918,32 @@ impl FromStr for LayoutSwitchTarget {
                 Ok(layout) => Ok(Self::Index(layout)),
                 _ => Err(r#"invalid layout action, can be "next", "prev" or a layout index"#),
             },
+        }
+    }
+}
+
+impl FromStr for HorizontalAlignment {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "left" => Ok(Self::Left),
+            "center" => Ok(Self::Center),
+            "right" => Ok(Self::Right),
+            _ => Err(r#"invalid Horizontal Alignment, can be "left", "right" or "center""#),
+        }
+    }
+}
+
+impl FromStr for VerticalAlignment {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "top" => Ok(Self::Top),
+            "center" => Ok(Self::Center),
+            "bottom" => Ok(Self::Bottom),
+            _ => Err(r#"invalid Horizontal Alignment, can be "top", "center" or "bottom""#),
         }
     }
 }

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -577,6 +577,46 @@ binds {
     // Center all fully visible columns on screen.
     Mod+Ctrl+C { center-visible-columns; }
 
+    // Align the focused window or column to an edge or the center of the screen.
+    // On tiling, aligning a window aligns its column; vertical is ignored since
+    // columns are always full height. On floating, windows can also be aligned
+    // vertically, and align-column does nothing.
+    //
+    // Alignment is remembered per column until it is reset, replaced by another
+    // align action, interactively resized, or the column is closed.
+    // Omit the properties to reset to the default alignment.
+    //
+    // `center-column` is equivalent to `align-window horizontal="center" vertical="center"`.
+    // See also the `center-focused-column` and `always-center-single-column` layout options.
+    //
+    // In this example, the numpad forms a 3x3 grid matching the target position
+    // (NumLock OFF keysyms; with NumLock on, these keys produce KP_1..KP_9 digits, but they are not working
+    // since 2024):
+    // 7 8 9
+    // 4 5 6
+    // 1 2 3
+    //   0
+    // Horizontal and vertical are decoupled: Mod+KP_Up then Mod+KP_Left is the same as Mod+KP_Home.
+    //
+    // align-window actions:
+    //
+    // Mod+KP_Home { align-window horizontal="left" vertical="top"; }
+    // Mod+KP_Up { align-window horizontal="center" vertical="top"; }
+    // Mod+KP_Prior { align-window horizontal="right" vertical="top"; }
+    // Mod+KP_Left { align-window horizontal="left" vertical="center"; }
+    // Mod+KP_Begin { align-window horizontal="center" vertical="center"; }
+    // Mod+KP_Right { align-window horizontal="right" vertical="center"; }
+    // Mod+KP_End { align-window horizontal="left" vertical="bottom"; }
+    // Mod+KP_Down { align-window horizontal="center" vertical="bottom"; }
+    // Mod+KP_Next { align-window horizontal="right" vertical="bottom"; }
+    //
+    // align-column actions:
+    //
+    // Mod+Ctrl+KP_Left  { align-column horizontal="left"; }
+    // Mod+Ctrl+KP_Begin { align-column horizontal="center"; }
+    // Mod+Ctrl+KP_Right { align-column horizontal="right"; }
+    // Mod+Shift+KP_Insert { align-column; }
+
     // Finer width adjustments.
     // This command can also:
     // * set width in pixels: "1000"

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1682,6 +1682,27 @@ impl State {
                     self.niri.queue_redraw_all();
                 }
             }
+            Action::AlignColumn(horizontal) => {
+                self.niri.layout.align_column(horizontal);
+                // FIXME: granular (added by artiepoole)
+                self.niri.queue_redraw_all();
+            }
+            Action::AlignWindow(horizontal, vertical) => {
+                self.niri.layout.align_window(None, horizontal, vertical);
+                // FIXME: granular
+                self.niri.queue_redraw_all();
+            }
+            Action::AlignWindowById(id, horizontal, vertical) => {
+                let window = self.niri.layout.windows().find(|(_, m)| m.id().get() == id);
+                let window = window.map(|(_, m)| m.window.clone());
+                if let Some(window) = window {
+                    self.niri
+                        .layout
+                        .align_window(Some(&window), horizontal, vertical);
+                    // FIXME: granular
+                    self.niri.queue_redraw_all();
+                }
+            }
             Action::CenterVisibleColumns => {
                 self.niri.layout.center_visible_columns();
                 // FIXME: granular

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use niri_config::utils::MergeWith as _;
 use niri_config::{PresetSize, RelativeTo};
-use niri_ipc::{PositionChange, SizeChange, WindowLayout};
+use niri_ipc::{HorizontalAlignment, PositionChange, SizeChange, VerticalAlignment, WindowLayout};
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Serial, Size};
 
@@ -1019,6 +1019,41 @@ impl<W: LayoutElement> FloatingSpace<W> {
 
         let new_pos = center_preferring_top_left_in_area(self.working_area, self.data[idx].size);
         self.move_to(idx, new_pos, true);
+    }
+
+    /// Aligns a window.
+    ///
+    /// If a direction's alignment is not provided, the position in the relevant axis is untouched
+    pub fn align_window(
+        &mut self,
+        id: Option<&W::Id>,
+        horizontal: Option<HorizontalAlignment>,
+        vertical: Option<VerticalAlignment>,
+    ) {
+        let Some(id) = id.or(self.active_window_id.as_ref()).cloned() else {
+            return;
+        };
+        let idx = self.idx_of(&id).unwrap();
+
+        let area = self.working_area;
+        let gaps = self.options.layout.gaps;
+        let width = self.data[idx].size.w;
+        let height = self.data[idx].size.h;
+
+        let x = match horizontal {
+            Some(HorizontalAlignment::Left) => area.loc.x + gaps,
+            Some(HorizontalAlignment::Center) => area.loc.x + (area.size.w - width) / 2.,
+            Some(HorizontalAlignment::Right) => area.loc.x + area.size.w - gaps - width,
+            None => self.data[idx].logical_pos.x,
+        };
+        let y = match vertical {
+            Some(VerticalAlignment::Top) => area.loc.y + gaps,
+            Some(VerticalAlignment::Center) => area.loc.y + (area.size.h - height) / 2.,
+            Some(VerticalAlignment::Bottom) => area.loc.y + area.size.h - gaps - height,
+            None => self.data[idx].logical_pos.y,
+        };
+
+        self.move_to(idx, Point::new(x, y), true);
     }
 
     pub fn descendants_added(&mut self, id: &W::Id) -> bool {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -41,7 +41,9 @@ use niri_config::utils::MergeWith as _;
 use niri_config::{
     Config, CornerRadius, LayoutPart, PresetSize, Workspace as WorkspaceConfig, WorkspaceReference,
 };
-use niri_ipc::{ColumnDisplay, PositionChange, SizeChange, WindowLayout};
+use niri_ipc::{
+    ColumnDisplay, HorizontalAlignment, PositionChange, SizeChange, VerticalAlignment, WindowLayout,
+};
 use scrolling::{Column, ColumnWidth};
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::utils::RescaleRenderElement;
@@ -2292,6 +2294,37 @@ impl<W: LayoutElement> Layout<W> {
             return;
         };
         workspace.center_window(id);
+    }
+
+    pub fn align_column(&mut self, horizontal: Option<HorizontalAlignment>) {
+        let Some(workspace) = self.active_workspace_mut() else {
+            return;
+        };
+        workspace.align_column(horizontal)
+    }
+
+    pub fn align_window(
+        &mut self,
+        id: Option<&W::Id>,
+        horizontal: Option<HorizontalAlignment>,
+        vertical: Option<VerticalAlignment>,
+    ) {
+        if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
+            if id.is_none() || id == Some(move_.tile.window().id()) {
+                return;
+            }
+        }
+
+        let workspace = if let Some(id) = id {
+            Some(self.workspaces_mut().find(|ws| ws.has_window(id)).unwrap())
+        } else {
+            self.active_workspace_mut()
+        };
+
+        let Some(workspace) = workspace else {
+            return;
+        };
+        workspace.align_window(id, horizontal, vertical)
     }
 
     pub fn center_visible_columns(&mut self) {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -606,31 +606,6 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         new_offset - area.loc.x
     }
 
-    fn compute_new_view_offset_centered(
-        &self,
-        target_x: Option<f64>,
-        col_x: f64,
-        width: f64,
-        mode: SizingMode,
-    ) -> f64 {
-        if mode.is_fullscreen() {
-            return self.compute_new_view_offset_fit(target_x, col_x, width, mode);
-        }
-
-        let area = if mode.is_maximized() {
-            self.parent_area
-        } else {
-            self.working_area
-        };
-
-        // Columns wider than the view are left-aligned (the fit code can deal with that).
-        if area.size.w <= width {
-            return self.compute_new_view_offset_fit(target_x, col_x, width, mode);
-        }
-
-        -(area.size.w - width) / 2. - area.loc.x
-    }
-
     fn compute_new_view_offset_aligned(
         &self,
         target_x: Option<f64>,
@@ -666,20 +641,6 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         )
     }
 
-    fn compute_new_view_offset_for_column_centered(
-        &self,
-        target_x: Option<f64>,
-        idx: usize,
-    ) -> f64 {
-        let col = &self.columns[idx];
-        self.compute_new_view_offset_centered(
-            target_x,
-            self.column_x(idx),
-            col.width(),
-            col.sizing_mode(),
-        )
-    }
-
     fn compute_new_view_offset_for_column_aligned(
         &self,
         target_x: Option<f64>,
@@ -707,13 +668,19 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         if self.is_centering_focused_column() {
-            return self.compute_new_view_offset_for_column_centered(target_x, idx);
+            return self.compute_new_view_offset_for_column_aligned(
+                target_x,
+                idx,
+                HorizontalAlignment::Center,
+            );
         }
 
         match self.options.layout.center_focused_column {
-            CenterFocusedColumn::Always => {
-                self.compute_new_view_offset_for_column_centered(target_x, idx)
-            }
+            CenterFocusedColumn::Always => self.compute_new_view_offset_for_column_aligned(
+                target_x,
+                idx,
+                HorizontalAlignment::Center,
+            ),
             CenterFocusedColumn::OnOverflow => {
                 let Some(prev_idx) = prev_idx else {
                     return self.compute_new_view_offset_for_column_fit(target_x, idx);
@@ -751,7 +718,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 if total_width <= self.working_area.size.w {
                     self.compute_new_view_offset_for_column_fit(target_x, idx)
                 } else {
-                    self.compute_new_view_offset_for_column_centered(target_x, idx)
+                    self.compute_new_view_offset_for_column_aligned(
+                        target_x,
+                        idx,
+                        HorizontalAlignment::Center,
+                    )
                 }
             }
             CenterFocusedColumn::Never => {
@@ -812,16 +783,6 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                 ));
             }
         }
-    }
-
-    fn animate_view_offset_to_column_centered(
-        &mut self,
-        target_x: Option<f64>,
-        idx: usize,
-        config: niri_config::Animation,
-    ) {
-        let new_view_offset = self.compute_new_view_offset_for_column_centered(target_x, idx);
-        self.animate_view_offset_with_config(idx, new_view_offset, config);
     }
 
     fn animate_view_offset_to_column_aligned(
@@ -899,7 +860,6 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         let x = pos.x + self.view_pos();
-
         // Aim for the center of the gap.
         let x = x + self.options.layout.gaps / 2.;
         let y = pos.y + self.options.layout.gaps / 2.;
@@ -2286,15 +2246,24 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     }
 
     pub fn center_column(&mut self) {
+        self.align_column(Some(HorizontalAlignment::Center))
+    }
+
+    pub fn align_column(&mut self, alignment: Option<HorizontalAlignment>) {
         if self.columns.is_empty() {
             return;
         }
-
-        self.animate_view_offset_to_column_centered(
-            None,
-            self.active_column_idx,
-            self.options.animations.horizontal_view_movement.0,
-        );
+        self.columns[self.active_column_idx].alignment = alignment;
+        if let Some(alignment) = alignment {
+            self.animate_view_offset_to_column_aligned(
+                None,
+                self.active_column_idx,
+                self.options.animations.horizontal_view_movement.0,
+                alignment,
+            );
+        } else {
+            self.animate_view_offset_to_column(None, self.active_column_idx, None)
+        }
 
         let col = &mut self.columns[self.active_column_idx];
         cancel_resize_for_column(&mut self.interactive_resize, col);
@@ -2320,26 +2289,6 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         self.center_column();
-    }
-
-    pub fn align_column(&mut self, alignment: Option<HorizontalAlignment>) {
-        if self.columns.is_empty() {
-            return;
-        }
-        self.columns[self.active_column_idx].alignment = alignment;
-        if let Some(alignment) = alignment {
-            self.animate_view_offset_to_column_aligned(
-                None,
-                self.active_column_idx,
-                self.options.animations.horizontal_view_movement.0,
-                alignment,
-            );
-        } else {
-            self.animate_view_offset_to_column(None, self.active_column_idx, None)
-        }
-
-        let col = &mut self.columns[self.active_column_idx];
-        cancel_resize_for_column(&mut self.interactive_resize, col);
     }
 
     pub fn align_window(
@@ -2677,15 +2626,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             InsertPosition::Floating => return None,
         };
 
-        // First window on an empty workspace will cancel out any view offset. Replicate this
-        // effect here.
         if self.columns.is_empty() {
             let view_offset = if self.is_centering_focused_column() {
-                self.compute_new_view_offset_centered(
+                self.compute_new_view_offset_aligned(
                     Some(0.),
                     0.,
                     hint_area.size.w,
                     SizingMode::Normal,
+                    HorizontalAlignment::Center,
                 )
             } else {
                 self.compute_new_view_offset_fit(Some(0.), 0., hint_area.size.w, SizingMode::Normal)

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -238,6 +238,9 @@ pub struct Column<W: LayoutElement> {
     /// Configurable properties of the layout.
     options: Rc<Options>,
 
+    /// Preferred alignment. None -> left as default
+    alignment: Option<HorizontalAlignment>,
+
     /// Unique ID of this column.
     id: ColumnId,
 }
@@ -699,6 +702,10 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         idx: usize,
         prev_idx: Option<usize>,
     ) -> f64 {
+        if let Some(horizontal) = self.columns[idx].alignment {
+            return self.compute_new_view_offset_for_column_aligned(target_x, idx, horizontal);
+        }
+
         if self.is_centering_focused_column() {
             return self.compute_new_view_offset_for_column_centered(target_x, idx);
         }
@@ -2319,7 +2326,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         if self.columns.is_empty() {
             return;
         }
-
+        self.columns[self.active_column_idx].alignment = alignment;
         if let Some(alignment) = alignment {
             self.animate_view_offset_to_column_aligned(
                 None,
@@ -3690,6 +3697,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             original_window_size,
             data: InteractiveResizeData { edges },
         };
+
+        let col_idx = self
+            .columns
+            .iter()
+            .position(|col| col.contains(&resize.window))
+            .unwrap();
+        self.columns[col_idx].alignment = None;
+
         self.interactive_resize = Some(resize);
 
         self.view_offset.stop_anim_and_gesture();
@@ -4126,6 +4141,7 @@ impl<W: LayoutElement> Column<W> {
             scale,
             clock: tile.clock.clone(),
             options,
+            alignment: None,
             id: ColumnId::next(),
         };
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use niri_config::utils::MergeWith as _;
 use niri_config::{CenterFocusedColumn, PresetSize, Struts};
-use niri_ipc::{ColumnDisplay, SizeChange, WindowLayout};
+use niri_ipc::{ColumnDisplay, HorizontalAlignment, SizeChange, VerticalAlignment, WindowLayout};
 use ordered_float::NotNan;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Logical, Point, Rectangle, Scale, Serial, Size};
@@ -628,6 +628,31 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         -(area.size.w - width) / 2. - area.loc.x
     }
 
+    fn compute_new_view_offset_aligned(
+        &self,
+        target_x: Option<f64>,
+        col_x: f64,
+        width: f64,
+        mode: SizingMode,
+        alignment: HorizontalAlignment,
+    ) -> f64 {
+        if mode.is_fullscreen() {
+            return self.compute_new_view_offset_fit(target_x, col_x, width, mode);
+        }
+
+        let (area, padding) = if mode.is_maximized() {
+            (self.parent_area, 0.)
+        } else {
+            (self.working_area, self.options.layout.gaps)
+        };
+
+        match alignment {
+            HorizontalAlignment::Left => -area.loc.x - padding,
+            HorizontalAlignment::Center => -(area.size.w - width) / 2. - area.loc.x,
+            HorizontalAlignment::Right => -(area.size.w - width) - area.loc.x + padding,
+        }
+    }
+
     fn compute_new_view_offset_for_column_fit(&self, target_x: Option<f64>, idx: usize) -> f64 {
         let col = &self.columns[idx];
         self.compute_new_view_offset_fit(
@@ -649,6 +674,22 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             self.column_x(idx),
             col.width(),
             col.sizing_mode(),
+        )
+    }
+
+    fn compute_new_view_offset_for_column_aligned(
+        &self,
+        target_x: Option<f64>,
+        idx: usize,
+        alignment: HorizontalAlignment,
+    ) -> f64 {
+        let col = &self.columns[idx];
+        self.compute_new_view_offset_aligned(
+            target_x,
+            self.column_x(idx),
+            col.width(),
+            col.sizing_mode(),
+            alignment,
         )
     }
 
@@ -773,6 +814,18 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         config: niri_config::Animation,
     ) {
         let new_view_offset = self.compute_new_view_offset_for_column_centered(target_x, idx);
+        self.animate_view_offset_with_config(idx, new_view_offset, config);
+    }
+
+    fn animate_view_offset_to_column_aligned(
+        &mut self,
+        target_x: Option<f64>,
+        idx: usize,
+        config: niri_config::Animation,
+        alignment: HorizontalAlignment,
+    ) {
+        let new_view_offset =
+            self.compute_new_view_offset_for_column_aligned(target_x, idx, alignment);
         self.animate_view_offset_with_config(idx, new_view_offset, config);
     }
 
@@ -2260,6 +2313,59 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
 
         self.center_column();
+    }
+
+    pub fn align_column(&mut self, alignment: Option<HorizontalAlignment>) {
+        if self.columns.is_empty() {
+            return;
+        }
+
+        if let Some(alignment) = alignment {
+            self.animate_view_offset_to_column_aligned(
+                None,
+                self.active_column_idx,
+                self.options.animations.horizontal_view_movement.0,
+                alignment,
+            );
+        } else {
+            self.animate_view_offset_to_column(None, self.active_column_idx, None)
+        }
+
+        let col = &mut self.columns[self.active_column_idx];
+        cancel_resize_for_column(&mut self.interactive_resize, col);
+    }
+
+    pub fn align_window(
+        &mut self,
+        window: Option<&W::Id>,
+        horizontal: Option<HorizontalAlignment>,
+        vertical: Option<VerticalAlignment>,
+    ) {
+        if self.columns.is_empty() {
+            return;
+        }
+
+        if vertical.is_some() && horizontal.is_none() {
+            // The user seems to be trying to change the vertical alignment without resetting
+            // horizontal
+            return;
+        }
+
+        let col_idx = if let Some(window) = window {
+            self.columns
+                .iter()
+                .position(|col| col.contains(window))
+                .unwrap()
+        } else {
+            self.active_column_idx
+        };
+
+        // only align the active column
+        if col_idx != self.active_column_idx {
+            return;
+        }
+
+        self.align_column(horizontal);
     }
 
     pub fn center_visible_columns(&mut self) {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -404,6 +404,22 @@ fn arbitrary_column_display() -> impl Strategy<Value = ColumnDisplay> {
     prop_oneof![Just(ColumnDisplay::Normal), Just(ColumnDisplay::Tabbed)]
 }
 
+fn arbitrary_horizontal_alignment() -> impl Strategy<Value = HorizontalAlignment> {
+    prop_oneof![
+        Just(HorizontalAlignment::Left),
+        Just(HorizontalAlignment::Center),
+        Just(HorizontalAlignment::Right)
+    ]
+}
+
+fn arbitrary_vertical_alignment() -> impl Strategy<Value = VerticalAlignment> {
+    prop_oneof![
+        Just(VerticalAlignment::Top),
+        Just(VerticalAlignment::Center),
+        Just(VerticalAlignment::Bottom)
+    ]
+}
+
 #[derive(Debug, Clone, Arbitrary)]
 enum Op {
     AddOutput(#[proptest(strategy = "1..=5usize")] usize),
@@ -517,6 +533,18 @@ enum Op {
         id: Option<usize>,
     },
     CenterVisibleColumns,
+    AlignWindow {
+        #[proptest(strategy = "proptest::option::of(1..=5usize)")]
+        id: Option<usize>,
+        #[proptest(strategy = "proptest::option::of(arbitrary_horizontal_alignment())")]
+        horizontal: Option<HorizontalAlignment>,
+        #[proptest(strategy = "proptest::option::of(arbitrary_vertical_alignment())")]
+        vertical: Option<VerticalAlignment>,
+    },
+    AlignColumn(
+        #[proptest(strategy = "proptest::option::of(arbitrary_horizontal_alignment())")]
+        Option<HorizontalAlignment>,
+    ),
     FocusWorkspaceDown,
     FocusWorkspaceUp,
     FocusWorkspace(#[proptest(strategy = "0..=4usize")] usize),
@@ -1179,6 +1207,15 @@ impl Op {
                 layout.center_window(id.as_ref());
             }
             Op::CenterVisibleColumns => layout.center_visible_columns(),
+            Op::AlignWindow {
+                id,
+                horizontal,
+                vertical,
+            } => {
+                let id = id.filter(|id| layout.has_window(id));
+                layout.align_window(id.as_ref(), horizontal, vertical);
+            }
+            Op::AlignColumn(alignment) => layout.align_column(alignment),
             Op::FocusWorkspaceDown => layout.switch_workspace_down(),
             Op::FocusWorkspaceUp => layout.switch_workspace_up(),
             Op::FocusWorkspace(idx) => layout.switch_workspace(idx),

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -6,7 +6,9 @@ use niri_config::utils::MergeWith as _;
 use niri_config::{
     CenterFocusedColumn, CornerRadius, OutputName, PresetSize, Workspace as WorkspaceConfig,
 };
-use niri_ipc::{ColumnDisplay, PositionChange, SizeChange, WindowLayout};
+use niri_ipc::{
+    ColumnDisplay, HorizontalAlignment, PositionChange, SizeChange, VerticalAlignment, WindowLayout,
+};
 use smithay::backend::renderer::element::Kind;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::desktop::{layer_map_for_output, Window};
@@ -1166,6 +1168,27 @@ impl<W: LayoutElement> Workspace<W> {
             self.floating.center_window(id);
         } else {
             self.scrolling.center_window(id);
+        }
+    }
+
+    pub fn align_column(&mut self, horizontal: Option<HorizontalAlignment>) {
+        if !self.floating_is_active.get() {
+            self.scrolling.align_column(horizontal);
+        }
+    }
+
+    pub fn align_window(
+        &mut self,
+        id: Option<&W::Id>,
+        horizontal: Option<HorizontalAlignment>,
+        vertical: Option<VerticalAlignment>,
+    ) {
+        if id.map_or(self.floating_is_active.get(), |id| {
+            self.floating.has_window(id)
+        }) {
+            self.floating.align_window(id, horizontal, vertical);
+        } else {
+            self.scrolling.align_window(id, horizontal, vertical);
         }
     }
 


### PR DESCRIPTION
- adds align-window for horizontal and vertical alignment of floating windows
- adds align-column for horizontal alignment of columns
- keeps center-column config and IPC functionality but calls align-window/align-column
  internally
- adds support for wider-than-display windows/column and panning within these windows via aligning ~~(does not allow for taller-than-display windows, with no intention to enable)~~ and taller-than-display windows (since rebasing)
- allows for alignment resetting (applies on re-selection)
- stores alignment in Column struct so as to survive various changes such as focus change, workspace move, workspace switch, spawn new column, add new item to column etc.

Credit:

this commit started as a rebase of b0o's #1929 onto current origin/main

Notable differences:
- new config structure puts IPC actions into niri-config/src/binds.rs
  from niri-config/lib.rs
- src/layout/scrolling.rs refactored
  - is_fullscreen now using SizingMode
  - self.options.gaps now self.options.layout.gaps

I also made use of MintyDoggo's #3033 enum idea, idea to call align functions for 
centering, and "borrowed" their column positioning maths

Related discussion (more of a monologue): https://github.com/niri-wm/niri/discussions/4269 