### PR TITLE
 input: honor keyboard-shortcuts-inhibit for mouse input

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3131,6 +3131,11 @@ impl State {
                 || is_mru_open
                 || self.niri.mods_with_wheel_binds.contains(&modifiers);
             if should_handle {
+                // Honor keyboard-shortcuts-inhibit for wheel binds, mirroring the
+                // FilterResult::Forward check in on_keyboard_key_event.
+                let inhibited = self.is_inhibiting_shortcuts();
+                let mut any_bind_ran = false;
+
                 let horizontal = horizontal_amount_v120.unwrap_or(0.);
                 let ticks = self.niri.horizontal_wheel_tracker.accumulate(horizontal);
                 if ticks != 0 {
@@ -3189,13 +3194,19 @@ impl State {
                         };
 
                     if let Some(right) = bind_right {
-                        for _ in 0..ticks {
-                            self.handle_bind(right.clone());
+                        if !inhibited || !right.allow_inhibiting {
+                            for _ in 0..ticks {
+                                self.handle_bind(right.clone());
+                                any_bind_ran = true;
+                            }
                         }
                     }
                     if let Some(left) = bind_left {
-                        for _ in ticks..0 {
-                            self.handle_bind(left.clone());
+                        if !inhibited || !left.allow_inhibiting {
+                            for _ in ticks..0 {
+                                self.handle_bind(left.clone());
+                                any_bind_ran = true;
+                            }
                         }
                     }
                 }
@@ -3280,18 +3291,26 @@ impl State {
                     };
 
                     if let Some(down) = bind_down {
-                        for _ in 0..ticks {
-                            self.handle_bind(down.clone());
+                        if !inhibited || !down.allow_inhibiting {
+                            for _ in 0..ticks {
+                                self.handle_bind(down.clone());
+                                any_bind_ran = true;
+                            }
                         }
                     }
                     if let Some(up) = bind_up {
-                        for _ in ticks..0 {
-                            self.handle_bind(up.clone());
+                        if !inhibited || !up.allow_inhibiting {
+                            for _ in ticks..0 {
+                                self.handle_bind(up.clone());
+                                any_bind_ran = true;
+                            }
                         }
                     }
                 }
 
-                return;
+                if any_bind_ran {
+                    return;
+                }
             } else {
                 self.niri.horizontal_wheel_tracker.reset();
                 self.niri.vertical_wheel_tracker.reset();
@@ -3405,6 +3424,11 @@ impl State {
             }
 
             if is_mru_open || self.niri.mods_with_finger_scroll_binds.contains(&modifiers) {
+                // Honor keyboard-shortcuts-inhibit for touchpad scroll binds, mirroring
+                // the wheel bind handling above.
+                let inhibited = self.is_inhibiting_shortcuts();
+                let mut any_bind_ran = false;
+
                 let ticks = self
                     .niri
                     .horizontal_finger_scroll_tracker
@@ -3432,13 +3456,19 @@ impl State {
                     drop(config);
 
                     if let Some(right) = bind_right {
-                        for _ in 0..ticks {
-                            self.handle_bind(right.clone());
+                        if !inhibited || !right.allow_inhibiting {
+                            for _ in 0..ticks {
+                                self.handle_bind(right.clone());
+                                any_bind_ran = true;
+                            }
                         }
                     }
                     if let Some(left) = bind_left {
-                        for _ in ticks..0 {
-                            self.handle_bind(left.clone());
+                        if !inhibited || !left.allow_inhibiting {
+                            for _ in ticks..0 {
+                                self.handle_bind(left.clone());
+                                any_bind_ran = true;
+                            }
                         }
                     }
                 }
@@ -3470,18 +3500,26 @@ impl State {
                     drop(config);
 
                     if let Some(down) = bind_down {
-                        for _ in 0..ticks {
-                            self.handle_bind(down.clone());
+                        if !inhibited || !down.allow_inhibiting {
+                            for _ in 0..ticks {
+                                self.handle_bind(down.clone());
+                                any_bind_ran = true;
+                            }
                         }
                     }
                     if let Some(up) = bind_up {
-                        for _ in ticks..0 {
-                            self.handle_bind(up.clone());
+                        if !inhibited || !up.allow_inhibiting {
+                            for _ in ticks..0 {
+                                self.handle_bind(up.clone());
+                                any_bind_ran = true;
+                            }
                         }
                     }
                 }
 
-                return;
+                if any_bind_ran {
+                    return;
+                }
             } else {
                 self.niri.horizontal_finger_scroll_tracker.reset();
                 self.niri.vertical_finger_scroll_tracker.reset();

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2858,7 +2858,11 @@ impl State {
                 }
             }
 
-            if button == Some(MouseButton::Middle) && !pointer.is_grabbed() && mod_down {
+            if button == Some(MouseButton::Middle)
+                && !pointer.is_grabbed()
+                && mod_down
+                && !self.is_inhibiting_shortcuts()
+            {
                 let output_ws = if is_overview_open {
                     self.niri.workspace_under_cursor(true)
                 } else {
@@ -2901,7 +2905,7 @@ impl State {
 
                 // Check if we need to start an interactive move.
                 if button == Some(MouseButton::Left) && !pointer.is_grabbed() {
-                    if is_overview_open || mod_down {
+                    if (is_overview_open || mod_down) && !self.is_inhibiting_shortcuts() {
                         let location = pointer.current_location();
 
                         if !is_overview_open {
@@ -2934,7 +2938,11 @@ impl State {
                     }
                 }
                 // Check if we need to start an interactive resize.
-                else if button == Some(MouseButton::Right) && !pointer.is_grabbed() && mod_down {
+                else if button == Some(MouseButton::Right)
+                    && !pointer.is_grabbed()
+                    && mod_down
+                    && !self.is_inhibiting_shortcuts()
+                {
                     let location = pointer.current_location();
                     let (output, pos_within_output) = self.niri.output_under(location).unwrap();
                     let edges = self


### PR DESCRIPTION
Currently, niri consults `is_inhibiting_shortcuts()` only in keyboard bind handling. Mouse bind handling and Mod+mouse gestures don't, so apps like Moonlight that request inhibit to forward input to a remote machine still see their `Mod+Wheel*` binds consumed locally instead of reaching the app.

The protocol covers keyboard keys, and `Mod` (Super/Alt) is one. Two changes here, with the same Mod-is-keyboard argument:

1. Mouse binds (commit 1): user-bound binds are the unit of meaning, not the input device. `Mod+WheelDown { focus-workspace-down }` and `Mod+U { focus-workspace-down }` are the same shortcut in user semantics — only the trigger differs.

2. Mod+mouse gestures (commit 2): the gesture is conditional on `Mod` held; since `Mod` is a keyboard key in protocol scope, the gesture that depends on it shouldn't fire when the focused surface has requested inhibit. This covers `Mod+LMB` (interactive move), `Mod+RMB` (interactive resize), `Mod+MMB` (spatial workspace switch)

Concrete failure mode that motivates this: same niri config on two machines, bridged via Moonlight. On machine A I press `Mod+WheelDown` expecting the remote (machine B) to switch workspaces — but niri consumes the event locally, so A's workspaces change while B's don't. Same with `Mod+LMB` drag: the drag motion never reaches machine B.

Tested locally on Arch (niri 26.04 base); binary verifies against moonlight and remmina.