### PR TITLE
Avoid triggering hot corners over overlays and during picks

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2432,10 +2432,6 @@ impl State {
     }
 
     fn on_pointer_motion<I: InputBackend>(&mut self, event: I::PointerMotionEvent) {
-        let was_inside_hot_corner = self.niri.pointer_inside_hot_corner;
-        // Any of the early returns here mean that the pointer is not inside the hot corner.
-        self.niri.pointer_inside_hot_corner = false;
-
         // We need an output to be able to move the pointer.
         if self.niri.global_space.outputs().next().is_none() {
             return;
@@ -2630,6 +2626,8 @@ impl State {
                 time: event.time_msec(),
             },
         );
+        // A pointer grab may consume motion without updating the canonical location.
+        let motion_reached_target = pointer.current_location() == new_pos;
 
         pointer.relative_motion(
             self,
@@ -2645,15 +2643,14 @@ impl State {
 
         // contents_under() will return no surface when the hot corner should trigger, so
         // pointer.motion() will set the current focus to None.
-        if under.hot_corner && pointer.current_focus().is_none() {
-            if !was_inside_hot_corner
+        if under.hot_corner && motion_reached_target && pointer.current_focus().is_none() {
+            if !self.niri.is_inside_hot_corner_at(pos)
                 && pointer
                     .with_grab(|_, grab| grab_allows_hot_corner(grab))
                     .unwrap_or(true)
             {
                 self.niri.layout.toggle_overview();
             }
-            self.niri.pointer_inside_hot_corner = true;
         }
 
         // Activate a new confinement if necessary.
@@ -2683,10 +2680,6 @@ impl State {
         &mut self,
         event: I::PointerMotionAbsoluteEvent,
     ) {
-        let was_inside_hot_corner = self.niri.pointer_inside_hot_corner;
-        // Any of the early returns here mean that the pointer is not inside the hot corner.
-        self.niri.pointer_inside_hot_corner = false;
-
         let Some(pos) = self.compute_absolute_location(&event, None).or_else(|| {
             self.global_bounding_rectangle().map(|output_geo| {
                 event.position_transformed(output_geo.size) + output_geo.loc.to_f64()
@@ -2698,6 +2691,7 @@ impl State {
         let serial = SERIAL_COUNTER.next_serial();
 
         let pointer = self.niri.seat.get_pointer().unwrap();
+        let old_pos = pointer.current_location();
 
         if let Some(output) = self.niri.screenshot_ui.selection_output() {
             let geom = self.niri.global_space.output_geometry(output).unwrap();
@@ -2731,20 +2725,21 @@ impl State {
                 time: event.time_msec(),
             },
         );
+        // A pointer grab may consume motion without updating the canonical location.
+        let motion_reached_target = pointer.current_location() == pos;
 
         pointer.frame(self);
 
         // contents_under() will return no surface when the hot corner should trigger, so
         // pointer.motion() will set the current focus to None.
-        if under.hot_corner && pointer.current_focus().is_none() {
-            if !was_inside_hot_corner
+        if under.hot_corner && motion_reached_target && pointer.current_focus().is_none() {
+            if !self.niri.is_inside_hot_corner_at(old_pos)
                 && pointer
                     .with_grab(|_, grab| grab_allows_hot_corner(grab))
                     .unwrap_or(true)
             {
                 self.niri.layout.toggle_overview();
             }
-            self.niri.pointer_inside_hot_corner = true;
         }
 
         self.niri.maybe_activate_pointer_constraint();
@@ -5232,7 +5227,11 @@ fn grab_allows_hot_corner(grab: &(dyn PointerGrab<State> + 'static)) -> bool {
     // - DnDGrab allows hot corner to DnD across workspaces.
     // - ClickGrab keeps pointer focus on the window, so the hot corner doesn't trigger.
     // - Touch grabs: touch doesn't trigger the hot corner.
-    if grab.is::<ResizeGrab>() || grab.is::<SpatialMovementGrab>() {
+    if grab.is::<PickWindowGrab>()
+        || grab.is::<PickColorGrab>()
+        || grab.is::<ResizeGrab>()
+        || grab.is::<SpatialMovementGrab>()
+    {
         return false;
     }
 
@@ -5275,6 +5274,18 @@ mod tests {
 
     use super::*;
     use crate::animation::Clock;
+
+    #[test]
+    fn picker_grabs_inhibit_hot_corner() {
+        let start_data = || PointerGrabStartData::<State> {
+            focus: None,
+            button: 0,
+            location: (0., 0.).into(),
+        };
+
+        assert!(!grab_allows_hot_corner(&PickWindowGrab::new(start_data())));
+        assert!(!grab_allows_hot_corner(&PickColorGrab::new(start_data())));
+    }
 
     #[test]
     fn bindings_suppress_keys() {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2617,6 +2617,11 @@ impl State {
 
         self.niri.pointer_contents.clone_from(&under);
 
+        let hot_corner_allowed = under.hot_corner
+            && pointer
+                .with_grab(|_, grab| grab_allows_hot_corner(grab))
+                .unwrap_or(true);
+
         pointer.motion(
             self,
             under.surface.clone(),
@@ -2641,16 +2646,14 @@ impl State {
 
         pointer.frame(self);
 
-        // contents_under() will return no surface when the hot corner should trigger, so
-        // pointer.motion() will set the current focus to None.
-        if under.hot_corner && motion_reached_target && pointer.current_focus().is_none() {
-            if !self.niri.is_inside_hot_corner_at(pos)
-                && pointer
-                    .with_grab(|_, grab| grab_allows_hot_corner(grab))
-                    .unwrap_or(true)
-            {
-                self.niri.layout.toggle_overview();
-            }
+        // contents_under() returns no surface for an active hot corner, so pointer.motion() will
+        // clear the current focus.
+        if hot_corner_allowed
+            && motion_reached_target
+            && pointer.current_focus().is_none()
+            && !self.niri.is_inside_hot_corner_at(pos)
+        {
+            self.niri.layout.toggle_overview();
         }
 
         // Activate a new confinement if necessary.
@@ -2716,6 +2719,11 @@ impl State {
 
         self.niri.pointer_contents.clone_from(&under);
 
+        let hot_corner_allowed = under.hot_corner
+            && pointer
+                .with_grab(|_, grab| grab_allows_hot_corner(grab))
+                .unwrap_or(true);
+
         pointer.motion(
             self,
             under.surface,
@@ -2730,16 +2738,14 @@ impl State {
 
         pointer.frame(self);
 
-        // contents_under() will return no surface when the hot corner should trigger, so
-        // pointer.motion() will set the current focus to None.
-        if under.hot_corner && motion_reached_target && pointer.current_focus().is_none() {
-            if !self.niri.is_inside_hot_corner_at(old_pos)
-                && pointer
-                    .with_grab(|_, grab| grab_allows_hot_corner(grab))
-                    .unwrap_or(true)
-            {
-                self.niri.layout.toggle_overview();
-            }
+        // contents_under() returns no surface for an active hot corner, so pointer.motion() will
+        // clear the current focus.
+        if hot_corner_allowed
+            && motion_reached_target
+            && pointer.current_focus().is_none()
+            && !self.niri.is_inside_hot_corner_at(old_pos)
+        {
+            self.niri.layout.toggle_overview();
         }
 
         self.niri.maybe_activate_pointer_constraint();

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -369,7 +369,6 @@ pub struct Niri {
     /// Used for limiting the notify to once per iteration, so that it's not spammed with high
     /// resolution mice.
     pub notified_activity_this_iteration: bool,
-    pub pointer_inside_hot_corner: bool,
     pub pointer_constraint_position_hint: Option<Point<f64, Logical>>,
     pub tablet_cursor_location: Option<Point<f64, Logical>>,
     pub gesture_swipe_3f_cumulative: Option<(f64, f64)>,
@@ -541,7 +540,7 @@ pub struct PointContents {
     pub window: Option<(Window, HitType)>,
     // If surface belongs to a layer surface, this is that layer surface.
     pub layer: Option<LayerSurface>,
-    // Pointer is over a hot corner.
+    // The hot corner wins the input hit test at this point.
     pub hot_corner: bool,
 }
 
@@ -2610,7 +2609,6 @@ impl Niri {
             pointer_inactivity_timer: None,
             pointer_inactivity_timer_got_reset: false,
             notified_activity_this_iteration: false,
-            pointer_inside_hot_corner: false,
             pointer_constraint_position_hint: None,
             tablet_cursor_location: None,
             gesture_swipe_3f_cumulative: None,
@@ -3131,6 +3129,11 @@ impl Niri {
         false
     }
 
+    pub(crate) fn is_inside_hot_corner_at(&self, pos: Point<f64, Logical>) -> bool {
+        self.output_under(pos)
+            .is_some_and(|(output, pos)| self.is_inside_hot_corner(output, pos))
+    }
+
     pub fn is_sticky_obscured_under(
         &self,
         output: &Output,
@@ -3451,7 +3454,9 @@ impl Niri {
                 .or_else(|| layer_toplevel_under(Layer::Bottom))
                 .or_else(|| layer_toplevel_under(Layer::Background));
         } else {
-            if self.is_inside_hot_corner(output, pos_within_output) {
+            // An input-interactive overlay is above the hot corner. Let it own the pointer while
+            // preserving the hot corner over regular top-layer panels and widgets.
+            if self.is_inside_hot_corner(output, pos_within_output) && under.is_none() {
                 rv.hot_corner = true;
                 return rv;
             }

--- a/src/tests/layer_shell.rs
+++ b/src/tests/layer_shell.rs
@@ -8,6 +8,44 @@ use super::*;
 use crate::tests::client::{LayerConfigureProps, LayerMargin};
 
 #[test]
+fn hot_corner_respects_layer_surface_ordering() {
+    let mut f = Fixture::new();
+    f.add_output(1, (1920, 1080));
+    let id = f.add_client();
+
+    let layer = f.client(id).create_layer(None, Layer::Top, "");
+    let surface = layer.surface.clone();
+    layer.set_configure_props(LayerConfigureProps {
+        size: Some((1920, 1080)),
+        ..Default::default()
+    });
+    layer.commit();
+    f.double_roundtrip(id);
+
+    let layer = f.client(id).layer(&surface);
+    layer.attach_new_buffer();
+    layer.set_size(1920, 1080);
+    layer.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    let under = f.niri().contents_under((0.5, 0.5).into());
+    assert!(under.hot_corner);
+    assert!(under.surface.is_none());
+
+    let layer = f.client(id).layer(&surface);
+    layer.set_configure_props(LayerConfigureProps {
+        layer: Some(Layer::Overlay),
+        ..Default::default()
+    });
+    layer.commit();
+    f.double_roundtrip(id);
+
+    let under = f.niri().contents_under((0.5, 0.5).into());
+    assert!(!under.hot_corner);
+    assert!(under.surface.is_some());
+}
+
+#[test]
 fn simple_top_anchor() {
     let mut f = Fixture::new();
     f.add_output(1, (1920, 1080));


### PR DESCRIPTION
I ran into this while working on my screenshot tool. It uses a fullscreen layer-shell overlay for interactive selection. Moving the pointer into a hot corner opened the overview behind the overlay, which only became visible after the tool exited.

this makes input-interactive Overlay layer surfaces take precedence over hot corners, while preserving the existing behavior for top layer panels and widgets. It also inhibits hot corners during window and color picker grabs and prevents delayed activation after an overlay or grab disappears.

fixes #4401. Tests generated by GPT 5.6-Sol under my guidance.
