### PR TITLE
Inset window borders/focus rings

### DIFF
--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -300,7 +300,7 @@ layout {
 
 Set the thickness of the border in logical pixels.
 
-You can use `is-inset` to have the border draw into and over the window content instead of outwards. The window and content size remains the same, but the border is drawn over the edge of the window content. This can be used to, for example, draw a transparent trim over the edges of the window content, as Adwaita apps do.
+You can use `is-inset` to have the border draw into and over the window content instead of outwards. The window and content size remains the same, but the border is composited over the window content. This can be used to, for example, draw a transparent trim around the edge of a window as Adwaita apps do.
 
 <sup>Since: 0.1.7</sup> You can use fractional values.
 The value will be rounded to physical pixels according to the scale factor of every output.

--- a/docs/wiki/Configuration:-Layout.md
+++ b/docs/wiki/Configuration:-Layout.md
@@ -281,6 +281,8 @@ layout {
 
         // Width of the border in logical pixels.
         width 4
+        // Draw the border inside the window.
+        // is-inset
 
         active-color "#ffc87f"
         inactive-color "#505050"
@@ -297,6 +299,8 @@ layout {
 #### Width
 
 Set the thickness of the border in logical pixels.
+
+You can use `is-inset` to have the border draw into and over the window content instead of outwards. The window and content size remains the same, but the border is drawn over the edge of the window content. This can be used to, for example, draw a transparent trim over the edges of the window content, as Adwaita apps do.
 
 <sup>Since: 0.1.7</sup> You can use fractional values.
 The value will be rounded to physical pixels according to the scale factor of every output.

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -228,10 +228,70 @@ impl CornerRadius {
     }
 }
 
+/// Width of a [`Border`], extending either out of or into its contents.
+///
+/// If you are writing layout code which calculates the size of some content
+/// with a border:
+/// - [`BorderWidth::Inset`] should be treated as no border, keeping content
+///   size the same
+/// - [`BorderWidth::Outset`] should be treated as a border which decreases the
+///   content size
+///   - use [`BorderWidth::outset`] to get the outset width, or 0 if it's an inset
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BorderWidth {
+    /// Border extends into the content, and draws over it.
+    Inset(f64),
+    /// Border extends out of the content.
+    Outset(f64),
+}
+
+impl BorderWidth {
+    pub fn outset(self) -> f64 {
+        match self {
+            Self::Inset(_) => 0.,
+            Self::Outset(width) => width,
+        }
+    }
+
+    pub fn is_inset(self) -> bool {
+        matches!(self, Self::Inset(_))
+    }
+
+    pub fn is_outset(self) -> bool {
+        matches!(self, Self::Outset(_))
+    }
+
+    fn with_value(self, width: f64) -> Self {
+        match self {
+            Self::Inset(_) => Self::Inset(width),
+            Self::Outset(_) => Self::Outset(width),
+        }
+    }
+
+    fn with_is_inset(self, is_inset: bool) -> Self {
+        let width = match self {
+            Self::Inset(width) | Self::Outset(width) => width,
+        };
+
+        if is_inset {
+            Self::Inset(width)
+        } else {
+            Self::Outset(width)
+        }
+    }
+
+    pub fn map(self, f: impl FnOnce(f64) -> f64) -> Self {
+        match self {
+            Self::Inset(width) => Self::Inset(f(width)),
+            Self::Outset(width) => Self::Outset(f(width)),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FocusRing {
     pub off: bool,
-    pub width: f64,
+    pub width: BorderWidth,
     pub active_color: Color,
     pub inactive_color: Color,
     pub urgent_color: Color,
@@ -244,7 +304,7 @@ impl Default for FocusRing {
     fn default() -> Self {
         Self {
             off: false,
-            width: 4.,
+            width: BorderWidth::Outset(4.),
             active_color: Color::from_rgba8_unpremul(127, 200, 255, 255),
             inactive_color: Color::from_rgba8_unpremul(80, 80, 80, 255),
             urgent_color: Color::from_rgba8_unpremul(155, 0, 0, 255),
@@ -258,7 +318,7 @@ impl Default for FocusRing {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Border {
     pub off: bool,
-    pub width: f64,
+    pub width: BorderWidth,
     pub active_color: Color,
     pub inactive_color: Color,
     pub urgent_color: Color,
@@ -271,7 +331,7 @@ impl Default for Border {
     fn default() -> Self {
         Self {
             off: true,
-            width: 4.,
+            width: BorderWidth::Outset(4.),
             active_color: Color::from_rgba8_unpremul(255, 200, 127, 255),
             inactive_color: Color::from_rgba8_unpremul(80, 80, 80, 255),
             urgent_color: Color::from_rgba8_unpremul(155, 0, 0, 255),
@@ -319,7 +379,12 @@ impl MergeWith<BorderRule> for Border {
             self.off = false;
         }
 
-        merge!((self, part), width);
+        if let Some(width) = part.width {
+            self.width = self.width.with_value(width.0);
+        }
+        if let Some(is_inset) = part.is_inset {
+            self.width = self.width.with_is_inset(is_inset);
+        }
 
         merge_color_gradient!(
             (self, part),
@@ -630,6 +695,8 @@ pub struct BorderRule {
     pub on: bool,
     #[knuffel(child, unwrap(argument))]
     pub width: Option<FloatOrInt<0, 65535>>,
+    #[knuffel(child, unwrap(argument))]
+    pub is_inset: Option<bool>,
     #[knuffel(child)]
     pub active_color: Option<Color>,
     #[knuffel(child)]
@@ -684,7 +751,7 @@ impl MergeWith<Self> for BorderRule {
     fn merge_with(&mut self, part: &Self) {
         merge_on_off!((self, part));
 
-        merge_clone_opt!((self, part), width);
+        merge_clone_opt!((self, part), width, is_inset);
 
         merge_color_gradient_opt!(
             (self, part),

--- a/niri-config/src/appearance.rs
+++ b/niri-config/src/appearance.rs
@@ -234,8 +234,8 @@ impl CornerRadius {
 /// with a border:
 /// - [`BorderWidth::Inset`] should be treated as no border, keeping content
 ///   size the same
-/// - [`BorderWidth::Outset`] should be treated as a border which decreases the
-///   content size
+/// - [`BorderWidth::Outset`] should be treated as extra padding which shrinks
+///   the actual content size
 ///   - use [`BorderWidth::outset`] to get the outset width, or 0 if it's an inset
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BorderWidth {
@@ -246,6 +246,12 @@ pub enum BorderWidth {
 }
 
 impl BorderWidth {
+    pub fn pixels(self) -> f64 {
+        match self {
+            Self::Inset(width) | Self::Outset(width) => width,
+        }
+    }
+
     pub fn outset(self) -> f64 {
         match self {
             Self::Inset(_) => 0.,
@@ -269,9 +275,7 @@ impl BorderWidth {
     }
 
     fn with_is_inset(self, is_inset: bool) -> Self {
-        let width = match self {
-            Self::Inset(width) | Self::Outset(width) => width,
-        };
+        let width = self.pixels();
 
         if is_inset {
             Self::Inset(width)

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1281,7 +1281,9 @@ mod tests {
             layout: Layout {
                 focus_ring: FocusRing {
                     off: false,
-                    width: 5.0,
+                    width: Outset(
+                        5.0,
+                    ),
                     active_color: Color {
                         r: 0.0,
                         g: 0.39215687,
@@ -1327,7 +1329,9 @@ mod tests {
                 },
                 border: Border {
                     off: false,
-                    width: 3.0,
+                    width: Outset(
+                        3.0,
+                    ),
                     active_color: Color {
                         r: 1.0,
                         g: 0.78431374,
@@ -1813,6 +1817,7 @@ mod tests {
                                 3.0,
                             ),
                         ),
+                        is_inset: None,
                         active_color: None,
                         inactive_color: None,
                         urgent_color: None,
@@ -1828,6 +1833,7 @@ mod tests {
                                 8.5,
                             ),
                         ),
+                        is_inset: None,
                         active_color: None,
                         inactive_color: None,
                         urgent_color: None,

--- a/niri-visual-tests/src/cases/gradient_area.rs
+++ b/niri-visual-tests/src/cases/gradient_area.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use niri::layout::focus_ring::FocusRing;
 use niri::render_helpers::border::BorderRenderElement;
-use niri_config::{Color, CornerRadius, GradientInterpolation};
+use niri_config::{BorderWidth, Color, CornerRadius, GradientInterpolation};
 use smithay::backend::renderer::element::RenderElement;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Physical, Point, Rectangle, Size};
@@ -20,7 +20,7 @@ impl GradientArea {
     pub fn new(_args: Args) -> Self {
         let border = FocusRing::new(niri_config::FocusRing {
             off: false,
-            width: 1.,
+            width: BorderWidth::Outset(1.),
             active_color: Color::from_rgba8_unpremul(255, 255, 255, 128),
             inactive_color: Color::default(),
             urgent_color: Color::default(),

--- a/niri-visual-tests/src/cases/layout.rs
+++ b/niri-visual-tests/src/cases/layout.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use niri::animation::Clock;
 use niri::layout::{ActivateWindow, AddWindowTarget, LayoutElement as _, Options, SizingMode};
 use niri::render_helpers::{RenderCtx, RenderTarget};
-use niri_config::{Color, OutputName, PresetSize};
+use niri_config::{BorderWidth, Color, OutputName, PresetSize};
 use smithay::backend::renderer::element::RenderElement;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::desktop::layer_map_for_output;
@@ -59,7 +59,7 @@ impl Layout {
                 },
                 border: niri_config::Border {
                     off: false,
-                    width: 4.,
+                    width: BorderWidth::Outset(4.),
                     active_color: Color::from_rgba8_unpremul(255, 163, 72, 255),
                     inactive_color: Color::from_rgba8_unpremul(50, 50, 50, 255),
                     urgent_color: Color::from_rgba8_unpremul(155, 0, 0, 255),

--- a/niri-visual-tests/src/cases/tile.rs
+++ b/niri-visual-tests/src/cases/tile.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use niri::layout::Options;
 use niri::render_helpers::xray::XrayPos;
 use niri::render_helpers::{RenderCtx, RenderTarget};
-use niri_config::Color;
+use niri_config::{BorderWidth, Color};
 use smithay::backend::renderer::element::RenderElement;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::utils::{Physical, Point, Rectangle, Size};
@@ -66,7 +66,7 @@ impl Tile {
                 },
                 border: niri_config::Border {
                     off: false,
-                    width: 32.,
+                    width: BorderWidth::Outset(32.),
                     active_color: Color::from_rgba8_unpremul(255, 163, 72, 255),
                     ..Default::default()
                 },

--- a/src/layout/floating.rs
+++ b/src/layout/floating.rs
@@ -1265,13 +1265,14 @@ impl<W: LayoutElement> FloatingSpace<W> {
         rules: &ResolvedWindowRules,
     ) -> Size<i32, Logical> {
         let border = self.options.layout.border.merged_with(&rules.border);
+        let border_width = border.width.outset();
 
         let resolve = |size: Option<PresetSize>, working_area_size: f64| {
             if let Some(size) = size {
                 let size = match resolve_preset_size(size, working_area_size) {
                     ResolvedSize::Tile(mut size) => {
                         if !border.off {
-                            size -= border.width * 2.;
+                            size -= border_width * 2.;
                         }
                         size
                     }
@@ -1412,7 +1413,7 @@ fn compute_toplevel_bounds(
 ) -> Size<i32, Logical> {
     let mut border = 0.;
     if !border_config.off {
-        border = border_config.width * 2.;
+        border = border_config.width.outset() * 2.;
     }
 
     Size::from((

--- a/src/layout/focus_ring.rs
+++ b/src/layout/focus_ring.rs
@@ -223,7 +223,7 @@ impl FocusRing {
         } else {
             self.sizes[0] = self.full_size;
             self.buffers[0].resize(self.sizes[0]);
-            self.locations[0] = Point::from((-width, -width)) + offset;
+            self.locations[0] = offset + Point::from((-width, -width));
 
             self.borders[0].update(
                 self.sizes[0],
@@ -252,9 +252,7 @@ impl FocusRing {
         }
 
         // If drawing as a border with width = 0, then there's nothing to draw.
-        let width = match self.config.width {
-            BorderWidth::Inset(width) | BorderWidth::Outset(width) => width,
-        };
+        let width = self.config.width.pixels();
         if self.draw_as_border && width == 0. {
             return;
         }

--- a/src/layout/focus_ring.rs
+++ b/src/layout/focus_ring.rs
@@ -1,6 +1,6 @@
 use std::iter::zip;
 
-use niri_config::{CornerRadius, Gradient, GradientRelativeTo};
+use niri_config::{BorderWidth, CornerRadius, Gradient, GradientRelativeTo};
 use smithay::backend::renderer::element::{Element as _, Kind};
 use smithay::utils::{Logical, Point, Rectangle, Size};
 
@@ -16,7 +16,7 @@ pub struct FocusRing {
     sizes: [Size<f64, Logical>; 8],
     borders: [BorderRenderElement; 8],
     full_size: Size<f64, Logical>,
-    is_border: bool,
+    draw_as_border: bool,
     use_border_shader: bool,
     config: niri_config::FocusRing,
     thicken_corners: bool,
@@ -37,7 +37,7 @@ impl FocusRing {
             sizes: Default::default(),
             borders: Default::default(),
             full_size: Default::default(),
-            is_border: false,
+            draw_as_border: false,
             use_border_shader: false,
             config,
             thicken_corners: true,
@@ -66,9 +66,31 @@ impl FocusRing {
         scale: f64,
         alpha: f32,
     ) {
-        let width = self.config.width;
-        self.full_size = win_size + Size::from((width, width)).upscale(2.);
-        self.is_border = is_border;
+        // `width`: the actual pixel width of the border, not counting
+        //     inset/outset - always >= 0
+        // `inset`: how far inwards into the window content we move the border
+        //     drawing algorithm
+        // `inner_size`: size of content completely uncovered by the border;
+        //     may be smaller than `win_size` if we draw the border *over* some of
+        //     the content
+        let (width, inset, is_inset) = match self.config.width {
+            BorderWidth::Inset(width) => {
+                // border exists inside the window content;
+                // it must not be bigger than the window size
+                let width = width.min(win_size.w / 2.).min(win_size.h / 2.);
+                (width, width, true)
+            }
+            BorderWidth::Outset(width) => {
+                // border exists outside the window content
+                (width, 0., false)
+            }
+        };
+        let inner_size = win_size - Size::from((inset, inset)).upscale(2.);
+        let offset = Point::from((inset, inset));
+
+        self.full_size = inner_size + Size::from((width, width)).upscale(2.);
+        let draw_as_border = is_border || is_inset;
+        self.draw_as_border = draw_as_border;
 
         let color = if is_urgent {
             self.config.urgent_color
@@ -97,13 +119,13 @@ impl FocusRing {
         // Set the defaults for solid color + rounded corners.
         let gradient = gradient.unwrap_or_else(|| Gradient::from(color));
 
-        let full_rect = Rectangle::new(Point::from((-width, -width)), self.full_size);
+        let full_rect = Rectangle::new(Point::from((-width, -width)) + offset, self.full_size);
         let gradient_area = match gradient.relative_to {
             GradientRelativeTo::Window => full_rect,
             GradientRelativeTo::WorkspaceView => view_rect,
         };
 
-        let rounded_corner_border_width = if is_border {
+        let rounded_corner_border_width = if draw_as_border {
             // HACK: increase the border width used for the inner rounded corners a tiny bit to
             // reduce background bleed.
             let extra = if self.thicken_corners { 0.5 } else { 0. };
@@ -121,7 +143,7 @@ impl FocusRing {
         // * We do not divide anything, only add, subtract and multiply by integers.
         // * At rendering time, tile positions are rounded to physical pixels.
 
-        if is_border {
+        if draw_as_border {
             let top_left = f64::max(width, ceil(f64::from(radius.top_left)));
             let top_right = f64::min(
                 self.full_size.w - top_left,
@@ -140,40 +162,44 @@ impl FocusRing {
             );
 
             // Top edge.
-            self.sizes[0] = Size::from((win_size.w + width * 2. - top_left - top_right, width));
-            self.locations[0] = Point::from((-width + top_left, -width));
+            self.sizes[0] = Size::from((inner_size.w + width * 2. - top_left - top_right, width));
+            self.locations[0] = offset + Point::from((-width + top_left, -width));
 
             // Bottom edge.
-            self.sizes[1] =
-                Size::from((win_size.w + width * 2. - bottom_left - bottom_right, width));
-            self.locations[1] = Point::from((-width + bottom_left, win_size.h));
+            self.sizes[1] = Size::from((
+                inner_size.w + width * 2. - bottom_left - bottom_right,
+                width,
+            ));
+            self.locations[1] = offset + Point::from((-width + bottom_left, inner_size.h));
 
             // Left edge.
-            self.sizes[2] = Size::from((width, win_size.h + width * 2. - top_left - bottom_left));
-            self.locations[2] = Point::from((-width, -width + top_left));
+            self.sizes[2] = Size::from((width, inner_size.h + width * 2. - top_left - bottom_left));
+            self.locations[2] = offset + Point::from((-width, -width + top_left));
 
             // Right edge.
-            self.sizes[3] = Size::from((width, win_size.h + width * 2. - top_right - bottom_right));
-            self.locations[3] = Point::from((win_size.w, -width + top_right));
+            self.sizes[3] =
+                Size::from((width, inner_size.h + width * 2. - top_right - bottom_right));
+            self.locations[3] = offset + Point::from((inner_size.w, -width + top_right));
 
             // Top-left corner.
             self.sizes[4] = Size::from((top_left, top_left));
-            self.locations[4] = Point::from((-width, -width));
+            self.locations[4] = offset + Point::from((-width, -width));
 
             // Top-right corner.
             self.sizes[5] = Size::from((top_right, top_right));
-            self.locations[5] = Point::from((win_size.w + width - top_right, -width));
+            self.locations[5] = offset + Point::from((inner_size.w + width - top_right, -width));
 
             // Bottom-right corner.
             self.sizes[6] = Size::from((bottom_right, bottom_right));
-            self.locations[6] = Point::from((
-                win_size.w + width - bottom_right,
-                win_size.h + width - bottom_right,
-            ));
+            self.locations[6] = offset
+                + Point::from((
+                    inner_size.w + width - bottom_right,
+                    inner_size.h + width - bottom_right,
+                ));
 
             // Bottom-left corner.
             self.sizes[7] = Size::from((bottom_left, bottom_left));
-            self.locations[7] = Point::from((-width, win_size.h + width - bottom_left));
+            self.locations[7] = offset + Point::from((-width, inner_size.h + width - bottom_left));
 
             for (buf, size) in zip(&mut self.buffers, self.sizes) {
                 buf.resize(size);
@@ -197,7 +223,7 @@ impl FocusRing {
         } else {
             self.sizes[0] = self.full_size;
             self.buffers[0].resize(self.sizes[0]);
-            self.locations[0] = Point::from((-width, -width));
+            self.locations[0] = Point::from((-width, -width)) + offset;
 
             self.borders[0].update(
                 self.sizes[0],
@@ -225,10 +251,11 @@ impl FocusRing {
             return;
         }
 
-        let border_width = -self.locations[0].y;
-
         // If drawing as a border with width = 0, then there's nothing to draw.
-        if self.is_border && border_width == 0. {
+        let width = match self.config.width {
+            BorderWidth::Inset(width) | BorderWidth::Outset(width) => width,
+        };
+        if self.draw_as_border && width == 0. {
             return;
         }
 
@@ -245,7 +272,7 @@ impl FocusRing {
             push(elem);
         };
 
-        if self.is_border {
+        if self.draw_as_border {
             for ((buf, border), loc) in zip(zip(&self.buffers, &self.borders), self.locations) {
                 push(buf, border, location + loc);
             }
@@ -258,7 +285,7 @@ impl FocusRing {
         }
     }
 
-    pub fn width(&self) -> f64 {
+    pub fn width(&self) -> BorderWidth {
         self.config.width
     }
 

--- a/src/layout/insert_hint_element.rs
+++ b/src/layout/insert_hint_element.rs
@@ -1,4 +1,4 @@
-use niri_config::CornerRadius;
+use niri_config::{BorderWidth, CornerRadius};
 use smithay::utils::{Logical, Point, Rectangle, Size};
 
 use super::focus_ring::{FocusRing, FocusRingRenderElement};
@@ -16,7 +16,7 @@ impl InsertHintElement {
         Self {
             inner: FocusRing::new(niri_config::FocusRing {
                 off: config.off,
-                width: 0.,
+                width: BorderWidth::Outset(0.),
                 active_color: config.color,
                 inactive_color: config.color,
                 urgent_color: config.color,
@@ -30,7 +30,7 @@ impl InsertHintElement {
     pub fn update_config(&mut self, config: niri_config::InsertHint) {
         self.inner.update_config(niri_config::FocusRing {
             off: config.off,
-            width: 0.,
+            width: BorderWidth::Outset(0.),
             active_color: config.color,
             inactive_color: config.color,
             urgent_color: config.color,

--- a/src/layout/scrolling.rs
+++ b/src/layout/scrolling.rs
@@ -532,12 +532,13 @@ impl<W: LayoutElement> ScrollingSpace<W> {
         };
 
         let working_size = self.working_area.size;
+        let border_width = border.width.outset();
 
         let width = if let Some(size) = width {
             let size = match resolve_preset_size(size, &self.options, working_size.w, extra.w) {
                 ResolvedSize::Tile(mut size) => {
                     if !border.off {
-                        size -= border.width * 2.;
+                        size -= border_width * 2.;
                     }
                     size
                 }
@@ -551,14 +552,14 @@ impl<W: LayoutElement> ScrollingSpace<W> {
 
         let mut full_height = self.working_area.size.h - self.options.layout.gaps * 2.;
         if !border.off {
-            full_height -= border.width * 2.;
+            full_height -= border_width * 2.;
         }
 
         let height = if let Some(height) = height {
             let height = match resolve_preset_size(height, &self.options, working_size.h, extra.h) {
                 ResolvedSize::Tile(mut size) => {
                     if !border.off {
-                        size -= border.width * 2.;
+                        size -= border_width * 2.;
                     }
                     size
                 }
@@ -5657,7 +5658,7 @@ fn compute_toplevel_bounds(
 ) -> Size<i32, Logical> {
     let mut border = 0.;
     if !border_config.off {
-        border = border_config.width * 2.;
+        border = border_config.width.outset() * 2.;
     }
 
     Size::from((

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -3,8 +3,8 @@ use std::cell::{Cell, OnceCell, RefCell};
 use niri_config::utils::{Flag, MergeWith as _};
 use niri_config::workspace::WorkspaceName;
 use niri_config::{
-    CenterFocusedColumn, FloatOrInt, OutputName, Struts, TabIndicatorLength, TabIndicatorPosition,
-    WorkspaceReference,
+    BorderWidth, CenterFocusedColumn, FloatOrInt, OutputName, Struts, TabIndicatorLength,
+    TabIndicatorPosition, WorkspaceReference,
 };
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -2156,7 +2156,7 @@ fn large_negative_height_change() {
 
     let mut options = Options::default();
     options.layout.border.off = false;
-    options.layout.border.width = 1.;
+    options.layout.border.width = BorderWidth::Outset(1.);
 
     check_ops_with_options(options, ops);
 }
@@ -2175,7 +2175,7 @@ fn large_max_size() {
 
     let mut options = Options::default();
     options.layout.border.off = false;
-    options.layout.border.width = 1.;
+    options.layout.border.width = BorderWidth::Outset(1.);
 
     check_ops_with_options(options, ops);
 }
@@ -2388,7 +2388,7 @@ fn config_change_updates_cached_sizes() {
     let mut config = Config::default();
     let border = &mut config.layout.border;
     border.off = false;
-    border.width = 2.;
+    border.width = BorderWidth::Outset(2.);
 
     let mut layout = Layout::new(Clock::default(), &config);
 
@@ -2400,7 +2400,7 @@ fn config_change_updates_cached_sizes() {
     }
     .apply(&mut layout);
 
-    config.layout.border.width = 4.;
+    config.layout.border.width = BorderWidth::Outset(4.);
     layout.update_config(&config);
 
     layout.verify_invariants();
@@ -2520,7 +2520,7 @@ fn fixed_height_takes_max_non_auto_into_account() {
         layout: niri_config::Layout {
             border: niri_config::Border {
                 off: false,
-                width: 4.,
+                width: BorderWidth::Outset(4.),
                 ..Default::default()
             },
             gaps: 0.,
@@ -3366,7 +3366,7 @@ fn preset_column_width_fixed_correct_with_border() {
             preset_column_widths: vec![PresetSize::Fixed(500)],
             border: niri_config::Border {
                 off: false,
-                width: 5.,
+                width: BorderWidth::Outset(5.),
                 ..Default::default()
             },
             ..Default::default()

--- a/src/layout/tests/fullscreen.rs
+++ b/src/layout/tests/fullscreen.rs
@@ -191,7 +191,7 @@ fn unfullscreen_with_large_border() {
         layout: niri_config::Layout {
             border: niri_config::Border {
                 off: false,
-                width: 10000.,
+                width: BorderWidth::Outset(10000.),
                 ..Default::default()
             },
             ..Default::default()

--- a/src/layout/tile.rs
+++ b/src/layout/tile.rs
@@ -242,7 +242,7 @@ impl<W: LayoutElement> Tile<W> {
         let rules = self.window.rules();
 
         let mut border_config = self.options.layout.border.merged_with(&rules.border);
-        border_config.width = round_max1(border_config.width);
+        border_config.width = border_config.width.map(round_max1);
         self.border.update_config(border_config.into());
 
         let mut focus_ring_config = self
@@ -250,7 +250,7 @@ impl<W: LayoutElement> Tile<W> {
             .layout
             .focus_ring
             .merged_with(&rules.focus_ring);
-        focus_ring_config.width = round_max1(focus_ring_config.width);
+        focus_ring_config.width = focus_ring_config.width.map(round_max1);
         self.focus_ring.update_config(focus_ring_config);
 
         let shadow_config = self.options.layout.shadow.merged_with(&rules.shadow);
@@ -287,7 +287,7 @@ impl<W: LayoutElement> Tile<W> {
                     tile_size.w = f64::max(tile_size.w, self.view_size.w);
                     tile_size.h = f64::max(tile_size.h, self.view_size.h);
                 } else if prev_sizing_mode.is_normal() && !self.border.is_off() {
-                    let width = self.border.width();
+                    let width = self.border.width().outset();
                     tile_size.w += width * 2.;
                     tile_size.h += width * 2.;
                 }
@@ -326,7 +326,7 @@ impl<W: LayoutElement> Tile<W> {
                     tile_size.w = f64::max(tile_size.w, self.view_size.w);
                     tile_size.h = f64::max(tile_size.h, self.view_size.h);
                 } else if prev_sizing_mode.is_normal() && !self.border.is_off() {
-                    let width = self.border.width();
+                    let width = self.border.width().outset();
                     tile_size.w += width * 2.;
                     tile_size.h += width * 2.;
                 }
@@ -392,7 +392,7 @@ impl<W: LayoutElement> Tile<W> {
 
         let rules = self.window.rules();
         let mut border_config = self.options.layout.border.merged_with(&rules.border);
-        border_config.width = round_max1(border_config.width);
+        border_config.width = border_config.width.map(round_max1);
         self.border.update_config(border_config.into());
 
         let mut focus_ring_config = self
@@ -400,7 +400,7 @@ impl<W: LayoutElement> Tile<W> {
             .layout
             .focus_ring
             .merged_with(&rules.focus_ring);
-        focus_ring_config.width = round_max1(focus_ring_config.width);
+        focus_ring_config.width = focus_ring_config.width.map(round_max1);
         self.focus_ring.update_config(focus_ring_config);
 
         let shadow_config = self.options.layout.shadow.merged_with(&rules.shadow);
@@ -538,7 +538,7 @@ impl<W: LayoutElement> Tile<W> {
         } else {
             false
         };
-        let radius = radius.expanded_by(self.focus_ring.width() as f32);
+        let radius = radius.expanded_by(self.focus_ring.width().outset() as f32);
         self.focus_ring.update_render_elements(
             animated_tile_size,
             is_active,
@@ -752,7 +752,7 @@ impl<W: LayoutElement> Tile<W> {
             return None;
         }
 
-        Some(self.border.width())
+        Some(self.border.width().outset())
     }
 
     fn visual_border_width(&self) -> Option<f64> {
@@ -771,7 +771,7 @@ impl<W: LayoutElement> Tile<W> {
         // fullscreening, but the rest of the code isn't quite ready for that yet. It needs to
         // handle things like computing intermediate tile size when an animated resize starts during
         // an animated unfullscreen resize.
-        Some(self.border.width())
+        Some(self.border.width().outset())
     }
 
     /// Returns the location of the window's visual geometry within this Tile.
@@ -943,7 +943,7 @@ impl<W: LayoutElement> Tile<W> {
     ) {
         // Can't go through effective_border_width() because we might be fullscreen.
         if !self.border.is_off() {
-            let width = self.border.width();
+            let width = self.border.width().outset();
             size.w = f64::max(1., size.w - width * 2.);
             size.h = f64::max(1., size.h - width * 2.);
         }
@@ -963,7 +963,7 @@ impl<W: LayoutElement> Tile<W> {
         if self.border.is_off() {
             size
         } else {
-            size + self.border.width() * 2.
+            size + self.border.width().outset() * 2.
         }
     }
 
@@ -971,7 +971,7 @@ impl<W: LayoutElement> Tile<W> {
         if self.border.is_off() {
             size
         } else {
-            size + self.border.width() * 2.
+            size + self.border.width().outset() * 2.
         }
     }
 
@@ -979,7 +979,7 @@ impl<W: LayoutElement> Tile<W> {
         if self.border.is_off() {
             size
         } else {
-            size - self.border.width() * 2.
+            size - self.border.width().outset() * 2.
         }
     }
 
@@ -987,7 +987,7 @@ impl<W: LayoutElement> Tile<W> {
         if self.border.is_off() {
             size
         } else {
-            size - self.border.width() * 2.
+            size - self.border.width().outset() * 2.
         }
     }
 
@@ -1019,7 +1019,7 @@ impl<W: LayoutElement> Tile<W> {
 
         // Can't go through effective_border_width() because we might be fullscreen.
         if !self.border.is_off() {
-            let width = self.border.width();
+            let width = self.border.width().outset();
 
             size.w = f64::max(1., size.w);
             size.h = f64::max(1., size.h);
@@ -1036,7 +1036,7 @@ impl<W: LayoutElement> Tile<W> {
 
         // Can't go through effective_border_width() because we might be fullscreen.
         if !self.border.is_off() {
-            let width = self.border.width();
+            let width = self.border.width().outset();
 
             if size.w > 0. {
                 size.w += width * 2.;
@@ -1121,6 +1121,17 @@ impl<W: LayoutElement> Tile<W> {
             xray_pos,
             &mut |elem| push(elem.into()),
         );
+
+        // If border/focus ring are inset, then they render after window contents
+        // (so that they're overlaid on top)
+        if self.border.width().is_inset() && self.visual_border_width().is_some() {
+            self.border
+                .render(ctx.renderer, location, &mut |elem| push(elem.into()));
+        }
+        if focus_ring && expanded_progress < 1. && self.focus_ring.width().is_inset() {
+            self.focus_ring
+                .render(ctx.renderer, location, &mut |elem| push(elem.into()));
+        }
 
         // If we're resizing, try to render a shader, or a fallback.
         let mut pushed_resize = false;
@@ -1317,7 +1328,14 @@ impl<W: LayoutElement> Tile<W> {
             }
         }
 
-        if let Some(width) = self.visual_border_width() {
+        // Border/focus ring only render at this point if they're outsets, so
+        // that they render below the content; if they're insets, they sit
+        // on top.
+        // TODO: replace with let-chain in Rust 2024
+        if let Some(width) = self
+            .visual_border_width()
+            .filter(|_| self.border.width().is_outset())
+        {
             self.border.render(
                 ctx.renderer,
                 location + Point::from((width, width)),
@@ -1329,7 +1347,7 @@ impl<W: LayoutElement> Tile<W> {
         // being outside the monitor or obscured by a solid colored bar, but it is visible under
         // semitransparent bars in maximized state (which is a bit weird) and in the overview (also
         // a bit weird).
-        if focus_ring && expanded_progress < 1. {
+        if focus_ring && expanded_progress < 1. && self.focus_ring.width().is_outset() {
             self.focus_ring
                 .render(ctx.renderer, location, &mut |elem| push(elem.into()));
         }

--- a/src/layout/workspace.rs
+++ b/src/layout/workspace.rs
@@ -898,7 +898,7 @@ impl<W: LayoutElement> Workspace<W> {
                 let rules = window.rules();
                 let border = self.options.layout.border.merged_with(&rules.border);
                 if !border.off {
-                    fixed += border.width * 2.;
+                    fixed += border.width.outset() * 2.;
                 }
 
                 ColumnWidth::Fixed(fixed)

--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use anyhow::ensure;
 use niri_config::{
-    Action, Bind, Color, Config, CornerRadius, GradientInterpolation, Key, Modifiers, MruDirection,
-    MruFilter, MruScope, Trigger,
+    Action, Bind, BorderWidth, Color, Config, CornerRadius, GradientInterpolation, Key, Modifiers,
+    MruDirection, MruFilter, MruScope, Trigger,
 };
 use pango::FontDescription;
 use pangocairo::cairo::{self, ImageSurface};
@@ -235,7 +235,7 @@ impl Thumbnail {
 
         let background = FocusRing::new(niri_config::FocusRing {
             off: false,
-            width: 0.,
+            width: BorderWidth::Outset(0.),
             active_gradient: None,
             ..Default::default()
         });
@@ -546,7 +546,8 @@ impl Thumbnail {
             let mut border = self.border.borrow_mut();
             let mut config = *border.config();
             config.off = !is_active;
-            config.width = round(BORDER);
+            let width = round(BORDER);
+            config.width = BorderWidth::Outset(width);
             config.active_color = color;
             border.update_config(config);
             border.set_thicken_corners(false);
@@ -556,7 +557,7 @@ impl Thumbnail {
                 true,
                 false,
                 Rectangle::default(),
-                radius.expanded_by(config.width as f32),
+                radius.expanded_by(width as f32),
                 scale,
                 1.,
             );


### PR DESCRIPTION
Adds `is-inset true` property to borders and focus rings for windows, which makes the border/focus ring draw _into_ the window content (overlaid on top), instead of out of it. This allows you to draw Adwaita-style transparent window trims on top of the content.

# Screenshots

At scale 2x

<img width="2879" height="1759" alt="image" src="https://github.com/user-attachments/assets/ff450165-62e7-43db-8fab-f5a4b0d14b2e" />

At scale 4x

<img width="2879" height="1759" alt="image" src="https://github.com/user-attachments/assets/1953f54a-5ed3-4ec1-ac39-9baa3425206d" />

Showing the border blending with the window content - cut-off "Downloads" text

<img width="1032" height="862" alt="image" src="https://github.com/user-attachments/assets/2bcc51d0-fecf-4c78-8b15-ab074af77ee8" />

If you look closely, you can see the border radius doesn't exactly line up with the window content. Honestly I'm not sure what causes this, but I've observed it before in the regular border-clipping algorithm. Might be the extra 0.5px of padding that's added? Don't think it's related to this PR and it's very minor, but not pixel perfect :(

# Configuration

```kdl
window-rule {
	border {
		on
		width 1
		is-inset true
		active-color "#ffffff11"
		inactive-color "#ffffff11"
		urgent-color "#ffffff11"
	}
}
```

The exact border color is taken from [Adwaita stylesheet](https://gitlab.gnome.org/GNOME/libadwaita/-/blob/main/src/stylesheet/widgets/_window.scss?ref_type=heads#L9).

I originally implemented this feature as negative-width borders, but I decided a separate `is-inset` field is more explicit and makes more sense.

# Code

Main points:
- added `BorderWidth` which is either `Inset(f64)` or `Outset(f64)`, instead of a separate `is_inset` field, so that consumers of `Border::width`, `FocusRing::width` have to handle the inset/outset cases explicitly
  - most layout code doesn't care about insets, so it can just treat an inset as 0-width
  - anything which used `XX.border.width()` before now uses `.width().outset()` to reflect this
- modified tile drawing: first we draw the `is-inset` border/focus ring, then window content, then _non_ `is-inset` border/focus ring; insets draw above window content
- if drawing an `is-inset` border, we will _always_ use the eight-piece drawing algorithm instead of drawing a rectangle behind the content. also renamed `is_border` to `draw_as_border` since `is_border` is like lowkey not a great name