### PR TITLE
niri-session: fix shellcheck warnings

### DIFF
--- a/resources/niri-session
+++ b/resources/niri-session
@@ -77,15 +77,15 @@ elif hash dinitctl >/dev/null 2>&1; then
     fi
 
     # Create the directory for the logfile, if doesn't exist
-    mkdir --parents $HOME/.local/share/niri
+    mkdir --parents "$HOME/.local/share/niri"
     # Start niri
     dinitctl --quiet --user start niri.target 2>&1
 
     # Wait for termination
-    dinit-monitor --user --initial -c $'sh -c " 
+    dinit-monitor --user --initial -c 'sh -c "
         if [ "%s" = "stopped" ] || [ "%s" = "failed" ]; then
             ppid=$(ps -o ppid= -p $$)
-            kill $ppid
+            kill "$ppid"
         fi"' niri >/dev/null 2>&1
 
     # Unset environment that we've set.


### PR DESCRIPTION
[ANSI-C strings](https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html) like `$''` are Bash-only. The one in niri-session can be replaced with an ordinary single-quoted string because it contains no backslash escapes.