### PR TITLE
Show the MRU switcher on all outputs

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -959,6 +959,8 @@ mod tests {
                     max-height 960
                 }
 
+                all-outputs true
+
                 binds {
                     Alt+Tab { next-window; }
                     Alt+grave { next-window filter="app-id"; }
@@ -2323,6 +2325,7 @@ mod tests {
                     max_height: 960.0,
                     max_scale: 0.5,
                 },
+                all_outputs: true,
                 binds: [
                     Bind {
                         key: Key {

--- a/niri-config/src/recent_windows.rs
+++ b/niri-config/src/recent_windows.rs
@@ -13,6 +13,7 @@ pub struct RecentWindows {
     pub open_delay_ms: u16,
     pub highlight: MruHighlight,
     pub previews: MruPreviews,
+    pub all_outputs: bool,
     pub binds: Vec<Bind>,
 }
 
@@ -24,6 +25,7 @@ impl Default for RecentWindows {
             open_delay_ms: 150,
             highlight: MruHighlight::default(),
             previews: MruPreviews::default(),
+            all_outputs: false,
             binds: default_binds(),
         }
     }
@@ -43,6 +45,8 @@ pub struct RecentWindowsPart {
     pub highlight: Option<MruHighlightPart>,
     #[knuffel(child)]
     pub previews: Option<MruPreviewsPart>,
+    #[knuffel(child, unwrap(argument))]
+    pub all_outputs: Option<bool>,
     #[knuffel(child)]
     pub binds: Option<MruBinds>,
 }
@@ -54,7 +58,7 @@ impl MergeWith<RecentWindowsPart> for RecentWindows {
             self.on = false;
         }
 
-        merge_clone!((self, part), debounce_ms, open_delay_ms);
+        merge_clone!((self, part), debounce_ms, open_delay_ms, all_outputs);
         merge!((self, part), highlight, previews);
 
         if let Some(part) = &part.binds {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2573,11 +2573,12 @@ impl State {
             self.niri.screenshot_ui.pointer_motion(point, None);
         }
 
-        if let Some(mru_output) = self.niri.window_mru_ui.output() {
+        if self.niri.window_mru_ui.is_open() {
             if let Some((output, pos_within_output)) = self.niri.output_under(new_pos) {
-                if mru_output == output {
-                    self.niri.window_mru_ui.pointer_motion(pos_within_output);
-                }
+                let output = output.clone();
+                self.niri
+                    .window_mru_ui
+                    .pointer_motion(&output, pos_within_output);
             }
         }
 
@@ -2708,11 +2709,12 @@ impl State {
             self.niri.screenshot_ui.pointer_motion(point, None);
         }
 
-        if let Some(mru_output) = self.niri.window_mru_ui.output() {
+        if self.niri.window_mru_ui.is_open() {
             if let Some((output, pos_within_output)) = self.niri.output_under(pos) {
-                if mru_output == output {
-                    self.niri.window_mru_ui.pointer_motion(pos_within_output);
-                }
+                let output = output.clone();
+                self.niri
+                    .window_mru_ui
+                    .pointer_motion(&output, pos_within_output);
             }
         }
 
@@ -2799,18 +2801,18 @@ impl State {
 
         if ButtonState::Pressed == button_state {
             let mut is_mru_open = false;
-            if let Some(mru_output) = self.niri.window_mru_ui.output() {
+            if self.niri.window_mru_ui.is_open() {
                 is_mru_open = true;
                 if let Some(MouseButton::Left) = button {
                     let location = pointer.current_location();
                     let (output, pos_within_output) = self.niri.output_under(location).unwrap();
-                    if mru_output == output {
-                        let id = self.niri.window_mru_ui.pointer_motion(pos_within_output);
-                        if id.is_some() {
-                            self.confirm_mru();
-                        } else {
-                            self.niri.cancel_mru();
-                        }
+                    let output = output.clone();
+                    let id = self
+                        .niri
+                        .window_mru_ui
+                        .pointer_motion(&output, pos_within_output);
+                    if id.is_some() {
+                        self.confirm_mru();
                     } else {
                         self.niri.cancel_mru();
                     }
@@ -3598,11 +3600,12 @@ impl State {
             self.niri.screenshot_ui.pointer_motion(point, None);
         }
 
-        if let Some(mru_output) = self.niri.window_mru_ui.output() {
+        if self.niri.window_mru_ui.is_open() {
             if let Some((output, pos_within_output)) = self.niri.output_under(pos) {
-                if mru_output == output {
-                    self.niri.window_mru_ui.pointer_motion(pos_within_output);
-                }
+                let output = output.clone();
+                self.niri
+                    .window_mru_ui
+                    .pointer_motion(&output, pos_within_output);
             }
         }
 
@@ -3689,15 +3692,15 @@ impl State {
                                 self.niri.queue_redraw_all();
                             }
                         }
-                    } else if let Some(mru_output) = self.niri.window_mru_ui.output() {
+                    } else if self.niri.window_mru_ui.is_open() {
                         if let Some((output, pos_within_output)) = self.niri.output_under(pos) {
-                            if mru_output == output {
-                                let id = self.niri.window_mru_ui.pointer_motion(pos_within_output);
-                                if id.is_some() {
-                                    self.confirm_mru();
-                                } else {
-                                    self.niri.cancel_mru();
-                                }
+                            let output = output.clone();
+                            let id = self
+                                .niri
+                                .window_mru_ui
+                                .pointer_motion(&output, pos_within_output);
+                            if id.is_some() {
+                                self.confirm_mru();
                             } else {
                                 self.niri.cancel_mru();
                             }
@@ -4287,15 +4290,15 @@ impl State {
                     self.niri.queue_redraw_all();
                 }
             }
-        } else if let Some(mru_output) = self.niri.window_mru_ui.output() {
+        } else if self.niri.window_mru_ui.is_open() {
             if let Some((output, pos_within_output)) = self.niri.output_under(pos) {
-                if mru_output == output {
-                    let id = self.niri.window_mru_ui.pointer_motion(pos_within_output);
-                    if id.is_some() {
-                        self.confirm_mru();
-                    } else {
-                        self.niri.cancel_mru();
-                    }
+                let output = output.clone();
+                let id = self
+                    .niri
+                    .window_mru_ui
+                    .pointer_motion(&output, pos_within_output);
+                if id.is_some() {
+                    self.confirm_mru();
                 } else {
                     self.niri.cancel_mru();
                 }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -6492,8 +6492,9 @@ impl Niri {
     }
 
     pub fn queue_redraw_mru_output(&mut self) {
-        if let Some(output) = self.window_mru_ui.output().cloned() {
-            self.queue_redraw(&output);
+        // The switcher is rendered on all outputs, so redraw them all.
+        if self.window_mru_ui.is_open() {
+            self.queue_redraw_all();
         }
     }
 }

--- a/src/ui/mru.rs
+++ b/src/ui/mru.rs
@@ -1024,7 +1024,11 @@ impl WindowMruUi {
         self.set_scope(scope);
     }
 
-    pub fn pointer_motion(&mut self, pos_within_output: Point<f64, Logical>) -> Option<MappedId> {
+    pub fn pointer_motion(
+        &mut self,
+        output: &Output,
+        pos_within_output: Point<f64, Logical>,
+    ) -> Option<MappedId> {
         let UiState::Open(inner) = &mut self.state else {
             return None;
         };
@@ -1033,9 +1037,12 @@ impl WindowMruUi {
             return None;
         }
 
-        inner.freeze_view = true;
+        // Only freeze the view on the output the UI was opened on.
+        if *output == inner.output {
+            inner.freeze_view = true;
+        }
 
-        let id = inner.thumbnail_under(pos_within_output);
+        let id = inner.thumbnail_under(output, pos_within_output);
         if let Some(id) = id {
             inner.wmru.set_current(id);
         }
@@ -1132,13 +1139,16 @@ impl WindowMruUi {
             // different <R> generic in offscreen vs. normal path.
         };
 
-        // During the closing fade, use an offscreen to avoid transparent compositing artifacts.
+        // During the closing fade, use an offscreen on the output the UI was opened on to avoid
+        // transparent compositing artifacts.
+        let is_main_output = *output == inner.output;
+
         let mut pushed_offscreen = false;
-        if *output == inner.output && alpha < 1. {
+        if is_main_output && alpha < 1. {
             let mut ctx = ctx.as_gles();
 
             let mut elems = Vec::new();
-            inner.render(niri, ctx.r(), &mut |elem| elems.push(elem));
+            inner.render(niri, output, ctx.r(), &mut |elem| elems.push(elem));
             elems.push(WindowMruUiRenderElement::SolidColor(render_backdrop(1.)));
 
             let scale = output.current_scale().fractional_scale();
@@ -1166,12 +1176,18 @@ impl WindowMruUi {
             }
         }
 
-        // When alpha is 1., render everything directly, without an offscreen.
+        // Render the switcher itself on every output.
         //
-        // This is not used as fallback when offscreen fails to render because it looks better to
-        // hide the previews immediately than to render them with alpha = 1. during a fade-out.
-        if *output == inner.output && alpha == 1. {
-            inner.render(niri, ctx, &mut |elem| push(elem));
+        // On the output the UI was opened on, render it directly only when alpha is 1.; during the
+        // closing fade it is instead drawn from the offscreen above.
+        //
+        // On the other outputs we render directly at full opacity: without a per-output offscreen,
+        // a partial fade would cause transparent compositing artifacts, and it looks better to
+        // keep the switcher visible for the entire (short) closing animation than to hide it
+        // immediately. This is only done when the `all-outputs` option is enabled.
+        let all_outputs = inner.config.borrow().recent_windows.all_outputs;
+        if !pushed_offscreen && (alpha == 1. || (all_outputs && !is_main_output)) {
+            inner.render(niri, output, ctx, &mut |elem| push(elem));
         }
 
         // This is used for both normal elems and for other outputs.
@@ -1297,18 +1313,28 @@ impl Inner {
     }
 
     fn compute_view_pos(&self) -> f64 {
+        self.compute_view_pos_for(&self.output, self.view_pos.target())
+    }
+
+    /// Computes the view position that shows the current selection on the given output, aligning
+    /// relative to the given current view position.
+    ///
+    /// On the output the UI was opened on, the current (animated) view position is passed in so
+    /// that the view scrolls to keep the selection in place. On other outputs a static view
+    /// position is used, centering the selection on that output.
+    fn compute_view_pos_for(&self, output: &Output, cur_view_pos: f64) -> f64 {
         let Some(current_id) = self.wmru.current_id else {
             return 0.;
         };
 
-        let output_size = output_size(&self.output);
+        let output_size = output_size(output);
 
         let working_x = STRUT + GAP;
         let working_width = (output_size.w - working_x * 2.).max(0.);
 
         let mut current_geo = Rectangle::default();
         let mut strip_width = 0.;
-        for (thumbnail, geo) in self.thumbnails() {
+        for (thumbnail, geo) in self.thumbnails(output) {
             if thumbnail.id == current_id {
                 current_geo = geo;
             }
@@ -1327,7 +1353,7 @@ impl Inner {
         }
 
         compute_view_offset(
-            self.view_pos.target() + working_x,
+            cur_view_pos + working_x,
             working_width,
             current_geo.loc.x,
             current_geo.size.w,
@@ -1483,9 +1509,12 @@ impl Inner {
         self.view_pos.offset(-delta);
     }
 
-    fn thumbnails(&self) -> impl Iterator<Item = (&Thumbnail, Rectangle<f64, Logical>)> {
-        let output_size = output_size(&self.output);
-        let scale = self.output.current_scale().fractional_scale();
+    fn thumbnails(
+        &self,
+        output: &Output,
+    ) -> impl Iterator<Item = (&Thumbnail, Rectangle<f64, Logical>)> {
+        let output_size = output_size(output);
+        let scale = output.current_scale().fractional_scale();
         let round = move |logical: f64| round_logical_in_physical(scale, logical);
 
         let padding = self.config.borrow().recent_windows.highlight.padding;
@@ -1507,17 +1536,19 @@ impl Inner {
 
     fn thumbnails_in_view_static(
         &self,
+        output: &Output,
+        view_pos: f64,
     ) -> impl Iterator<Item = (&Thumbnail, Rectangle<f64, Logical>)> {
-        let output_size = output_size(&self.output);
-        let scale = self.output.current_scale().fractional_scale();
+        let output_size = output_size(output);
+        let scale = output.current_scale().fractional_scale();
         let round = |logical: f64| round_logical_in_physical(scale, logical);
 
-        let view_pos = round(self.view_pos.current());
+        let view_pos = round(view_pos);
 
         let leftmost = view_pos;
         let rightmost = view_pos + output_size.w;
 
-        self.thumbnails()
+        self.thumbnails(output)
             .skip_while(move |(_, geo)| geo.loc.x + geo.size.w <= leftmost)
             .map_while(move |(thumbnail, mut geo)| {
                 if rightmost <= geo.loc.x {
@@ -1531,33 +1562,43 @@ impl Inner {
 
     fn thumbnails_in_view_render(
         &self,
+        output: &Output,
+        view_pos: f64,
     ) -> impl Iterator<Item = (&Thumbnail, Rectangle<f64, Logical>)> {
-        let output_size = output_size(&self.output);
-        let scale = self.output.current_scale().fractional_scale();
+        let output_size = output_size(output);
+        let scale = output.current_scale().fractional_scale();
         let round = move |logical: f64| round_logical_in_physical(scale, logical);
 
-        let view_pos = round(self.view_pos.current());
+        let view_pos = round(view_pos);
 
-        self.thumbnails().filter_map(move |(thumbnail, mut geo)| {
-            geo.loc.x -= view_pos;
-            geo.loc.x += round(thumbnail.render_offset());
+        self.thumbnails(output)
+            .filter_map(move |(thumbnail, mut geo)| {
+                geo.loc.x -= view_pos;
+                geo.loc.x += round(thumbnail.render_offset());
 
-            if geo.loc.x + geo.size.w < 0. || output_size.w < geo.loc.x {
-                return None;
-            }
+                if geo.loc.x + geo.size.w < 0. || output_size.w < geo.loc.x {
+                    return None;
+                }
 
-            Some((thumbnail, geo))
-        })
+                Some((thumbnail, geo))
+            })
     }
 
     fn render<R: NiriRenderer>(
         &self,
         niri: &Niri,
+        output: &Output,
         mut ctx: RenderCtx<R>,
         push: &mut dyn FnMut(WindowMruUiRenderElement<R>),
     ) {
-        let output_size = output_size(&self.output);
-        let scale = self.output.current_scale().fractional_scale();
+        let output_size = output_size(output);
+        let scale = output.current_scale().fractional_scale();
+
+        let view_pos = if *output == self.output {
+            self.view_pos.current()
+        } else {
+            self.compute_view_pos_for(output, 0.)
+        };
 
         let panel_texture =
             self.scope_panel
@@ -1586,7 +1627,7 @@ impl Inner {
 
         let config = self.config.borrow();
 
-        for (thumbnail, geo) in self.thumbnails_in_view_render() {
+        for (thumbnail, geo) in self.thumbnails_in_view_render(output, view_pos) {
             let id = thumbnail.id;
             let Some((_, mapped)) = niri.layout.windows().find(|(_, m)| m.id() == id) else {
                 error!("window in the MRU must be present in the layout");
@@ -1600,15 +1641,21 @@ impl Inner {
         }
     }
 
-    fn thumbnail_under(&self, pos: Point<f64, Logical>) -> Option<MappedId> {
-        let scale = self.output.current_scale().fractional_scale();
+    fn thumbnail_under(&self, output: &Output, pos: Point<f64, Logical>) -> Option<MappedId> {
+        let scale = output.current_scale().fractional_scale();
         let round = move |logical: f64| round_logical_in_physical(scale, logical);
         let padding = self.config.borrow().recent_windows.highlight.padding;
         let padding = round(padding) + round(BORDER);
         let padding = Point::new(padding, padding);
         let title_gap = round(TITLE_GAP);
 
-        for (thumbnail, mut geo) in self.thumbnails_in_view_static() {
+        let view_pos = if *output == self.output {
+            self.view_pos.current()
+        } else {
+            self.compute_view_pos_for(output, 0.)
+        };
+
+        for (thumbnail, mut geo) in self.thumbnails_in_view_static(output, view_pos) {
             geo.loc -= padding;
             geo.size += padding.to_size().upscale(2.);
 


### PR DESCRIPTION
## Show the MRU (Alt+Tab) switcher on all outputs

Currently, the recent-windows switcher only renders on the output it was opened on (the focused output). In a multi-monitor setup, that means pressing Alt+Tab draws your eye to one screen while the switcher appears on the other.

This PR renders the switcher on **every** output, so no matter where you're looking, the preview strip shows up right there.

### What changed

- `render_output()` now draws the switcher itself on every output (the backdrop was already per-output).
- Each output computes its own strip layout: thumbnails are sized and positioned relative to that output's geometry and scale, and the strip is centered on the current selection on each screen.
- Pointer motion and clicks work on any output: the input handlers pass the output under the cursor into the UI, so hovering/clicking a thumbnail on a secondary monitor selects it correctly.
- The view animation (`window_movement`) that scrolls the strip when advancing still runs on the output the switcher was opened on; secondary outputs use a static, freshly-recomputed centered view.
- `queue_redraw_mru_output()` now redraws all outputs instead of just the main one.
- New `recent-windows` config option `all-outputs` (bool, default `false`, opt-in):

```kdl
recent-windows {
    all-outputs true
}
```

With `all-outputs` disabled the behavior is exactly as before (switcher only on the focused output).

### Known limitations (v1)

- The closing fade only happens on the output the UI was opened on. Secondary outputs render the switcher at full opacity for the whole (short) closing animation and hide it when it ends. Fading each output would require a per-output offscreen, and rendering at partial alpha without one causes transparent compositing artifacts.
- The smooth scroll when advancing the selection is only animated on the main output; secondary outputs re-center the selection instantly.

### Testing

- `cargo build`, `cargo test`, `cargo clippy`, `cargo fmt --check` all pass.
- Tested on a real multi-monitor session.