### PR TITLE
ipc: add output-relative window geometries

### DIFF
--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -117,6 +117,8 @@ pub enum Request {
     ReturnError,
     /// Request information about the overview.
     OverviewState,
+    /// Request the geometry of all windows.
+    WindowGeometries,
     /// Request information about screencasts.
     Casts,
 }
@@ -147,6 +149,8 @@ pub enum Response {
     Workspaces(Vec<Workspace>),
     /// Information about open windows.
     Windows(Vec<Window>),
+    /// Information about open windows with their geometry.
+    WindowGeometries(Vec<WindowGeometry>),
     /// Information about layer-shell surfaces.
     Layers(Vec<LayerSurface>),
     /// Information about the keyboard layout.
@@ -165,6 +169,22 @@ pub enum Response {
     OverviewState(Overview),
     /// Information about screencasts.
     Casts(Vec<Cast>),
+}
+
+/// Geometry of a window.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct WindowGeometry {
+    /// Id of the window.
+    pub id: u64,
+    /// X coordinate of the tile relative to the active output's top-left corner.
+    pub x: i32,
+    /// Y coordinate of the tile relative to the active output's top-left corner.
+    pub y: i32,
+    /// Width of the tile.
+    pub width: i32,
+    /// Height of the tile.
+    pub height: i32,
 }
 
 /// Overview information.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -178,13 +178,13 @@ pub struct WindowGeometry {
     /// Id of the window.
     pub id: u64,
     /// X coordinate of the tile relative to the active output's top-left corner.
-    pub x: i32,
+    pub x: f64,
     /// Y coordinate of the tile relative to the active output's top-left corner.
-    pub y: i32,
+    pub y: f64,
     /// Width of the tile.
-    pub width: i32,
+    pub width: f64,
     /// Height of the tile.
-    pub height: i32,
+    pub height: f64,
 }
 
 /// Overview information.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -73,6 +73,8 @@ pub enum Request {
     Workspaces,
     /// Request information about open windows.
     Windows,
+    /// Request window geometries.
+    WindowGeometries,
     /// Request information about layer-shell surfaces.
     Layers,
     /// Request information about the configured keyboard layouts.
@@ -117,8 +119,6 @@ pub enum Request {
     ReturnError,
     /// Request information about the overview.
     OverviewState,
-    /// Request the geometry of all windows.
-    WindowGeometries,
     /// Request information about screencasts.
     Casts,
 }
@@ -149,7 +149,7 @@ pub enum Response {
     Workspaces(Vec<Workspace>),
     /// Information about open windows.
     Windows(Vec<Window>),
-    /// Information about open windows with their geometry.
+    /// Information about window geometries.
     WindowGeometries(Vec<WindowGeometry>),
     /// Information about layer-shell surfaces.
     Layers(Vec<LayerSurface>),
@@ -171,19 +171,21 @@ pub enum Response {
     Casts(Vec<Cast>),
 }
 
-/// Geometry of a window.
+/// Information about a window's geometry.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct WindowGeometry {
     /// Id of the window.
     pub id: u64,
-    /// X coordinate of the tile relative to the active output's top-left corner.
+    /// Name of the output.
+    pub output: String,
+    /// X position.
     pub x: f64,
-    /// Y coordinate of the tile relative to the active output's top-left corner.
+    /// Y position.
     pub y: f64,
-    /// Width of the tile.
+    /// Width.
     pub width: f64,
-    /// Height of the tile.
+    /// Height.
     pub height: f64,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,8 @@ pub enum Msg {
     Workspaces,
     /// List open windows.
     Windows,
+    /// List window geometries.
+    WindowGeometries,
     /// List open layer-shell surfaces.
     Layers,
     /// Get the configured keyboard layouts.

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -43,6 +43,7 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
         },
         Msg::Workspaces => Request::Workspaces,
         Msg::Windows => Request::Windows,
+        Msg::WindowGeometries => Request::WindowGeometries,
         Msg::Layers => Request::Layers,
         Msg::KeyboardLayouts => Request::KeyboardLayouts,
         Msg::EventStream => Request::EventStream,
@@ -198,6 +199,27 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
             for window in windows {
                 print_window(&window);
                 println!();
+            }
+        }
+        Msg::WindowGeometries => {
+            let Response::WindowGeometries(mut geometries) = response else {
+                bail!("unexpected response: expected WindowGeometries, got {response:?}");
+            };
+
+            if json {
+                let geometries =
+                    serde_json::to_string(&geometries).context("error formatting response")?;
+                println!("{geometries}");
+                return Ok(());
+            }
+
+            geometries.sort_unstable_by(|a, b| a.id.cmp(&b.id));
+
+            for geom in geometries {
+                println!(
+                    "Window ID {}: x={}, y={}, width={}, height={}",
+                    geom.id, geom.x, geom.y, geom.width, geom.height
+                );
             }
         }
         Msg::Layers => {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -202,7 +202,7 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
             }
         }
         Msg::WindowGeometries => {
-            let Response::WindowGeometries(mut geometries) = response else {
+            let Response::WindowGeometries(geometries) = response else {
                 bail!("unexpected response: expected WindowGeometries, got {response:?}");
             };
 
@@ -213,12 +213,15 @@ pub fn handle_msg(mut msg: Msg, json: bool) -> anyhow::Result<()> {
                 return Ok(());
             }
 
-            geometries.sort_unstable_by(|a, b| a.id.cmp(&b.id));
-
-            for geom in geometries {
+            for geometry in geometries {
                 println!(
-                    "Window ID {}: x={}, y={}, width={}, height={}",
-                    geom.id, geom.x, geom.y, geom.width, geom.height
+                    "Window ID {} on {}: x={}, y={}, width={}, height={}",
+                    geometry.id,
+                    geometry.output,
+                    fmt_rounded(geometry.x),
+                    fmt_rounded(geometry.y),
+                    fmt_rounded(geometry.width),
+                    fmt_rounded(geometry.height),
                 );
             }
         }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -302,10 +302,10 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
                         let id = tile.window().id().get();
                         let geometry = niri_ipc::WindowGeometry {
                             id,
-                            x: pos.x.round() as i32,
-                            y: pos.y.round() as i32,
-                            width: size.w.round() as i32,
-                            height: size.h.round() as i32,
+                            x: pos.x,
+                            y: pos.y,
+                            width: size.w,
+                            height: size.h,
                         };
                         geometries.push(geometry);
                     }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -287,6 +287,35 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let windows = state.windows.windows.values().cloned().collect();
             Response::Windows(windows)
         }
+        Request::WindowGeometries => {
+            let (tx, rx) = async_channel::bounded(1);
+            ctx.event_loop.insert_idle(move |state| {
+                let mut geometries = Vec::new();
+                for mon in state.niri.layout.monitors() {
+                    let ws = mon.active_workspace_ref();
+                    for (tile, pos, visible) in ws.tiles_with_render_positions() {
+                        if !visible {
+                            continue;
+                        }
+
+                        let size = tile.animated_tile_size();
+                        let id = tile.window().id().get();
+                        let geometry = niri_ipc::WindowGeometry {
+                            id,
+                            x: pos.x.round() as i32,
+                            y: pos.y.round() as i32,
+                            width: size.w.round() as i32,
+                            height: size.h.round() as i32,
+                        };
+                        geometries.push(geometry);
+                    }
+                }
+                let _ = tx.send_blocking(geometries);
+            });
+            let result = rx.recv().await;
+            let geometries = result.map_err(|_| String::from("error getting window geometries"))?;
+            Response::WindowGeometries(geometries)
+        }
         Request::Layers => {
             let (tx, rx) = async_channel::bounded(1);
             ctx.event_loop.insert_idle(move |state| {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -291,29 +291,25 @@ async fn process(ctx: &ClientCtx, request: Request) -> Reply {
             let (tx, rx) = async_channel::bounded(1);
             ctx.event_loop.insert_idle(move |state| {
                 let mut geometries = Vec::new();
-                for mon in state.niri.layout.monitors() {
-                    let ws = mon.active_workspace_ref();
-                    for (tile, pos, visible) in ws.tiles_with_render_positions() {
-                        if !visible {
-                            continue;
-                        }
-
-                        let size = tile.animated_tile_size();
-                        let id = tile.window().id().get();
-                        let geometry = niri_ipc::WindowGeometry {
-                            id,
-                            x: pos.x,
-                            y: pos.y,
-                            width: size.w,
-                            height: size.h,
-                        };
-                        geometries.push(geometry);
-                    }
-                }
+                state
+                    .niri
+                    .layout
+                    .with_window_render_geometries(|window, output, geometry| {
+                        geometries.push(niri_ipc::WindowGeometry {
+                            id: window.id().get(),
+                            output: output.name(),
+                            x: geometry.loc.x,
+                            y: geometry.loc.y,
+                            width: geometry.size.w,
+                            height: geometry.size.h,
+                        });
+                    });
                 let _ = tx.send_blocking(geometries);
             });
-            let result = rx.recv().await;
-            let geometries = result.map_err(|_| String::from("error getting window geometries"))?;
+            let geometries = rx
+                .recv()
+                .await
+                .map_err(|_| String::from("error getting window geometries"))?;
             Response::WindowGeometries(geometries)
         }
         Request::Layers => {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1714,6 +1714,49 @@ impl<W: LayoutElement> Layout<W> {
         }
     }
 
+    pub(crate) fn with_window_render_geometries(
+        &self,
+        mut f: impl FnMut(&W, &Output, Rectangle<f64, Logical>),
+    ) {
+        if let Some(move_) = self
+            .interactive_move
+            .as_ref()
+            .and_then(InteractiveMoveState::moving)
+        {
+            let zoom = self.overview_zoom();
+            let geometry = Rectangle::new(
+                move_.tile_render_location(zoom) + move_.tile.bob_offset().upscale(zoom),
+                move_.tile.animated_tile_size().upscale(zoom),
+            );
+            if geometry
+                .intersection(Rectangle::from_size(output_size(&move_.output)))
+                .is_some()
+            {
+                f(move_.tile.window(), &move_.output, geometry);
+            }
+        }
+
+        for mon in self.monitors() {
+            let zoom = mon.overview_zoom();
+            let output_bounds = Rectangle::from_size(output_size(mon.output()));
+            for (ws, ws_geometry) in mon.workspaces_with_render_geo() {
+                for (tile, pos, visible) in ws.tiles_with_render_positions() {
+                    if !visible {
+                        continue;
+                    }
+
+                    let geometry = Rectangle::new(
+                        ws_geometry.loc + (pos + tile.bob_offset()).upscale(zoom),
+                        tile.animated_tile_size().upscale(zoom),
+                    );
+                    if geometry.intersection(output_bounds).is_some() {
+                        f(tile.window(), mon.output(), geometry);
+                    }
+                }
+            }
+        }
+    }
+
     pub fn with_windows_mut(&mut self, mut f: impl FnMut(&mut W, Option<&Output>)) {
         if let Some(InteractiveMoveState::Moving(move_)) = &mut self.interactive_move {
             f(move_.tile.window_mut(), Some(&move_.output));

--- a/src/layout/tests/animations.rs
+++ b/src/layout/tests/animations.rs
@@ -68,6 +68,59 @@ fn set_up_two_in_column() -> Layout<TestWindow> {
     check_ops_with_options(make_options(), ops)
 }
 
+fn window_render_geometries(layout: &Layout<TestWindow>) -> Vec<Rectangle<f64, Logical>> {
+    let mut geometries = Vec::new();
+    layout.with_window_render_geometries(|_, _, geometry| {
+        geometries.push(geometry);
+    });
+    geometries
+}
+
+#[test]
+fn window_render_geometries_follow_overview_and_interactive_move() {
+    let mut layout = check_ops([
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams {
+                rules: Some(ResolvedWindowRules {
+                    baba_is_float: Some(true),
+                    ..ResolvedWindowRules::default()
+                }),
+                ..TestWindowParams::new(1)
+            },
+        },
+        Op::Communicate(1),
+        Op::CompleteAnimations,
+    ]);
+
+    let normal = window_render_geometries(&layout);
+    assert_eq!(normal.len(), 1);
+    let workspace_pos = layout
+        .active_workspace()
+        .unwrap()
+        .tiles_with_render_positions()
+        .next()
+        .unwrap()
+        .1;
+    assert_ne!(normal[0].loc, workspace_pos);
+
+    check_ops_on_layout(&mut layout, [Op::ToggleOverview, Op::CompleteAnimations]);
+    let overview = window_render_geometries(&layout);
+    assert_eq!(overview.len(), 1);
+    assert_eq!(
+        overview[0].size,
+        normal[0].size.upscale(layout.overview_zoom())
+    );
+
+    let output = layout.outputs().next().unwrap().clone();
+    assert!(layout.interactive_move_begin(1, &output, (50., 100.).into()));
+    assert!(layout.interactive_move_update(&1, (1000., 0.).into(), output, (400., 300.).into(),));
+
+    let moving = window_render_geometries(&layout);
+    assert_eq!(moving.len(), 1);
+    assert_ne!(moving[0].loc, overview[0].loc);
+}
+
 #[test]
 fn height_resize_animates_next_y() {
     let mut layout = set_up_two_in_column();


### PR DESCRIPTION
Supersedes #3305, which can be closed in favor of this PR. Close #3305.

Adds `niri msg window-geometries` for querying the current output-relative geometry of visible window tiles.

Unlike #3305, this reuses niri's existing render-position pipeline instead of maintaining separate geometry calculations. This preserves fractional logical coordinates and correctly handles multiple outputs, overview and workspace animations, interactive moves, render offsets, hidden tabs, and fully off-screen windows.

Co-authored-by: Szybet <53944559+Szybet@users.noreply.github.com>