### PR TITLE
Animate window movement between workspaces

### DIFF
--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -498,11 +498,6 @@ impl<W: LayoutElement> FloatingSpace<W> {
         }
     }
 
-    pub fn remove_active_tile(&mut self) -> Option<RemovedTile<W>> {
-        let id = self.active_window_id.clone()?;
-        Some(self.remove_tile(&id))
-    }
-
     pub fn remove_tile(&mut self, id: &W::Id) -> RemovedTile<W> {
         let idx = self.idx_of(id).unwrap();
         self.remove_tile_by_idx(idx)

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -16,6 +16,7 @@ use super::{
     ConfigureIntent, InteractiveResizeData, LayoutElement, Options, RemovedTile, SizeFrac,
 };
 use crate::animation::{Animation, Clock};
+use crate::layout::RenderLayer;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::xray::XrayPos;
@@ -265,9 +266,19 @@ impl<W: LayoutElement> FloatingSpace<W> {
         self.tiles.iter().any(Tile::are_transitions_ongoing) || !self.closing_windows.is_empty()
     }
 
-    pub fn update_render_elements(&mut self, is_active: bool, view_rect: Rectangle<f64, Logical>) {
+    pub fn update_render_elements(
+        &mut self,
+        is_active: bool,
+        view_rect: Rectangle<f64, Logical>,
+        layer: RenderLayer,
+    ) {
         let active = self.active_window_id.clone();
         for (tile, offset) in self.tiles_with_offsets_mut() {
+            // Skip tiles belonging to a different render layer.
+            if layer.is_normal() == tile.is_moving_between_workspaces() {
+                continue;
+            }
+
             let id = tile.window().id();
             let is_active = is_active && Some(id) == active.as_ref();
 
@@ -1057,6 +1068,7 @@ impl<W: LayoutElement> FloatingSpace<W> {
         xray_pos: XrayPos,
         view_rect: Rectangle<f64, Logical>,
         focus_ring: bool,
+        layer: RenderLayer,
         push: &mut dyn FnMut(FloatingSpaceRenderElement<R>),
     ) {
         let scale = Scale::from(self.scale);
@@ -1064,13 +1076,20 @@ impl<W: LayoutElement> FloatingSpace<W> {
         // Draw the closing windows on top of the other windows.
         //
         // FIXME: I guess this should rather preserve the stacking order when the window is closed.
-        for closing in self.closing_windows.iter().rev() {
-            let elem = closing.render(ctx.as_gles(), view_rect, scale);
-            push(elem.into());
+        if layer.is_normal() {
+            for closing in self.closing_windows.iter().rev() {
+                let elem = closing.render(ctx.as_gles(), view_rect, scale);
+                push(elem.into());
+            }
         }
 
         let active = self.active_window_id.clone();
         for (tile, tile_pos) in self.tiles_with_render_positions() {
+            // Skip tiles belonging to a different render layer.
+            if layer.is_normal() == tile.is_moving_between_workspaces() {
+                continue;
+            }
+
             // For the active tile, draw the focus ring.
             let focus_ring = focus_ring && Some(tile.window().id()) == active.as_ref();
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -3357,14 +3357,13 @@ impl<W: LayoutElement> Layout<W> {
             };
 
             let ws = &mut mon.workspaces[ws_idx];
-            let transaction = Transaction::new();
-            let mut removed = if let Some(window) = window {
-                ws.remove_tile(window, transaction)
-            } else if let Some(removed) = ws.remove_active_tile(transaction) {
-                removed
-            } else {
+            let Some(window) = window.or_else(|| ws.active_window().map(|win| win.id())) else {
                 return;
             };
+            let window = window.clone();
+
+            let transaction = Transaction::new();
+            let mut removed = ws.remove_tile(&window, transaction);
 
             removed.tile.stop_move_animations();
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -932,7 +932,7 @@ impl<W: LayoutElement> Layout<W> {
             panic!()
         };
 
-        monitors[monitor_idx].add_column(workspace_idx, column, activate);
+        monitors[monitor_idx].add_column(workspace_idx, column, activate, None);
 
         if activate {
             *active_monitor_idx = monitor_idx;
@@ -1110,6 +1110,7 @@ impl<W: LayoutElement> Layout<W> {
                     scrolling_width,
                     is_full_width,
                     is_floating,
+                    None,
                 );
 
                 // Set the default height for scrolling windows.
@@ -3381,6 +3382,7 @@ impl<W: LayoutElement> Layout<W> {
                 removed.width,
                 removed.is_full_width,
                 removed.is_floating,
+                None,
             );
             if activate.map_smart(|| false) {
                 *active_monitor_idx = new_idx;
@@ -4252,6 +4254,7 @@ impl<W: LayoutElement> Layout<W> {
                             move_.width,
                             move_.is_full_width,
                             false,
+                            None,
                         );
                     }
                     InsertPosition::InColumn(column_idx, tile_idx) => {
@@ -4306,6 +4309,7 @@ impl<W: LayoutElement> Layout<W> {
                             move_.width,
                             move_.is_full_width,
                             true,
+                            None,
                         );
                     }
                 }
@@ -4347,6 +4351,7 @@ impl<W: LayoutElement> Layout<W> {
                     move_.width,
                     move_.is_full_width,
                     move_.is_floating,
+                    None,
                 );
             }
         }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -955,10 +955,7 @@ impl<W: LayoutElement> Layout<W> {
                         (mon_idx, MonitorAddWindowTarget::Auto)
                     }
                     AddWindowTarget::Workspace(ws_id) => {
-                        let mon_idx = monitors
-                            .iter()
-                            .position(|mon| mon.workspaces.iter().any(|ws| ws.id() == ws_id))
-                            .unwrap();
+                        let mon_idx = monitors.iter().position(|mon| mon.has_ws(ws_id)).unwrap();
 
                         (
                             mon_idx,
@@ -1253,12 +1250,8 @@ impl<W: LayoutElement> Layout<W> {
         match &self.monitor_set {
             MonitorSet::Normal { ref monitors, .. } => {
                 for mon in monitors {
-                    if let Some((index, workspace)) = mon
-                        .workspaces
-                        .iter()
-                        .enumerate()
-                        .find(|(_, w)| w.id() == id)
-                    {
+                    if let Some(index) = mon.idx_of_ws(id) {
+                        let workspace = &mon.workspaces[index];
                         return Some((index, workspace));
                     }
                 }
@@ -2624,12 +2617,8 @@ impl<W: LayoutElement> Layout<W> {
 
                 if is_scrolling {
                     if let Some((ws, geo)) = mon.workspace_under(pos_within_output) {
-                        let ws_id = ws.id();
-                        let ws = mon
-                            .workspaces
-                            .iter_mut()
-                            .find(|ws| ws.id() == ws_id)
-                            .unwrap();
+                        let idx = mon.idx_of_ws(ws.id()).unwrap();
+                        let ws = &mut mon.workspaces[idx];
                         // As far as the DnD scroll gesture is concerned, the workspace spans across
                         // the whole monitor horizontally.
                         let ws_pos = Point::from((0., geo.loc.y));
@@ -2687,9 +2676,7 @@ impl<W: LayoutElement> Layout<W> {
                                     .iter_mut()
                                     .position(|ws| ws.activate_window(&id))
                                     .unwrap(),
-                                DndHoldTarget::Workspace(id) => {
-                                    mon.workspaces.iter().position(|ws| ws.id() == id).unwrap()
-                                }
+                                DndHoldTarget::Workspace(id) => mon.idx_of_ws(id).unwrap(),
                             };
 
                             mon.dnd_scroll_gesture_end();
@@ -2870,11 +2857,8 @@ impl<W: LayoutElement> Layout<W> {
             let (insert_ws, geo) = mon.insert_position(move_.pointer_pos_within_output);
             match insert_ws {
                 InsertWorkspace::Existing(ws_id) => {
-                    let ws = mon
-                        .workspaces
-                        .iter_mut()
-                        .find(|ws| ws.id() == ws_id)
-                        .unwrap();
+                    let idx = mon.idx_of_ws(ws_id).unwrap();
+                    let ws = &mut mon.workspaces[idx];
                     let pos_within_workspace =
                         (move_.pointer_pos_within_output - geo.loc).downscale(zoom);
                     let position = if move_.is_floating {
@@ -4175,11 +4159,7 @@ impl<W: LayoutElement> Layout<W> {
                         let (insert_ws, geo) = mon.insert_position(move_.pointer_pos_within_output);
                         let (position, offset) = match insert_ws {
                             InsertWorkspace::Existing(ws_id) => {
-                                let ws_idx = mon
-                                    .workspaces
-                                    .iter_mut()
-                                    .position(|ws| ws.id() == ws_id)
-                                    .unwrap();
+                                let ws_idx = mon.idx_of_ws(ws_id).unwrap();
 
                                 let position = if move_.is_floating {
                                     InsertPosition::Floating
@@ -4225,11 +4205,7 @@ impl<W: LayoutElement> Layout<W> {
                 let tile_render_loc = move_.tile_render_location(zoom);
 
                 let ws_idx = match insert_ws {
-                    InsertWorkspace::Existing(ws_id) => mon
-                        .workspaces
-                        .iter()
-                        .position(|ws| ws.id() == ws_id)
-                        .unwrap(),
+                    InsertWorkspace::Existing(ws_id) => mon.idx_of_ws(ws_id).unwrap(),
                     InsertWorkspace::NewAt(ws_idx) => {
                         if mon.options.layout.empty_workspace_above_first && ws_idx == 0 {
                             // Reuse the top empty workspace.
@@ -4778,12 +4754,8 @@ impl<W: LayoutElement> Layout<W> {
                 let Some((ws, ws_geo)) = mon.workspace_under(pointer_pos_within_output) else {
                     return;
                 };
-                let ws_id = ws.id();
-                let ws = mon
-                    .workspaces
-                    .iter_mut()
-                    .find(|ws| ws.id() == ws_id)
-                    .unwrap();
+                let idx = mon.idx_of_ws(ws.id()).unwrap();
+                let ws = &mut mon.workspaces[idx];
 
                 let tile_pos = tile_pos - ws_geo.loc;
                 ws.start_close_animation_for_tile(renderer, snapshot, tile_size, tile_pos, blocker);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4271,8 +4271,6 @@ impl<W: LayoutElement> Layout<W> {
                         );
                     }
                     InsertPosition::Floating => {
-                        let tile_render_loc = move_.tile_render_location(zoom);
-
                         let mut tile = move_.tile;
                         tile.floating_pos = None;
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2107,14 +2107,24 @@ impl<W: LayoutElement> Layout<W> {
         let Some(monitor) = self.active_monitor() else {
             return;
         };
-        monitor.move_to_workspace_up(focus);
+        let activate = if focus {
+            ActivateWindow::Smart
+        } else {
+            ActivateWindow::No
+        };
+        monitor.move_to_workspace_up(activate);
     }
 
     pub fn move_to_workspace_down(&mut self, focus: bool) {
         let Some(monitor) = self.active_monitor() else {
             return;
         };
-        monitor.move_to_workspace_down(focus);
+        let activate = if focus {
+            ActivateWindow::Smart
+        } else {
+            ActivateWindow::No
+        };
+        monitor.move_to_workspace_down(activate);
     }
 
     pub fn move_to_workspace(

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -558,6 +558,14 @@ struct OverviewGesture {
     value: f64,
 }
 
+/// Layer of windows to render.
+#[derive(Clone, Copy)]
+pub enum RenderLayer {
+    Normal,
+    /// Windows currently moving between workspaces.
+    MovingBetweenWorkspaces,
+}
+
 impl SizingMode {
     #[must_use]
     pub fn is_normal(&self) -> bool {
@@ -684,6 +692,16 @@ impl OverviewProgress {
 
     fn is_animation(&self) -> bool {
         matches!(self, OverviewProgress::Animation(_))
+    }
+}
+
+impl RenderLayer {
+    /// Returns `true` if the render layer is [`Normal`].
+    ///
+    /// [`Normal`]: RenderLayer::Normal
+    #[must_use]
+    pub fn is_normal(&self) -> bool {
+        matches!(self, Self::Normal)
     }
 }
 
@@ -4304,6 +4322,13 @@ impl<W: LayoutElement> Layout<W> {
                 let new_tile_render_loc = ws_geo.loc + tile_offset.upscale(zoom);
 
                 tile.animate_move_from((tile_render_loc - new_tile_render_loc).downscale(zoom));
+
+                // Interactive move into floating barely animates (it doesn't really move after
+                // being dropped), so setting it as moving between workspaces would just cause it to
+                // awkwardly sit unclipped for a moment before the animation runs out.
+                if !matches!(position, InsertPosition::Floating) {
+                    tile.set_anim_y_between_workspaces();
+                }
             }
             MonitorSet::NoOutputs { workspaces, .. } => {
                 if workspaces.is_empty() {

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -20,6 +20,7 @@ use super::workspace::{
 use super::{compute_overview_zoom, ActivateWindow, HitType, LayoutElement, Options};
 use crate::animation::{Animation, Clock};
 use crate::input::swipe_tracker::SwipeTracker;
+use crate::layout::RenderLayer;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
@@ -815,6 +816,7 @@ impl<W: LayoutElement> Monitor<W> {
         } else {
             self.active_workspace_idx
         };
+        let source_id = self.workspaces[source_workspace_idx].id();
 
         let new_idx = min(idx, self.workspaces.len() - 1);
         if new_idx == source_workspace_idx {
@@ -831,6 +833,11 @@ impl<W: LayoutElement> Monitor<W> {
             return;
         };
         let window = window.clone();
+
+        let mut old_render_pos = workspace
+            .tiles_with_render_positions()
+            .find_map(|(tile, offset, _visible)| (tile.window().id() == &window).then_some(offset))
+            .unwrap();
 
         let transaction = Transaction::new();
         let removed = workspace.remove_tile(&window, transaction);
@@ -855,6 +862,31 @@ impl<W: LayoutElement> Monitor<W> {
         if self.workspace_switch.is_none() {
             self.clean_up_workspaces();
         }
+
+        let new_idx = self.idx_of_ws(new_id).unwrap();
+
+        // Animate vertical movement between workspaces.
+        //
+        // Recompute the source idx in case some workspace was removed during clean-up. If the
+        // source workspace itself was removed, don't bother animating this since the removal is
+        // instant anyway.
+        if let Some(source_workspace_idx) = self.idx_of_ws(source_id) {
+            old_render_pos.y +=
+                self.workspace_size_with_gap(1.).h * (source_workspace_idx as f64 - new_idx as f64);
+        }
+
+        let (tile, new_render_pos) = self.workspaces[new_idx]
+            .tiles_with_render_positions_mut(false)
+            .find(|(tile, _)| tile.window().id() == &window)
+            .unwrap();
+        // If the view is following the tile, match the animation.
+        let config = if activate {
+            self.options.animations.workspace_switch.0
+        } else {
+            self.options.animations.window_movement.0
+        };
+        tile.animate_move_from_with_config(old_render_pos - new_render_pos, config);
+        tile.set_anim_y_between_workspaces();
     }
 
     pub fn move_column_to_workspace_up(&mut self, activate: bool) {
@@ -886,11 +918,38 @@ impl<W: LayoutElement> Monitor<W> {
             return;
         }
 
-        let Some(column) = workspace.remove_active_column() else {
+        let Some(id) = workspace.scrolling().active_column().map(Column::id) else {
             return;
         };
+        let mut old_render_pos = workspace
+            .scrolling()
+            .columns_with_render_positions()
+            .find_map(|(col, pos)| (col.id() == id).then_some(pos))
+            .unwrap();
 
+        let column = workspace.remove_active_column().unwrap();
+
+        // Animate vertical movement between workspaces.
+        old_render_pos.y +=
+            self.workspace_size_with_gap(1.).h * (source_workspace_idx as f64 - new_idx as f64);
+
+        let new_id = self.workspaces[new_idx].id();
         self.add_column(new_idx, column, activate);
+
+        let new_idx = self.idx_of_ws(new_id).unwrap();
+        let (column, new_render_pos) = self.workspaces[new_idx]
+            .scrolling_mut()
+            .columns_with_render_positions_mut()
+            .find(|(col, _pos)| col.id() == id)
+            .unwrap();
+        // If the view is following the tile, match the animation.
+        let config = if activate {
+            self.options.animations.workspace_switch.0
+        } else {
+            self.options.animations.window_movement.0
+        };
+        column.animate_move_from_with_config(old_render_pos - new_render_pos, config);
+        column.set_anim_y_between_workspaces();
     }
 
     pub fn switch_workspace_up(&mut self) {
@@ -1014,8 +1073,12 @@ impl<W: LayoutElement> Monitor<W> {
             .as_ref()
             .and_then(|hint| hint.workspace.existing_id());
 
+        for ws in &mut self.workspaces {
+            ws.update_render_elements(is_active, RenderLayer::MovingBetweenWorkspaces);
+        }
+
         for (ws, geo) in self.workspaces_with_render_geo_mut(true) {
-            ws.update_render_elements(is_active);
+            ws.update_render_elements(is_active, RenderLayer::Normal);
 
             if Some(ws.id()) == insert_hint_ws_id {
                 insert_hint_ws_geo = Some(geo);
@@ -1421,15 +1484,22 @@ impl<W: LayoutElement> Monitor<W> {
         })
     }
 
-    pub fn workspaces_with_render_geo(
+    pub fn workspaces_with_render_geo_cull(
         &self,
+        cull: bool,
     ) -> impl Iterator<Item = (&Workspace<W>, Rectangle<f64, Logical>)> {
         let output_geo = Rectangle::from_size(self.view_size);
 
         let geo = self.workspaces_render_geo();
         zip(self.workspaces.iter(), geo)
             // Cull out workspaces outside the output.
-            .filter(move |(_ws, geo)| geo.intersection(output_geo).is_some())
+            .filter(move |(_ws, geo)| !cull || geo.intersection(output_geo).is_some())
+    }
+
+    pub fn workspaces_with_render_geo(
+        &self,
+    ) -> impl Iterator<Item = (&Workspace<W>, Rectangle<f64, Logical>)> {
+        self.workspaces_with_render_geo_cull(true)
     }
 
     pub fn workspaces_with_render_geo_idx(
@@ -1599,28 +1669,6 @@ impl<W: LayoutElement> Monitor<W> {
         // Ceil the height in physical pixels.
         let height = (self.view_size.h * scale).ceil() as i32;
 
-        // Crop the elements to prevent them overflowing, currently visible during a workspace
-        // switch.
-        //
-        // HACK: crop to infinite bounds at least horizontally where we
-        // know there's no workspace joining or monitor bounds, otherwise
-        // it will cut pixel shaders and mess up the coordinate space.
-        // There's also a damage tracking bug which causes glitched
-        // rendering for maximized GTK windows.
-        //
-        // FIXME: use proper bounds after fixing the Crop element.
-        let crop_bounds = if self.workspace_switch.is_some() || self.overview_progress.is_some() {
-            Rectangle::new(
-                Point::from((-i32::MAX / 2, 0)),
-                Size::from((i32::MAX, height)),
-            )
-        } else {
-            Rectangle::new(
-                Point::from((-i32::MAX / 2, -i32::MAX / 2)),
-                Size::from((i32::MAX, i32::MAX)),
-            )
-        };
-
         let zoom = self.overview_zoom();
 
         let insert_hint_render_loc = self
@@ -1639,32 +1687,110 @@ impl<W: LayoutElement> Monitor<W> {
             )
         };
 
-        for (ws, geo) in self.workspaces_with_render_geo() {
-            // Macro instead of closure because ws and insert hint have different elem types.
-            macro_rules! push {
-                () => {{
-                    &mut |elem| {
-                        let elem = CropRenderElement::from_element(elem, scale, crop_bounds);
-                        if let Some(elem) = elem {
-                            let elem = MonitorInnerRenderElement::from(elem);
-                            push(scale_relocate(geo, elem));
+        // Draw in passes for correct Z ordering during window movement between workspaces:
+        // - floating windows moving between workspaces
+        // - normal floating windows
+        // - scrolling windows moving between workspaces
+        // - normal scrolling windows
+        for pass in 0..4 {
+            // Don't cull when drawing windows moving between workspaces so that windows moving to
+            // workspaces off-screen will still render.
+            let cull = matches!(pass, 1 | 3);
+
+            // Crop the elements to prevent them overflowing, currently visible during a workspace
+            // switch.
+            //
+            // HACK: crop to infinite bounds at least horizontally where we
+            // know there's no workspace joining or monitor bounds, otherwise
+            // it will cut pixel shaders and mess up the coordinate space.
+            // There's also a damage tracking bug which causes glitched
+            // rendering for maximized GTK windows.
+            //
+            // FIXME: use proper bounds after fixing the Crop element.
+            //
+            // Also, check cull here to avoid cropping windows moving between workspaces.
+            //
+            // FIXME: for cull=true, it might be better visually to crop to a workspace-high region
+            // anchored to the window/column as it moves between workspaces, to prevent overflowing
+            // windows from appearing and disappearing.
+            let crop_bounds =
+                if cull && (self.workspace_switch.is_some() || self.overview_progress.is_some()) {
+                    Rectangle::new(
+                        Point::from((-i32::MAX / 2, 0)),
+                        Size::from((i32::MAX, height)),
+                    )
+                } else {
+                    Rectangle::new(
+                        Point::from((-i32::MAX / 2, -i32::MAX / 2)),
+                        Size::from((i32::MAX, i32::MAX)),
+                    )
+                };
+
+            for (ws, geo) in self.workspaces_with_render_geo_cull(cull) {
+                // Macro instead of closure because ws and insert hint have different elem types.
+                macro_rules! push {
+                    () => {{
+                        &mut |elem| {
+                            let elem = CropRenderElement::from_element(elem, scale, crop_bounds);
+                            if let Some(elem) = elem {
+                                let elem = MonitorInnerRenderElement::from(elem);
+                                push(scale_relocate(geo, elem));
+                            }
+                        }
+                    }};
+                }
+
+                let xray_pos = XrayPos::new(geo.loc, zoom);
+
+                match pass {
+                    0 => {
+                        ws.render_floating(
+                            ctx.r(),
+                            xray_pos,
+                            focus_ring,
+                            RenderLayer::MovingBetweenWorkspaces,
+                            push!(),
+                        );
+                    }
+                    1 => {
+                        ws.render_floating(
+                            ctx.r(),
+                            xray_pos,
+                            focus_ring,
+                            RenderLayer::Normal,
+                            push!(),
+                        );
+
+                        if let Some(loc) = insert_hint_render_loc {
+                            if loc.workspace == InsertWorkspace::Existing(ws.id()) {
+                                self.insert_hint_element.render(
+                                    ctx.renderer,
+                                    loc.location,
+                                    push!(),
+                                );
+                            }
                         }
                     }
-                }};
-            }
-
-            let xray_pos = XrayPos::new(geo.loc, zoom);
-
-            ws.render_floating(ctx.r(), xray_pos, focus_ring, push!());
-
-            if let Some(loc) = insert_hint_render_loc {
-                if loc.workspace == InsertWorkspace::Existing(ws.id()) {
-                    self.insert_hint_element
-                        .render(ctx.renderer, loc.location, push!());
+                    2 => {
+                        ws.render_scrolling(
+                            ctx.r(),
+                            xray_pos,
+                            focus_ring,
+                            RenderLayer::MovingBetweenWorkspaces,
+                            push!(),
+                        );
+                    }
+                    _ => {
+                        ws.render_scrolling(
+                            ctx.r(),
+                            xray_pos,
+                            focus_ring,
+                            RenderLayer::Normal,
+                            push!(),
+                        );
+                    }
                 }
             }
-
-            ws.render_scrolling(ctx.r(), xray_pos, focus_ring, push!());
         }
     }
 

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -760,13 +760,13 @@ impl<W: LayoutElement> Monitor<W> {
 
     pub fn move_down_or_to_workspace_down(&mut self) {
         if !self.active_workspace().move_down() {
-            self.move_to_workspace_down(true);
+            self.move_to_workspace_down(ActivateWindow::Smart);
         }
     }
 
     pub fn move_up_or_to_workspace_up(&mut self) {
         if !self.active_workspace().move_up() {
-            self.move_to_workspace_up(true);
+            self.move_to_workspace_up(ActivateWindow::Smart);
         }
     }
 
@@ -782,72 +782,14 @@ impl<W: LayoutElement> Monitor<W> {
         }
     }
 
-    pub fn move_to_workspace_up(&mut self, focus: bool) {
-        let source_workspace_idx = self.active_workspace_idx;
-
-        let new_idx = source_workspace_idx.saturating_sub(1);
-        if new_idx == source_workspace_idx {
-            return;
-        }
-        let new_id = self.workspaces[new_idx].id();
-
-        let workspace = &mut self.workspaces[source_workspace_idx];
-        let Some(removed) = workspace.remove_active_tile(Transaction::new()) else {
-            return;
-        };
-
-        let activate = if focus {
-            ActivateWindow::Yes
-        } else {
-            ActivateWindow::Smart
-        };
-
-        self.add_tile(
-            removed.tile,
-            MonitorAddWindowTarget::Workspace {
-                id: new_id,
-                column_idx: None,
-            },
-            activate,
-            true,
-            removed.width,
-            removed.is_full_width,
-            removed.is_floating,
-        );
+    pub fn move_to_workspace_up(&mut self, activate: ActivateWindow) {
+        let new_idx = self.active_workspace_idx.saturating_sub(1);
+        self.move_to_workspace(None, new_idx, activate);
     }
 
-    pub fn move_to_workspace_down(&mut self, focus: bool) {
-        let source_workspace_idx = self.active_workspace_idx;
-
-        let new_idx = min(source_workspace_idx + 1, self.workspaces.len() - 1);
-        if new_idx == source_workspace_idx {
-            return;
-        }
-        let new_id = self.workspaces[new_idx].id();
-
-        let workspace = &mut self.workspaces[source_workspace_idx];
-        let Some(removed) = workspace.remove_active_tile(Transaction::new()) else {
-            return;
-        };
-
-        let activate = if focus {
-            ActivateWindow::Yes
-        } else {
-            ActivateWindow::Smart
-        };
-
-        self.add_tile(
-            removed.tile,
-            MonitorAddWindowTarget::Workspace {
-                id: new_id,
-                column_idx: None,
-            },
-            activate,
-            true,
-            removed.width,
-            removed.is_full_width,
-            removed.is_floating,
-        );
+    pub fn move_to_workspace_down(&mut self, activate: ActivateWindow) {
+        let new_idx = min(self.active_workspace_idx + 1, self.workspaces.len() - 1);
+        self.move_to_workspace(None, new_idx, activate);
     }
 
     pub fn move_to_workspace(
@@ -917,6 +859,11 @@ impl<W: LayoutElement> Monitor<W> {
 
         let workspace = &mut self.workspaces[source_workspace_idx];
         if workspace.floating_is_active() {
+            let activate = if activate {
+                ActivateWindow::Smart
+            } else {
+                ActivateWindow::No
+            };
             self.move_to_workspace_up(activate);
             return;
         }
@@ -938,6 +885,11 @@ impl<W: LayoutElement> Monitor<W> {
 
         let workspace = &mut self.workspaces[source_workspace_idx];
         if workspace.floating_is_active() {
+            let activate = if activate {
+                ActivateWindow::Smart
+            } else {
+                ActivateWindow::No
+            };
             self.move_to_workspace_down(activate);
             return;
         }

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -395,6 +395,14 @@ impl<W: LayoutElement> Monitor<W> {
         &mut self.workspaces[self.active_workspace_idx]
     }
 
+    pub fn idx_of_ws(&self, id: WorkspaceId) -> Option<usize> {
+        self.workspaces.iter().position(|ws| ws.id() == id)
+    }
+
+    pub fn has_ws(&self, id: WorkspaceId) -> bool {
+        self.idx_of_ws(id).is_some()
+    }
+
     pub fn windows(&self) -> impl Iterator<Item = &W> {
         self.workspaces.iter().flat_map(|ws| ws.windows())
     }
@@ -491,7 +499,7 @@ impl<W: LayoutElement> Monitor<W> {
                 (self.active_workspace_idx, WorkspaceAddWindowTarget::Auto)
             }
             MonitorAddWindowTarget::Workspace { id, column_idx } => {
-                let idx = self.workspaces.iter().position(|ws| ws.id() == id).unwrap();
+                let idx = self.idx_of_ws(id).unwrap();
                 let target = if let Some(column_idx) = column_idx {
                     WorkspaceAddWindowTarget::NewColumnAt(column_idx)
                 } else {
@@ -654,9 +662,10 @@ impl<W: LayoutElement> Monitor<W> {
     }
 
     pub fn unname_workspace(&mut self, id: WorkspaceId) -> bool {
-        let Some(ws) = self.workspaces.iter_mut().find(|ws| ws.id() == id) else {
+        let Some(idx) = self.idx_of_ws(id) else {
             return false;
         };
+        let ws = &mut self.workspaces[idx];
 
         ws.unname();
 
@@ -914,7 +923,7 @@ impl<W: LayoutElement> Monitor<W> {
 
     fn previous_workspace_idx(&self) -> Option<usize> {
         let id = self.previous_workspace_id?;
-        self.workspaces.iter().position(|w| w.id() == id)
+        self.idx_of_ws(id)
     }
 
     pub fn switch_workspace(&mut self, idx: usize) {
@@ -1017,7 +1026,8 @@ impl<W: LayoutElement> Monitor<W> {
         if let Some(hint) = &self.insert_hint {
             match hint.workspace {
                 InsertWorkspace::Existing(ws_id) => {
-                    if let Some(ws) = self.workspaces.iter().find(|ws| ws.id() == ws_id) {
+                    if let Some(idx) = self.idx_of_ws(ws_id) {
+                        let ws = &self.workspaces[idx];
                         if let Some(mut area) = ws.insert_hint_area(hint.position) {
                             let scale = ws.scale().fractional_scale();
                             let view_size = ws.view_size();

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -540,13 +540,20 @@ impl<W: LayoutElement> Monitor<W> {
             width,
             is_full_width,
             is_floating,
+            None,
         );
     }
 
-    pub fn add_column(&mut self, mut workspace_idx: usize, column: Column<W>, activate: bool) {
+    pub fn add_column(
+        &mut self,
+        mut workspace_idx: usize,
+        column: Column<W>,
+        activate: bool,
+        anim: Option<niri_config::Animation>,
+    ) {
         let workspace = &mut self.workspaces[workspace_idx];
 
-        workspace.add_column(column, activate);
+        workspace.add_column(column, activate, anim);
 
         // After adding a new window, workspace becomes this output's own.
         if workspace.name().is_none() {
@@ -577,12 +584,21 @@ impl<W: LayoutElement> Monitor<W> {
         width: ColumnWidth,
         is_full_width: bool,
         is_floating: bool,
+        anim: Option<niri_config::Animation>,
     ) {
         let (mut workspace_idx, target) = self.resolve_add_window_target(target);
 
         let workspace = &mut self.workspaces[workspace_idx];
 
-        workspace.add_tile(tile, target, activate, width, is_full_width, is_floating);
+        workspace.add_tile(
+            tile,
+            target,
+            activate,
+            width,
+            is_full_width,
+            is_floating,
+            anim,
+        );
 
         // After adding a new window, workspace becomes this output's own.
         if workspace.name().is_none() {
@@ -842,6 +858,13 @@ impl<W: LayoutElement> Monitor<W> {
         let transaction = Transaction::new();
         let removed = workspace.remove_tile(&window, transaction);
 
+        // If the view is following the tile, match the animation.
+        let config = if activate {
+            self.options.animations.workspace_switch.0
+        } else {
+            self.options.animations.window_movement.0
+        };
+
         self.add_tile(
             removed.tile,
             MonitorAddWindowTarget::Workspace {
@@ -857,6 +880,7 @@ impl<W: LayoutElement> Monitor<W> {
             removed.width,
             removed.is_full_width,
             removed.is_floating,
+            Some(config),
         );
 
         if self.workspace_switch.is_none() {
@@ -879,12 +903,6 @@ impl<W: LayoutElement> Monitor<W> {
             .tiles_with_render_positions_mut(false)
             .find(|(tile, _)| tile.window().id() == &window)
             .unwrap();
-        // If the view is following the tile, match the animation.
-        let config = if activate {
-            self.options.animations.workspace_switch.0
-        } else {
-            self.options.animations.window_movement.0
-        };
         tile.animate_move_from_with_config(old_render_pos - new_render_pos, config);
         tile.set_anim_y_between_workspaces();
     }
@@ -933,8 +951,15 @@ impl<W: LayoutElement> Monitor<W> {
         old_render_pos.y +=
             self.workspace_size_with_gap(1.).h * (source_workspace_idx as f64 - new_idx as f64);
 
+        // If the view is following the column, match the animation.
+        let config = if activate {
+            self.options.animations.workspace_switch.0
+        } else {
+            self.options.animations.window_movement.0
+        };
+
         let new_id = self.workspaces[new_idx].id();
-        self.add_column(new_idx, column, activate);
+        self.add_column(new_idx, column, activate, Some(config));
 
         let new_idx = self.idx_of_ws(new_id).unwrap();
         let (column, new_render_pos) = self.workspaces[new_idx]
@@ -942,12 +967,6 @@ impl<W: LayoutElement> Monitor<W> {
             .columns_with_render_positions_mut()
             .find(|(col, _pos)| col.id() == id)
             .unwrap();
-        // If the view is following the tile, match the animation.
-        let config = if activate {
-            self.options.animations.workspace_switch.0
-        } else {
-            self.options.animations.window_movement.0
-        };
         column.animate_move_from_with_config(old_render_pos - new_render_pos, config);
         column.set_anim_y_between_workspaces();
     }

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -818,14 +818,13 @@ impl<W: LayoutElement> Monitor<W> {
         });
 
         let workspace = &mut self.workspaces[source_workspace_idx];
-        let transaction = Transaction::new();
-        let removed = if let Some(window) = window {
-            workspace.remove_tile(window, transaction)
-        } else if let Some(removed) = workspace.remove_active_tile(transaction) {
-            removed
-        } else {
+        let Some(window) = window.or_else(|| workspace.active_window().map(|win| win.id())) else {
             return;
         };
+        let window = window.clone();
+
+        let transaction = Transaction::new();
+        let removed = workspace.remove_tile(&window, transaction);
 
         self.add_tile(
             removed.tile,

--- a/src/layout/monitor.rs
+++ b/src/layout/monitor.rs
@@ -850,55 +850,13 @@ impl<W: LayoutElement> Monitor<W> {
     }
 
     pub fn move_column_to_workspace_up(&mut self, activate: bool) {
-        let source_workspace_idx = self.active_workspace_idx;
-
-        let new_idx = source_workspace_idx.saturating_sub(1);
-        if new_idx == source_workspace_idx {
-            return;
-        }
-
-        let workspace = &mut self.workspaces[source_workspace_idx];
-        if workspace.floating_is_active() {
-            let activate = if activate {
-                ActivateWindow::Smart
-            } else {
-                ActivateWindow::No
-            };
-            self.move_to_workspace_up(activate);
-            return;
-        }
-
-        let Some(column) = workspace.remove_active_column() else {
-            return;
-        };
-
-        self.add_column(new_idx, column, activate);
+        let new_idx = self.active_workspace_idx.saturating_sub(1);
+        self.move_column_to_workspace(new_idx, activate);
     }
 
     pub fn move_column_to_workspace_down(&mut self, activate: bool) {
-        let source_workspace_idx = self.active_workspace_idx;
-
-        let new_idx = min(source_workspace_idx + 1, self.workspaces.len() - 1);
-        if new_idx == source_workspace_idx {
-            return;
-        }
-
-        let workspace = &mut self.workspaces[source_workspace_idx];
-        if workspace.floating_is_active() {
-            let activate = if activate {
-                ActivateWindow::Smart
-            } else {
-                ActivateWindow::No
-            };
-            self.move_to_workspace_down(activate);
-            return;
-        }
-
-        let Some(column) = workspace.remove_active_column() else {
-            return;
-        };
-
-        self.add_column(new_idx, column, activate);
+        let new_idx = min(self.active_workspace_idx + 1, self.workspaces.len() - 1);
+        self.move_column_to_workspace(new_idx, activate);
     }
 
     pub fn move_column_to_workspace(&mut self, idx: usize, activate: bool) {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4203,8 +4203,16 @@ impl<W: LayoutElement> Column<W> {
     }
 
     pub fn animate_move_from(&mut self, from: Point<f64, Logical>) {
-        self.animate_move_x_from(from.x);
-        self.animate_move_y_from(from.y);
+        self.animate_move_from_with_config(from, self.options.animations.window_movement.0);
+    }
+
+    pub fn animate_move_from_with_config(
+        &mut self,
+        from: Point<f64, Logical>,
+        config: niri_config::Animation,
+    ) {
+        self.animate_move_x_from_with_config(from.x, config);
+        self.animate_move_y_from_with_config(from.y, config);
     }
 
     pub fn animate_move_x_from(&mut self, from_x_offset: f64) {

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -195,6 +195,9 @@ pub struct Column<W: LayoutElement> {
     /// Animation of the render offset during window swapping.
     move_animation: Option<MoveAnimation>,
 
+    /// Animation of a column visually moving vertically.
+    move_y_animation: Option<MoveAnimation>,
+
     /// Latest known view size for this column's workspace.
     view_size: Size<f64, Logical>,
 
@@ -3971,6 +3974,7 @@ impl<W: LayoutElement> Column<W> {
             display_mode,
             tab_indicator: TabIndicator::new(options.layout.tab_indicator),
             move_animation: None,
+            move_y_animation: None,
             view_size,
             working_area,
             parent_area,
@@ -4077,6 +4081,11 @@ impl<W: LayoutElement> Column<W> {
                 self.move_animation = None;
             }
         }
+        if let Some(move_) = &mut self.move_y_animation {
+            if move_.anim.is_done() {
+                self.move_y_animation = None;
+            }
+        }
 
         for tile in &mut self.tiles {
             tile.advance_animations();
@@ -4087,12 +4096,14 @@ impl<W: LayoutElement> Column<W> {
 
     pub fn are_animations_ongoing(&self) -> bool {
         self.move_animation.is_some()
+            || self.move_y_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_animations_ongoing)
     }
 
     pub fn are_transitions_ongoing(&self) -> bool {
         self.move_animation.is_some()
+            || self.move_y_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_transitions_ongoing)
     }
@@ -4159,6 +4170,9 @@ impl<W: LayoutElement> Column<W> {
         if let Some(move_) = &self.move_animation {
             offset.x += move_.from * move_.anim.value();
         }
+        if let Some(move_) = &self.move_y_animation {
+            offset.y += move_.from * move_.anim.value();
+        }
 
         offset
     }
@@ -4184,6 +4198,30 @@ impl<W: LayoutElement> Column<W> {
         self.move_animation = Some(MoveAnimation {
             anim,
             from: from_x_offset + current_offset,
+        });
+    }
+
+    pub fn animate_move_y_from(&mut self, from_y_offset: f64) {
+        self.animate_move_y_from_with_config(
+            from_y_offset,
+            self.options.animations.window_movement.0,
+        );
+    }
+
+    pub fn animate_move_y_from_with_config(
+        &mut self,
+        from_y_offset: f64,
+        config: niri_config::Animation,
+    ) {
+        let current_offset = self
+            .move_y_animation
+            .as_ref()
+            .map_or(0., |move_| move_.from * move_.anim.value());
+
+        let anim = Animation::new(self.clock.clone(), 1., 0., 0., config);
+        self.move_y_animation = Some(MoveAnimation {
+            anim,
+            from: from_y_offset + current_offset,
         });
     }
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -18,7 +18,7 @@ use super::workspace::{InteractiveResize, ResolvedSize};
 use super::{ConfigureIntent, HitType, InteractiveResizeData, LayoutElement, Options, RemovedTile};
 use crate::animation::{Animation, Clock};
 use crate::input::swipe_tracker::SwipeTracker;
-use crate::layout::SizingMode;
+use crate::layout::{RenderLayer, SizingMode};
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::xray::XrayPos;
@@ -306,6 +306,10 @@ pub enum ScrollDirection {
 struct MoveAnimation {
     anim: Animation,
     from: f64,
+    /// Whether this animation is for moving the tile between workspaces.
+    ///
+    /// Controls whether the tile is rendered uncropped and above others.
+    is_between_workspaces: bool,
 }
 
 impl<W: LayoutElement> ScrollingSpace<W> {
@@ -422,11 +426,16 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             || !self.closing_windows.is_empty()
     }
 
-    pub fn update_render_elements(&mut self, is_active: bool) {
+    pub fn update_render_elements(&mut self, is_active: bool, layer: RenderLayer) {
         let view_pos = Point::from((self.view_pos(), 0.));
         let view_size = self.view_size;
         let active_idx = self.active_column_idx;
         for (col_idx, (col, col_x)) in self.columns_mut().enumerate() {
+            // Skip columns belonging to a different render layer.
+            if layer.is_normal() == col.is_moving_between_workspaces() {
+                continue;
+            }
+
             let is_active = is_active && col_idx == active_idx;
             let col_off = Point::from((col_x, 0.));
             let col_pos = view_pos - col_off - col.render_offset();
@@ -2938,15 +2947,18 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         mut ctx: RenderCtx<R>,
         xray_pos: XrayPos,
         focus_ring: bool,
+        layer: RenderLayer,
         push: &mut dyn FnMut(ScrollingSpaceRenderElement<R>),
     ) {
         let scale = Scale::from(self.scale);
 
         // Draw the closing windows on top of the other windows.
-        let view_rect = Rectangle::new(Point::from((self.view_pos(), 0.)), self.view_size);
-        for closing in self.closing_windows.iter().rev() {
-            let elem = closing.render(ctx.as_gles(), view_rect, scale);
-            push(elem.into());
+        if layer.is_normal() {
+            let view_rect = Rectangle::new(Point::from((self.view_pos(), 0.)), self.view_size);
+            for closing in self.closing_windows.iter().rev() {
+                let elem = closing.render(ctx.as_gles(), view_rect, scale);
+                push(elem.into());
+            }
         }
 
         if self.columns.is_empty() {
@@ -2957,6 +2969,12 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         // This matches self.tiles_with_render_positions().
         for (col, col_pos) in self.columns_with_render_positions() {
+            // Skip columns belonging to a different render layer.
+            if layer.is_normal() == col.is_moving_between_workspaces() {
+                first = false;
+                continue;
+            }
+
             // Draw the tab indicator on top.
             {
                 let pos = col_pos.to_physical_precise_round(scale).to_logical(scale);
@@ -4133,6 +4151,34 @@ impl<W: LayoutElement> Column<W> {
             || self.tiles.iter().any(Tile::are_transitions_ongoing)
     }
 
+    pub fn is_moving_between_workspaces(&self) -> bool {
+        self.move_y_animation
+            .as_ref()
+            .is_some_and(|anim| anim.is_between_workspaces)
+            || self
+                .move_x_animation
+                .as_ref()
+                .is_some_and(|anim| anim.is_between_workspaces)
+            // When moving a window between workspaces into the scrolling layout, it will be
+            // immediately put into a new column, however the Y move animation and the
+            // moving-between-workspaces flag will be set on the tile rather than on that new
+            // column. Since the scrolling layout rendering checks moving between workspaces
+            // per-column rather than per-tile, we need to include the tiles here.
+            //
+            // This is not always visually correct: for example, interactive-moving a tile into an
+            // otherwise stationary column will now cause that entire column to draw unculled. I'm
+            // not sure there's a good solution overall for all edge cases here. Consider that the
+            // column tab indicator needs to draw on top of the tiles, but in this counterexample
+            // above, the column is stationary, so the single moving tile would instead need to draw
+            // on top of the tab indicator.
+            //
+            // I'm going with this simple check for now that should look ok in most cases.
+            || self
+                .tiles
+                .iter()
+                .any(|tile| tile.is_moving_between_workspaces())
+    }
+
     pub fn update_render_elements(&mut self, is_active: bool, view_rect: Rectangle<f64, Logical>) {
         let active_idx = self.active_tile_idx;
         for (tile_idx, (tile, tile_off)) in self.tiles_mut().enumerate() {
@@ -4227,15 +4273,16 @@ impl<W: LayoutElement> Column<W> {
         from_x_offset: f64,
         config: niri_config::Animation,
     ) {
-        let current_offset = self
-            .move_x_animation
-            .as_ref()
-            .map_or(0., |move_| move_.from * move_.anim.value());
+        let (current_offset, current_between) =
+            self.move_x_animation.as_ref().map_or((0., false), |move_| {
+                (move_.from * move_.anim.value(), move_.is_between_workspaces)
+            });
 
         let anim = Animation::new(self.clock.clone(), 1., 0., 0., config);
         self.move_x_animation = Some(MoveAnimation {
             anim,
             from: from_x_offset + current_offset,
+            is_between_workspaces: current_between,
         });
     }
 
@@ -4251,15 +4298,16 @@ impl<W: LayoutElement> Column<W> {
         from_y_offset: f64,
         config: niri_config::Animation,
     ) {
-        let current_offset = self
-            .move_y_animation
-            .as_ref()
-            .map_or(0., |move_| move_.from * move_.anim.value());
+        let (current_offset, current_between) =
+            self.move_y_animation.as_ref().map_or((0., false), |move_| {
+                (move_.from * move_.anim.value(), move_.is_between_workspaces)
+            });
 
         let anim = Animation::new(self.clock.clone(), 1., 0., 0., config);
         self.move_y_animation = Some(MoveAnimation {
             anim,
             from: from_y_offset + current_offset,
+            is_between_workspaces: current_between,
         });
     }
 
@@ -4271,6 +4319,12 @@ impl<W: LayoutElement> Column<W> {
             if value > 0.001 {
                 move_.from += offset / value;
             }
+        }
+    }
+
+    pub fn set_anim_y_between_workspaces(&mut self) {
+        if let Some(anim) = &mut self.move_y_animation {
+            anim.is_between_workspaces = true;
         }
     }
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1823,7 +1823,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     .get_or_insert(self.view_offset.stationary() + offset.x);
             }
 
-            offset.x += self.columns[source_col_idx].render_offset().x;
+            offset += self.columns[source_col_idx].render_offset();
             let RemovedTile { tile, .. } = self.remove_tile_by_idx(
                 source_col_idx,
                 0,
@@ -1833,14 +1833,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             self.add_tile_to_column(target_column_idx, None, tile, source_tile_was_active);
 
             let target_column = &mut self.columns[target_column_idx];
-            offset.x -= target_column.render_offset().x;
+            offset -= target_column.render_offset();
             offset += prev_off - target_column.tile_offset(target_column.tiles.len() - 1);
 
             let new_tile = target_column.tiles.last_mut().unwrap();
             new_tile.animate_move_from(offset);
         } else {
             // Move out of column.
-            let mut offset = Point::from((source_column.render_offset().x, 0.));
+            let mut offset = source_column.render_offset();
 
             let removed =
                 self.remove_tile_by_idx(source_col_idx, source_tile_idx, Transaction::new(), None);
@@ -1898,7 +1898,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let cur_x = self.column_x(source_col_idx);
 
         let source_column = &self.columns[source_col_idx];
-        let mut offset = Point::from((source_column.render_offset().x, 0.));
+        let mut offset = source_column.render_offset();
         let prev_off = source_column.tile_offset(source_tile_idx);
 
         let source_tile_was_active = self.active_column_idx == source_col_idx
@@ -1913,7 +1913,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             let target_column_idx = source_col_idx;
 
             offset.x += cur_x - self.column_x(source_col_idx + 1);
-            offset.x -= self.columns[source_col_idx + 1].render_offset().x;
+            offset -= self.columns[source_col_idx + 1].render_offset();
 
             if source_tile_was_active {
                 // Make sure the target column gets activated.
@@ -1977,10 +1977,9 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let target_column_idx = self.active_column_idx;
         let source_column_idx = self.active_column_idx + 1;
 
-        let offset = self.column_x(source_column_idx)
-            + self.columns[source_column_idx].render_offset().x
-            - self.column_x(target_column_idx);
-        let mut offset = Point::from((offset, 0.));
+        let mut offset = self.columns[source_column_idx].render_offset();
+        offset.x += self.column_x(source_column_idx);
+        offset.x -= self.column_x(target_column_idx);
         let prev_off = self.columns[source_column_idx].tile_offset(0);
 
         let removed = self.remove_tile_by_idx(source_column_idx, 0, Transaction::new(), None);
@@ -1988,7 +1987,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let target_column = &mut self.columns[target_column_idx];
         offset += prev_off - target_column.tile_offset(target_column.tiles.len() - 1);
-        offset.x -= target_column.render_offset().x;
+        offset -= target_column.render_offset();
 
         let new_tile = target_column.tiles.last_mut().unwrap();
         new_tile.animate_move_from(offset);
@@ -2010,7 +2009,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let source_tile_idx = source_column.tiles.len() - 1;
 
-        let mut offset = Point::from((source_column.render_offset().x, 0.));
+        let mut offset = source_column.render_offset();
         let prev_off = source_column.tile_offset(source_tile_idx);
 
         let removed =

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -4166,6 +4166,11 @@ impl<W: LayoutElement> Column<W> {
         offset
     }
 
+    pub fn animate_move_from(&mut self, from: Point<f64, Logical>) {
+        self.animate_move_x_from(from.x);
+        self.animate_move_y_from(from.y);
+    }
+
     pub fn animate_move_x_from(&mut self, from_x_offset: f64) {
         self.animate_move_x_from_with_config(
             from_x_offset,

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1163,6 +1163,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         tile
     }
 
+    pub fn active_column(&self) -> Option<&Column<W>> {
+        if self.columns.is_empty() {
+            return None;
+        }
+
+        Some(&self.columns[self.active_column_idx])
+    }
+
     pub fn remove_active_column(&mut self) -> Option<Column<W>> {
         if self.columns.is_empty() {
             return None;

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -23,6 +23,7 @@ use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::xray::XrayPos;
 use crate::render_helpers::RenderCtx;
+use crate::utils::id::IdCounter;
 use crate::utils::transaction::{Transaction, TransactionBlocker};
 use crate::utils::ResizeEdge;
 use crate::window::ResolvedWindowRules;
@@ -142,6 +143,25 @@ pub(super) struct ViewGesture {
     dnd_nonzero_start_time: Option<Duration>,
 }
 
+static COLUMN_ID_COUNTER: IdCounter = IdCounter::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ColumnId(u64);
+
+impl ColumnId {
+    fn next() -> ColumnId {
+        ColumnId(COLUMN_ID_COUNTER.next())
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    pub fn specific(id: u64) -> Self {
+        Self(id)
+    }
+}
+
 #[derive(Debug)]
 pub struct Column<W: LayoutElement> {
     /// Tiles in this column.
@@ -217,6 +237,9 @@ pub struct Column<W: LayoutElement> {
 
     /// Configurable properties of the layout.
     options: Rc<Options>,
+
+    /// Unique ID of this column.
+    id: ColumnId,
 }
 
 /// Extra per-tile data.
@@ -3970,6 +3993,7 @@ impl<W: LayoutElement> Column<W> {
             scale,
             clock: tile.clock.clone(),
             options,
+            id: ColumnId::next(),
         };
 
         let pending_sizing_mode = tile.window().pending_sizing_mode();
@@ -3994,6 +4018,10 @@ impl<W: LayoutElement> Column<W> {
         }
 
         rv
+    }
+
+    pub fn id(&self) -> ColumnId {
+        self.id
     }
 
     fn update_config(

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -2362,19 +2362,39 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         zip(columns, offsets)
     }
 
+    pub fn columns_with_render_positions(
+        &self,
+    ) -> impl Iterator<Item = (&Column<W>, Point<f64, Logical>)> {
+        let view_off = Point::from((-self.view_pos(), 0.));
+        self.columns_in_render_order().map(move |(col, col_x)| {
+            let col_off = Point::from((col_x, 0.));
+            let col_render_off = col.render_offset();
+            let pos = view_off + col_off + col_render_off;
+            (col, pos)
+        })
+    }
+
+    pub fn columns_with_render_positions_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (&mut Column<W>, Point<f64, Logical>)> {
+        let view_off = Point::from((-self.view_pos(), 0.));
+        self.columns_in_render_order_mut().map(move |(col, col_x)| {
+            let col_off = Point::from((col_x, 0.));
+            let col_render_off = col.render_offset();
+            let pos = view_off + col_off + col_render_off;
+            (col, pos)
+        })
+    }
+
     pub fn tiles_with_render_positions(
         &self,
     ) -> impl Iterator<Item = (&Tile<W>, Point<f64, Logical>, bool)> {
         let scale = self.scale;
-        let view_off = Point::from((-self.view_pos(), 0.));
-        self.columns_in_render_order()
-            .flat_map(move |(col, col_x)| {
-                let col_off = Point::from((col_x, 0.));
-                let col_render_off = col.render_offset();
+        self.columns_with_render_positions()
+            .flat_map(move |(col, col_pos)| {
                 col.tiles_in_render_order()
                     .map(move |(tile, tile_off, visible)| {
-                        let pos =
-                            view_off + col_off + col_render_off + tile_off + tile.render_offset();
+                        let pos = col_pos + tile_off + tile.render_offset();
                         // Round to physical pixels.
                         let pos = pos.to_physical_precise_round(scale).to_logical(scale);
                         (tile, pos, visible)
@@ -2387,15 +2407,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         round: bool,
     ) -> impl Iterator<Item = (&mut Tile<W>, Point<f64, Logical>)> {
         let scale = self.scale;
-        let view_off = Point::from((-self.view_pos(), 0.));
-        self.columns_in_render_order_mut()
-            .flat_map(move |(col, col_x)| {
-                let col_off = Point::from((col_x, 0.));
-                let col_render_off = col.render_offset();
+        self.columns_with_render_positions_mut()
+            .flat_map(move |(col, col_pos)| {
                 col.tiles_in_render_order_mut()
                     .map(move |(tile, tile_off)| {
-                        let mut pos =
-                            view_off + col_off + col_render_off + tile_off + tile.render_offset();
+                        let mut pos = col_pos + tile_off + tile.render_offset();
                         // Round to physical pixels.
                         if round {
                             pos = pos.to_physical_precise_round(scale).to_logical(scale);
@@ -2908,23 +2924,17 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let mut first = true;
 
-        // This matches self.tiles_in_render_order().
-        let view_off = Point::from((-self.view_pos(), 0.));
-        for (col, col_x) in self.columns_in_render_order() {
-            let col_off = Point::from((col_x, 0.));
-            let col_render_off = col.render_offset();
-
+        // This matches self.tiles_with_render_positions().
+        for (col, col_pos) in self.columns_with_render_positions() {
             // Draw the tab indicator on top.
             {
-                let pos = view_off + col_off + col_render_off;
-                let pos = pos.to_physical_precise_round(scale).to_logical(scale);
+                let pos = col_pos.to_physical_precise_round(scale).to_logical(scale);
                 col.tab_indicator
                     .render(ctx.renderer, pos, &mut |elem| push(elem.into()));
             }
 
             for (tile, tile_off, visible) in col.tiles_in_render_order() {
-                let tile_pos =
-                    view_off + col_off + col_render_off + tile_off + tile.render_offset();
+                let tile_pos = col_pos + tile_off + tile.render_offset();
                 // Round to physical pixels.
                 let tile_pos = tile_pos.to_physical_precise_round(scale).to_logical(scale);
 
@@ -2955,14 +2965,9 @@ impl<W: LayoutElement> ScrollingSpace<W> {
     pub fn window_under(&self, pos: Point<f64, Logical>) -> Option<(&W, HitType)> {
         // This matches self.tiles_with_render_positions().
         let scale = self.scale;
-        let view_off = Point::from((-self.view_pos(), 0.));
-        for (col, col_x) in self.columns_in_render_order() {
-            let col_off = Point::from((col_x, 0.));
-            let col_render_off = col.render_offset();
-
+        for (col, col_pos) in self.columns_with_render_positions() {
             // Hit the tab indicator.
             if col.display_mode == ColumnDisplay::Tabbed && col.sizing_mode().is_normal() {
-                let col_pos = view_off + col_off + col_render_off;
                 let col_pos = col_pos.to_physical_precise_round(scale).to_logical(scale);
 
                 if let Some(idx) = col.tab_indicator.hit(
@@ -2983,8 +2988,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     continue;
                 }
 
-                let tile_pos =
-                    view_off + col_off + col_render_off + tile_off + tile.render_offset();
+                let tile_pos = col_pos + tile_off + tile.render_offset();
                 // Round to physical pixels.
                 let tile_pos = tile_pos.to_physical_precise_round(scale).to_logical(scale);
 

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -193,7 +193,7 @@ pub struct Column<W: LayoutElement> {
     tab_indicator: TabIndicator,
 
     /// Animation of the render offset during window swapping.
-    move_animation: Option<MoveAnimation>,
+    move_x_animation: Option<MoveAnimation>,
 
     /// Animation of a column visually moving vertically.
     move_y_animation: Option<MoveAnimation>,
@@ -936,11 +936,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let offset = self.column_x(col_idx + 1) - prev_next_x;
         if self.active_column_idx <= col_idx {
             for col in &mut self.columns[col_idx + 1..] {
-                col.animate_move_from(-offset);
+                col.animate_move_x_from(-offset);
             }
         } else {
             for col in &mut self.columns[..=col_idx] {
-                col.animate_move_from(offset);
+                col.animate_move_x_from(offset);
             }
         }
     }
@@ -999,11 +999,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let config = anim_config.unwrap_or(self.options.animations.window_movement.0);
         if self.active_column_idx <= idx {
             for col in &mut self.columns[idx + 1..] {
-                col.animate_move_from_with_config(-offset, config);
+                col.animate_move_x_from_with_config(-offset, config);
             }
         } else {
             for col in &mut self.columns[..idx] {
-                col.animate_move_from_with_config(offset, config);
+                col.animate_move_x_from_with_config(offset, config);
             }
         }
 
@@ -1143,11 +1143,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         // Animate movement of the other columns.
         if self.active_column_idx <= column_idx {
             for col in &mut self.columns[column_idx + 1..] {
-                col.animate_move_from_with_config(offset, movement_config);
+                col.animate_move_x_from_with_config(offset, movement_config);
             }
         } else {
             for col in &mut self.columns[..=column_idx] {
-                col.animate_move_from_with_config(-offset, movement_config);
+                col.animate_move_x_from_with_config(-offset, movement_config);
             }
         }
 
@@ -1172,11 +1172,11 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         let offset = self.column_x(column_idx + 1) - self.column_x(column_idx);
         if self.active_column_idx <= column_idx {
             for col in &mut self.columns[column_idx + 1..] {
-                col.animate_move_from_with_config(offset, movement_config);
+                col.animate_move_x_from_with_config(offset, movement_config);
             }
         } else {
             for col in &mut self.columns[..column_idx] {
-                col.animate_move_from_with_config(-offset, movement_config);
+                col.animate_move_x_from_with_config(-offset, movement_config);
             }
         }
 
@@ -1304,7 +1304,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
                     // Notably, this is necessary to fix the animation jump when resizing width back
                     // and forth in quick succession (in a way that cancels the resize animation).
                     if ongoing_resize_anim {
-                        col.animate_move_from_with_config(
+                        col.animate_move_x_from_with_config(
                             offset,
                             self.options.animations.window_resize.anim,
                         );
@@ -1315,7 +1315,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             } else {
                 for col in &mut self.columns[..=col_idx] {
                     if ongoing_resize_anim {
-                        col.animate_move_from_with_config(
+                        col.animate_move_x_from_with_config(
                             -offset,
                             self.options.animations.window_resize.anim,
                         );
@@ -1700,17 +1700,17 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         // The column we just moved is offset by the difference between its new and old position.
         let new_col_x = self.column_x(new_idx);
-        self.columns[new_idx].animate_move_from(current_col_x - new_col_x);
+        self.columns[new_idx].animate_move_x_from(current_col_x - new_col_x);
 
         // All columns in between moved by the width of the column that we just moved.
         let others_x_offset = next_col_x - current_col_x;
         if self.active_column_idx < new_idx {
             for col in &mut self.columns[self.active_column_idx..new_idx] {
-                col.animate_move_from(others_x_offset);
+                col.animate_move_x_from(others_x_offset);
             }
         } else {
             for col in &mut self.columns[new_idx + 1..=self.active_column_idx] {
-                col.animate_move_from(-others_x_offset);
+                col.animate_move_x_from(-others_x_offset);
             }
         }
 
@@ -3973,7 +3973,7 @@ impl<W: LayoutElement> Column<W> {
             is_pending_fullscreen: false,
             display_mode,
             tab_indicator: TabIndicator::new(options.layout.tab_indicator),
-            move_animation: None,
+            move_x_animation: None,
             move_y_animation: None,
             view_size,
             working_area,
@@ -4076,9 +4076,9 @@ impl<W: LayoutElement> Column<W> {
     }
 
     pub fn advance_animations(&mut self) {
-        if let Some(move_) = &mut self.move_animation {
+        if let Some(move_) = &mut self.move_x_animation {
             if move_.anim.is_done() {
-                self.move_animation = None;
+                self.move_x_animation = None;
             }
         }
         if let Some(move_) = &mut self.move_y_animation {
@@ -4095,14 +4095,14 @@ impl<W: LayoutElement> Column<W> {
     }
 
     pub fn are_animations_ongoing(&self) -> bool {
-        self.move_animation.is_some()
+        self.move_x_animation.is_some()
             || self.move_y_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_animations_ongoing)
     }
 
     pub fn are_transitions_ongoing(&self) -> bool {
-        self.move_animation.is_some()
+        self.move_x_animation.is_some()
             || self.move_y_animation.is_some()
             || self.tab_indicator.are_animations_ongoing()
             || self.tiles.iter().any(Tile::are_transitions_ongoing)
@@ -4167,7 +4167,7 @@ impl<W: LayoutElement> Column<W> {
     pub fn render_offset(&self) -> Point<f64, Logical> {
         let mut offset = Point::from((0., 0.));
 
-        if let Some(move_) = &self.move_animation {
+        if let Some(move_) = &self.move_x_animation {
             offset.x += move_.from * move_.anim.value();
         }
         if let Some(move_) = &self.move_y_animation {
@@ -4177,25 +4177,25 @@ impl<W: LayoutElement> Column<W> {
         offset
     }
 
-    pub fn animate_move_from(&mut self, from_x_offset: f64) {
-        self.animate_move_from_with_config(
+    pub fn animate_move_x_from(&mut self, from_x_offset: f64) {
+        self.animate_move_x_from_with_config(
             from_x_offset,
             self.options.animations.window_movement.0,
         );
     }
 
-    pub fn animate_move_from_with_config(
+    pub fn animate_move_x_from_with_config(
         &mut self,
         from_x_offset: f64,
         config: niri_config::Animation,
     ) {
         let current_offset = self
-            .move_animation
+            .move_x_animation
             .as_ref()
             .map_or(0., |move_| move_.from * move_.anim.value());
 
         let anim = Animation::new(self.clock.clone(), 1., 0., 0., config);
-        self.move_animation = Some(MoveAnimation {
+        self.move_x_animation = Some(MoveAnimation {
             anim,
             from: from_x_offset + current_offset,
         });
@@ -4226,7 +4226,7 @@ impl<W: LayoutElement> Column<W> {
     }
 
     pub fn offset_move_anim_current(&mut self, offset: f64) {
-        if let Some(move_) = self.move_animation.as_mut() {
+        if let Some(move_) = self.move_x_animation.as_mut() {
             // If the anim is almost done, there's little point trying to offset it; we can let
             // things jump. If it turns out like a bad idea, we could restart the anim instead.
             let value = move_.anim.value();

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -907,7 +907,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         activate: bool,
         width: ColumnWidth,
         is_full_width: bool,
-        anim_config: Option<niri_config::Animation>,
+        anim: Option<niri_config::Animation>,
     ) {
         let column = Column::new_with_tile(
             tile,
@@ -919,7 +919,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             is_full_width,
         );
 
-        self.add_column(col_idx, column, activate, anim_config);
+        self.add_column(col_idx, column, activate, anim);
     }
 
     pub fn add_tile_to_column(
@@ -984,6 +984,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         activate: bool,
         width: ColumnWidth,
         is_full_width: bool,
+        anim: Option<niri_config::Animation>,
     ) {
         let right_of_idx = self
             .columns
@@ -992,7 +993,7 @@ impl<W: LayoutElement> ScrollingSpace<W> {
             .unwrap();
         let col_idx = right_of_idx + 1;
 
-        self.add_tile(Some(col_idx), tile, activate, width, is_full_width, None);
+        self.add_tile(Some(col_idx), tile, activate, width, is_full_width, anim);
     }
 
     pub fn add_column(

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -1026,20 +1026,6 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         }
     }
 
-    pub fn remove_active_tile(&mut self, transaction: Transaction) -> Option<RemovedTile<W>> {
-        if self.columns.is_empty() {
-            return None;
-        }
-
-        let column = &self.columns[self.active_column_idx];
-        Some(self.remove_tile_by_idx(
-            self.active_column_idx,
-            column.active_tile_idx,
-            transaction,
-            None,
-        ))
-    }
-
     pub fn remove_tile(&mut self, window: &W::Id, transaction: Transaction) -> RemovedTile<W> {
         let column_idx = self
             .columns

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -573,8 +573,16 @@ impl<W: LayoutElement> Tile<W> {
     }
 
     pub fn animate_move_from(&mut self, from: Point<f64, Logical>) {
-        self.animate_move_x_from(from.x);
-        self.animate_move_y_from(from.y);
+        self.animate_move_from_with_config(from, self.options.animations.window_movement.0);
+    }
+
+    pub fn animate_move_from_with_config(
+        &mut self,
+        from: Point<f64, Logical>,
+        config: niri_config::Animation,
+    ) {
+        self.animate_move_x_from_with_config(from.x, config);
+        self.animate_move_y_from_with_config(from.y, config);
     }
 
     pub fn animate_move_x_from(&mut self, from: f64) {

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -160,6 +160,10 @@ struct ResizeAnimation {
 struct MoveAnimation {
     anim: Animation,
     from: f64,
+    /// Whether this animation is for moving the tile between workspaces.
+    ///
+    /// Controls whether the tile is rendered uncropped and above others.
+    is_between_workspaces: bool,
 }
 
 #[derive(Debug)]
@@ -456,6 +460,16 @@ impl<W: LayoutElement> Tile<W> {
                 .is_some_and(|alpha| !alpha.anim.is_done())
     }
 
+    pub fn is_moving_between_workspaces(&self) -> bool {
+        self.move_y_animation
+            .as_ref()
+            .is_some_and(|anim| anim.is_between_workspaces)
+            || self
+                .move_x_animation
+                .as_ref()
+                .is_some_and(|anim| anim.is_between_workspaces)
+    }
+
     pub fn update_render_elements(&mut self, is_active: bool, view_rect: Rectangle<f64, Logical>) {
         let rules = self.window.rules();
         let animated_tile_size = self.animated_tile_size();
@@ -593,7 +607,11 @@ impl<W: LayoutElement> Tile<W> {
         let current_offset = self.render_offset().x;
 
         // Preserve the previous config if ongoing.
-        let anim = self.move_x_animation.take().map(|move_| move_.anim);
+        let move_ = self.move_x_animation.take();
+        let current_between = move_
+            .as_ref()
+            .is_some_and(|move_| move_.is_between_workspaces);
+        let anim = move_.map(|move_| move_.anim);
         let anim = anim
             .map(|anim| anim.restarted(1., 0., 0.))
             .unwrap_or_else(|| Animation::new(self.clock.clone(), 1., 0., 0., config));
@@ -601,6 +619,7 @@ impl<W: LayoutElement> Tile<W> {
         self.move_x_animation = Some(MoveAnimation {
             anim,
             from: from + current_offset,
+            is_between_workspaces: current_between,
         });
     }
 
@@ -612,7 +631,11 @@ impl<W: LayoutElement> Tile<W> {
         let current_offset = self.render_offset().y;
 
         // Preserve the previous config if ongoing.
-        let anim = self.move_y_animation.take().map(|move_| move_.anim);
+        let move_ = self.move_y_animation.take();
+        let current_between = move_
+            .as_ref()
+            .is_some_and(|move_| move_.is_between_workspaces);
+        let anim = move_.map(|move_| move_.anim);
         let anim = anim
             .map(|anim| anim.restarted(1., 0., 0.))
             .unwrap_or_else(|| Animation::new(self.clock.clone(), 1., 0., 0., config));
@@ -620,6 +643,7 @@ impl<W: LayoutElement> Tile<W> {
         self.move_y_animation = Some(MoveAnimation {
             anim,
             from: from + current_offset,
+            is_between_workspaces: current_between,
         });
     }
 
@@ -637,6 +661,12 @@ impl<W: LayoutElement> Tile<W> {
     pub fn stop_move_animations(&mut self) {
         self.move_x_animation = None;
         self.move_y_animation = None;
+    }
+
+    pub fn set_anim_y_between_workspaces(&mut self) {
+        if let Some(anim) = &mut self.move_y_animation {
+            anim.is_between_workspaces = true;
+        }
     }
 
     pub fn animate_alpha(&mut self, from: f64, to: f64, config: niri_config::Animation) {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -751,23 +751,6 @@ impl<W: LayoutElement> Workspace<W> {
         removed
     }
 
-    pub fn remove_active_tile(&mut self, transaction: Transaction) -> Option<RemovedTile<W>> {
-        let from_floating = self.floating_is_active.get();
-        let removed = if from_floating {
-            self.floating.remove_active_tile()?
-        } else {
-            self.scrolling.remove_active_tile(transaction)?
-        };
-
-        if let Some(output) = &self.output {
-            removed.tile.window().output_leave(output);
-        }
-
-        self.update_focus_floating_tiling_after_removing(from_floating);
-
-        Some(removed)
-    }
-
     pub fn remove_active_column(&mut self) -> Option<Column<W>> {
         let from_floating = self.floating_is_active.get();
         if from_floating {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -28,6 +28,7 @@ use super::{
     RemovedTile, SizeFrac,
 };
 use crate::animation::Clock;
+use crate::layout::RenderLayer;
 use crate::niri_render_elements;
 use crate::render_helpers::renderer::NiriRenderer;
 use crate::render_helpers::shadow::ShadowRenderElement;
@@ -375,21 +376,26 @@ impl<W: LayoutElement> Workspace<W> {
         self.scrolling.are_transitions_ongoing() || self.floating.are_transitions_ongoing()
     }
 
-    pub fn update_render_elements(&mut self, is_active: bool) {
+    pub fn update_render_elements(&mut self, is_active: bool, layer: RenderLayer) {
         self.scrolling
-            .update_render_elements(is_active && !self.floating_is_active.get());
+            .update_render_elements(is_active && !self.floating_is_active.get(), layer);
 
         let view_rect = Rectangle::from_size(self.view_size);
-        self.floating
-            .update_render_elements(is_active && self.floating_is_active.get(), view_rect);
-
-        self.shadow.update_render_elements(
-            self.view_size,
-            true,
-            CornerRadius::default(),
-            self.scale.fractional_scale(),
-            1.,
+        self.floating.update_render_elements(
+            is_active && self.floating_is_active.get(),
+            view_rect,
+            layer,
         );
+
+        if layer.is_normal() {
+            self.shadow.update_render_elements(
+                self.view_size,
+                true,
+                CornerRadius::default(),
+                self.scale.fractional_scale(),
+                1.,
+            );
+        }
     }
 
     pub fn update_config(&mut self, base_options: Rc<Options>) {
@@ -1613,11 +1619,12 @@ impl<W: LayoutElement> Workspace<W> {
         ctx: RenderCtx<R>,
         xray_pos: XrayPos,
         focus_ring: bool,
+        layer: RenderLayer,
         push: &mut dyn FnMut(WorkspaceRenderElement<R>),
     ) {
         let scrolling_focus_ring = focus_ring && !self.floating_is_active();
         self.scrolling
-            .render(ctx, xray_pos, scrolling_focus_ring, &mut |elem| {
+            .render(ctx, xray_pos, scrolling_focus_ring, layer, &mut |elem| {
                 push(elem.into())
             });
     }
@@ -1627,18 +1634,23 @@ impl<W: LayoutElement> Workspace<W> {
         ctx: RenderCtx<R>,
         xray_pos: XrayPos,
         focus_ring: bool,
+        layer: RenderLayer,
         push: &mut dyn FnMut(WorkspaceRenderElement<R>),
     ) {
-        if !self.is_floating_visible() {
+        if !self.is_floating_visible() && layer.is_normal() {
             return;
         }
 
         let view_rect = Rectangle::from_size(self.view_size);
         let floating_focus_ring = focus_ring && self.floating_is_active();
-        self.floating
-            .render(ctx, xray_pos, view_rect, floating_focus_ring, &mut |elem| {
-                push(elem.into())
-            });
+        self.floating.render(
+            ctx,
+            xray_pos,
+            view_rect,
+            floating_focus_ring,
+            layer,
+            &mut |elem| push(elem.into()),
+        );
     }
 
     pub fn render_shadow<R: NiriRenderer>(
@@ -1962,6 +1974,10 @@ impl<W: LayoutElement> Workspace<W> {
 
     pub fn scrolling(&self) -> &ScrollingSpace<W> {
         &self.scrolling
+    }
+
+    pub fn scrolling_mut(&mut self) -> &mut ScrollingSpace<W> {
+        &mut self.scrolling
     }
 
     pub fn floating(&self) -> &FloatingSpace<W> {

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -1960,12 +1960,10 @@ impl<W: LayoutElement> Workspace<W> {
         self.layout_config.as_ref()
     }
 
-    #[cfg(test)]
     pub fn scrolling(&self) -> &ScrollingSpace<W> {
         &self.scrolling
     }
 
-    #[cfg(test)]
     pub fn floating(&self) -> &FloatingSpace<W> {
         &self.floating
     }

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -604,6 +604,7 @@ impl<W: LayoutElement> Workspace<W> {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_tile(
         &mut self,
         mut tile: Tile<W>,
@@ -612,6 +613,7 @@ impl<W: LayoutElement> Workspace<W> {
         width: ColumnWidth,
         is_full_width: bool,
         is_floating: bool,
+        anim: Option<niri_config::Animation>,
     ) {
         self.enter_output_for_window(tile.window());
         tile.restore_to_floating = is_floating;
@@ -631,7 +633,7 @@ impl<W: LayoutElement> Workspace<W> {
                     }
                 } else {
                     self.scrolling
-                        .add_tile(None, tile, activate, width, is_full_width, None);
+                        .add_tile(None, tile, activate, width, is_full_width, anim);
 
                     if activate {
                         self.floating_is_active = FloatingActive::No;
@@ -641,7 +643,7 @@ impl<W: LayoutElement> Workspace<W> {
             WorkspaceAddWindowTarget::NewColumnAt(col_idx) => {
                 let activate = activate.map_smart(|| false);
                 self.scrolling
-                    .add_tile(Some(col_idx), tile, activate, width, is_full_width, None);
+                    .add_tile(Some(col_idx), tile, activate, width, is_full_width, anim);
 
                 if activate {
                     self.floating_is_active = FloatingActive::No;
@@ -681,14 +683,20 @@ impl<W: LayoutElement> Workspace<W> {
                     }
                 } else if floating_has_window {
                     self.scrolling
-                        .add_tile(None, tile, activate, width, is_full_width, None);
+                        .add_tile(None, tile, activate, width, is_full_width, anim);
 
                     if activate {
                         self.floating_is_active = FloatingActive::No;
                     }
                 } else {
-                    self.scrolling
-                        .add_tile_right_of(next_to, tile, activate, width, is_full_width);
+                    self.scrolling.add_tile_right_of(
+                        next_to,
+                        tile,
+                        activate,
+                        width,
+                        is_full_width,
+                        anim,
+                    );
 
                     if activate {
                         self.floating_is_active = FloatingActive::No;
@@ -714,12 +722,17 @@ impl<W: LayoutElement> Workspace<W> {
         }
     }
 
-    pub fn add_column(&mut self, column: Column<W>, activate: bool) {
+    pub fn add_column(
+        &mut self,
+        column: Column<W>,
+        activate: bool,
+        anim: Option<niri_config::Animation>,
+    ) {
         for (tile, _) in column.tiles() {
             self.enter_output_for_window(tile.window());
         }
 
-        self.scrolling.add_column(None, column, activate, None);
+        self.scrolling.add_column(None, column, activate, anim);
 
         if activate {
             self.floating_is_active = FloatingActive::No;


### PR DESCRIPTION
Implements #373. Not exactly how I wrote there: after some thinking, I decided that making the view position line up would be more annoying than helpful. So, in this PR the final positions all behave exactly the same as before, just the windows and columns are animated into them rather than teleporting.

Based on #4420, otherwise should be ready to go.