### PR TITLE
fix: use `active_window` for geometry calculation

### DIFF
--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -360,7 +360,10 @@ impl<W: LayoutElement> FloatingSpace<W> {
     ///
     /// During animations, assumes the final tile position.
     pub fn active_window_visual_rectangle(&self) -> Option<Rectangle<f64, Logical>> {
-        let (tile, offset) = self.tiles_with_offsets().next()?;
+        let active_id = self.active_window_id.as_ref()?;
+        let (tile, offset) = self
+            .tiles_with_offsets()
+            .find(|(tile, _)| tile.window().id() == active_id)?;
 
         let window_pos = offset + tile.window_loc();
         let window_size = tile.window_size();


### PR DESCRIPTION
Niri currently uses the topmost floating window for `warp-mouse-to-focus`. However, this conflicts with `focus-follows-mouse` since it implicitly(?) focuses on a window; it doesn't set it as topmost until you click on it, resulting in the video below

https://github.com/user-attachments/assets/da48cec5-0a04-4120-a0ae-6ab90df3475a

This PR fixes the problem by using the active window to resolve geometry

https://github.com/user-attachments/assets/5278ea47-0b11-4085-b0e6-92ad4daf54db

No tests were added; I'm not sure how to do those yet.