### PR TITLE
input: per-keyboard-device xkb and repeat configuration

### DIFF
--- a/docs/wiki/Configuration:-Input.md
+++ b/docs/wiki/Configuration:-Input.md
@@ -4,7 +4,7 @@ In this section you can configure input devices like keyboard and mouse, and som
 
 There's a section for each device type: `keyboard`, `touchpad`, `mouse`, `trackpoint`, `trackball`, `tablet`, `touch`.
 Settings in those sections will apply to every device of that type.
-Currently, there's no way to configure specific devices individually (but that is planned).
+Currently, there's no way to configure specific touchpad/mouse/etc. devices individually (but that is planned), except for `keyboard`, which can be given a device name to configure just that one keyboard — see [Per-Keyboard Configuration](#per-keyboard-configuration) below.
 
 All settings at a glance:
 
@@ -130,6 +130,36 @@ input {
     }
 }
 ```
+
+#### Per-Keyboard Configuration
+
+You can give a `keyboard` block a device name argument to configure just that keyboard, e.g. to use a different layout on an external keyboard than on your laptop's built-in one.
+Run `niri msg keyboard-layouts` or `libinput list-devices` to find a device's exact name.
+
+```kdl
+input {
+    // Applies to every keyboard that isn't matched by a named block below.
+    keyboard {
+        xkb {
+            layout "br"
+        }
+    }
+
+    keyboard "Topre Corporation Realforce 87U" {
+        xkb {
+            layout "us"
+        }
+    }
+}
+```
+
+A named `keyboard` block only needs to set what's different about that device: any setting it doesn't specify (`repeat-rate`, `numlock`, etc.) falls back to the unnamed `keyboard` block above it, the same way the unnamed block itself falls back to the regular defaults.
+
+Keep all of your `keyboard` blocks together in one `input` section (ideally in one file): a later `input` section's `keyboard` blocks fully replace the earlier ones, the same as `touchpad` and other device sections do.
+
+> [!TIP]
+>
+> Since the Wayland protocol only lets a compositor advertise one active keymap per seat at a time, niri implements this by switching the active keymap whenever a different keyboard device sends a key press than the one that sent the last one. This is transparent for normal use, but note that XWayland applications generally only see one X11-wide keymap, so per-keyboard layouts may not be reflected correctly in X11-only clients.
 
 > [!TIP]
 >

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -10,7 +10,8 @@ use crate::FloatOrInt;
 
 #[derive(Debug, Default, PartialEq)]
 pub struct Input {
-    pub keyboard: Keyboard,
+    /// All configured keyboard blocks, including at most one unnamed (fallback) one.
+    pub keyboards: Vec<Keyboard>,
     pub touchpad: Touchpad,
     pub mouse: Mouse,
     pub trackpoint: Trackpoint,
@@ -27,8 +28,9 @@ pub struct Input {
 
 #[derive(knuffel::Decode, Debug, Default, PartialEq)]
 pub struct InputPart {
-    #[knuffel(child)]
-    pub keyboard: Option<KeyboardPart>,
+    /// Every `keyboard { ... }` / `keyboard "name" { ... }` child of this `input` block.
+    #[knuffel(children(name = "keyboard"))]
+    pub keyboards: Vec<KeyboardPart>,
     #[knuffel(child)]
     pub touchpad: Option<Touchpad>,
     #[knuffel(child)]
@@ -57,9 +59,32 @@ pub struct InputPart {
 
 impl MergeWith<InputPart> for Input {
     fn merge_with(&mut self, part: &InputPart) {
+        // A later `input { keyboard ... }` section fully replaces the previously configured
+        // keyboards, same as e.g. `touchpad` below. Keep all `keyboard` blocks for a given setup
+        // together in one `input` section (ideally one file) to avoid surprises.
+        //
+        // Named keyboards inherit any setting they don't specify themselves from the unnamed
+        // keyboard block in the same section (or from the regular defaults, if there isn't one),
+        // so e.g. `numlock` or `repeat-rate` don't need to be repeated in every keyboard block.
+        if !part.keyboards.is_empty() {
+            let mut fallback = Keyboard::default();
+            if let Some(fallback_part) = part.keyboards.iter().find(|k| k.name.is_none()) {
+                fallback.merge_with(fallback_part);
+            }
+
+            self.keyboards = part
+                .keyboards
+                .iter()
+                .map(|keyboard_part| {
+                    let mut keyboard = fallback.clone();
+                    keyboard.merge_with(keyboard_part);
+                    keyboard
+                })
+                .collect();
+        }
+
         merge!(
             (self, part),
-            keyboard,
             disable_power_key_handling,
             workspace_auto_back_and_forth,
         );
@@ -84,8 +109,37 @@ impl MergeWith<InputPart> for Input {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+impl Input {
+    /// Returns the unnamed (fallback) keyboard config, applied to keyboards that don't match any
+    /// named `keyboard "..." { }` block, and used for devices whose identity we can't determine.
+    pub fn fallback_keyboard(&self) -> Keyboard {
+        self.keyboards
+            .iter()
+            .find(|keyboard| keyboard.name.is_none())
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Returns the keyboard config for the given libinput device name, falling back to
+    /// [`Self::fallback_keyboard`] if no `keyboard "name" { }` block matches it.
+    pub fn keyboard_named(&self, name: &str) -> Keyboard {
+        self.keyboards
+            .iter()
+            .find(|keyboard| {
+                keyboard
+                    .name
+                    .as_deref()
+                    .is_some_and(|n| n.eq_ignore_ascii_case(name))
+            })
+            .cloned()
+            .unwrap_or_else(|| self.fallback_keyboard())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Keyboard {
+    /// Libinput device name this config applies to, or `None` for the fallback keyboard config.
+    pub name: Option<String>,
     pub xkb: Xkb,
     pub repeat_delay: u16,
     pub repeat_rate: u8,
@@ -96,6 +150,7 @@ pub struct Keyboard {
 impl Default for Keyboard {
     fn default() -> Self {
         Self {
+            name: None,
             xkb: Default::default(),
             // The defaults were chosen to match wlroots and sway.
             repeat_delay: 600,
@@ -108,6 +163,8 @@ impl Default for Keyboard {
 
 #[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct KeyboardPart {
+    #[knuffel(argument)]
+    pub name: Option<String>,
     #[knuffel(child)]
     pub xkb: Option<Xkb>,
     #[knuffel(child, unwrap(argument))]
@@ -122,6 +179,7 @@ pub struct KeyboardPart {
 
 impl MergeWith<KeyboardPart> for Keyboard {
     fn merge_with(&mut self, part: &KeyboardPart) {
+        self.name.clone_from(&part.name);
         merge_clone!((self, part), xkb, repeat_delay, repeat_rate, track_layout);
         merge!((self, part), numlock);
     }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -50,7 +50,9 @@ pub use crate::binds::*;
 pub use crate::debug::Debug;
 pub use crate::error::{ConfigIncludeError, ConfigParseResult};
 pub use crate::gestures::Gestures;
-pub use crate::input::{Input, ModKey, ScrollMethod, TrackLayout, WarpMouseToFocusMode, Xkb};
+pub use crate::input::{
+    Input, Keyboard, ModKey, ScrollMethod, TrackLayout, WarpMouseToFocusMode, Xkb,
+};
 pub use crate::layer_rule::LayerRule;
 pub use crate::layout::*;
 pub use crate::misc::*;
@@ -644,8 +646,8 @@ mod tests {
     #[test]
     fn default_repeat_params() {
         let config = Config::parse_mem("").unwrap();
-        assert_eq!(config.input.keyboard.repeat_delay, 600);
-        assert_eq!(config.input.keyboard.repeat_rate, 25);
+        assert_eq!(config.input.fallback_keyboard().repeat_delay, 600);
+        assert_eq!(config.input.fallback_keyboard().repeat_rate, 25);
     }
 
     #[track_caller]
@@ -971,22 +973,25 @@ mod tests {
         assert_debug_snapshot!(parsed, @r#"
         Config {
             input: Input {
-                keyboard: Keyboard {
-                    xkb: Xkb {
-                        rules: "",
-                        model: "",
-                        layout: "us,ru",
-                        variant: "",
-                        options: Some(
-                            "grp:win_space_toggle",
-                        ),
-                        file: None,
+                keyboards: [
+                    Keyboard {
+                        name: None,
+                        xkb: Xkb {
+                            rules: "",
+                            model: "",
+                            layout: "us,ru",
+                            variant: "",
+                            options: Some(
+                                "grp:win_space_toggle",
+                            ),
+                            file: None,
+                        },
+                        repeat_delay: 600,
+                        repeat_rate: 25,
+                        track_layout: Window,
+                        numlock: false,
                     },
-                    repeat_delay: 600,
-                    repeat_rate: 25,
-                    track_layout: Window,
-                    numlock: false,
-                },
+                ],
                 touchpad: Touchpad {
                     off: false,
                     tap: true,
@@ -2450,8 +2455,24 @@ mod tests {
                 &format!("{default_config:#?}")
             ),
             @r#"
-        -            numlock: false,
-        +            numlock: true,
+        -        keyboards: [],
+        +        keyboards: [
+        +            Keyboard {
+        +                name: None,
+        +                xkb: Xkb {
+        +                    rules: "",
+        +                    model: "",
+        +                    layout: "",
+        +                    variant: "",
+        +                    options: None,
+        +                    file: None,
+        +                },
+        +                repeat_delay: 600,
+        +                repeat_rate: 25,
+        +                track_layout: Global,
+        +                numlock: true,
+        +            },
+        +        ],
 
         -            tap: false,
         +            tap: true,

--- a/resources/default-config.kdl
+++ b/resources/default-config.kdl
@@ -25,6 +25,18 @@ input {
         numlock
     }
 
+    // You can give a keyboard block a device name to configure just that keyboard, e.g. to set
+    // a different layout on an external keyboard than on your laptop's built-in one. Run
+    // `niri msg keyboard-layouts` or check `libinput list-devices` to find the exact device name.
+    // A named keyboard block only overrides settings it sets; anything left unset falls back to
+    // the unnamed keyboard block above.
+    //
+    // keyboard "My External Keyboard" {
+    //     xkb {
+    //         layout "us"
+    //     }
+    // }
+
     // Next sections include libinput settings.
     // Omitting settings disables them, or leaves them at their default values.
     // All commented-out settings here are examples, not defaults.

--- a/src/dbus/freedesktop_a11y.rs
+++ b/src/dbus/freedesktop_a11y.rs
@@ -652,7 +652,8 @@ impl State {
         });
 
         let config = self.niri.config.borrow();
-        let repeat_delay = Duration::from_millis(u64::from(config.input.keyboard.repeat_delay));
+        let repeat_delay =
+            Duration::from_millis(u64::from(config.input.fallback_keyboard().repeat_delay));
         let released = state == KeyState::Released;
 
         let Some(manager) = &self.niri.a11y_manager else {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -413,7 +413,11 @@ impl State {
         &mut self,
         event: I::KeyboardKeyEvent,
         consumed_by_a11y: &mut bool,
-    ) {
+    ) where
+        I::Device: 'static,
+    {
+        self.apply_keyboard_config::<I>(&event);
+
         let mod_key = self.backend.mod_key(&self.niri.config.borrow());
 
         let serial = SERIAL_COUNTER.next_serial();
@@ -614,17 +618,17 @@ impl State {
             self.niri.event_loop.remove(token);
         }
 
-        let config = self.niri.config.borrow();
-        let config = &config.input.keyboard;
-
-        let repeat_rate = config.repeat_rate;
+        // Use the currently active keyboard's repeat settings, so bind repeat matches whichever
+        // physical device is actually being used.
+        let repeat_rate = self.niri.current_keyboard.repeat_rate;
         if repeat_rate == 0 {
             return;
         }
         let repeat_duration = Duration::from_secs_f64(1. / f64::from(repeat_rate));
 
-        let repeat_timer =
-            Timer::from_duration(Duration::from_millis(u64::from(config.repeat_delay)));
+        let repeat_timer = Timer::from_duration(Duration::from_millis(u64::from(
+            self.niri.current_keyboard.repeat_delay,
+        )));
 
         let token = self
             .niri
@@ -658,6 +662,71 @@ impl State {
 
         self.niri.pointer_visibility = PointerVisibility::Hidden;
         self.niri.queue_redraw_all();
+    }
+
+    /// Resolves the keyboard config for the physical device that produced `event`, and applies it
+    /// if it differs from the config currently active on the seat.
+    ///
+    /// The Wayland protocol only allows a single active keymap per seat, so "per keyboard device"
+    /// configuration means re-applying the resolved config for whichever physical device most
+    /// recently sent a key event. The resolved config is cached per device, so idle devices and
+    /// repeat events from the same device don't pay for re-matching against the config every time.
+    fn apply_keyboard_config<I: InputBackend>(&mut self, event: &I::KeyboardKeyEvent)
+    where
+        I::Device: 'static,
+    {
+        let device = event.device();
+
+        let keyboard_config = match (&device as &dyn Any).downcast_ref::<input::Device>() {
+            Some(input_device) => {
+                match self.niri.keyboard_device_cache.entry(input_device.clone()) {
+                    Entry::Occupied(entry) => entry.get().clone(),
+                    Entry::Vacant(entry) => {
+                        let config = self
+                            .niri
+                            .config
+                            .borrow()
+                            .input
+                            .keyboard_named(&input_device.name());
+                        entry.insert(config.clone());
+                        config
+                    }
+                }
+            }
+            // Backends without a real libinput device (e.g. winit, used for nested test
+            // sessions) always get the fallback keyboard config.
+            None => self.niri.config.borrow().input.fallback_keyboard(),
+        };
+
+        if keyboard_config == self.niri.current_keyboard {
+            return;
+        }
+
+        if keyboard_config.xkb != self.niri.current_keyboard.xkb {
+            if let Some(xkb_file) = keyboard_config.xkb.file.clone() {
+                if let Err(err) = self.set_xkb_file(xkb_file) {
+                    warn!("error loading xkb_file for keyboard device: {err:?}");
+                }
+            } else {
+                let keyboard = self.niri.seat.get_keyboard().unwrap();
+                if let Err(err) = keyboard.set_xkb_config(self, keyboard_config.xkb.to_xkb_config())
+                {
+                    warn!("error updating xkb config for keyboard device: {err:?}");
+                }
+            }
+        }
+
+        if keyboard_config.repeat_rate != self.niri.current_keyboard.repeat_rate
+            || keyboard_config.repeat_delay != self.niri.current_keyboard.repeat_delay
+        {
+            let keyboard = self.niri.seat.get_keyboard().unwrap();
+            keyboard.change_repeat_info(
+                keyboard_config.repeat_rate.into(),
+                keyboard_config.repeat_delay.into(),
+            );
+        }
+
+        self.niri.current_keyboard = keyboard_config;
     }
 
     pub fn handle_bind(&mut self, bind: Bind) {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -272,6 +272,12 @@ pub struct Niri {
     pub tablets: HashMap<input::Device, TabletData>,
     pub touch: HashSet<input::Device>,
 
+    // The resolved per-keyboard-device config currently applied to the seat's single keyboard,
+    // and a cache of resolved configs by device so we don't need to re-match by name on every
+    // keystroke. Cleared whenever the keyboard configs change on reload.
+    pub current_keyboard: niri_config::Keyboard,
+    pub keyboard_device_cache: HashMap<input::Device, niri_config::Keyboard>,
+
     // Smithay state.
     pub compositor_state: CompositorState,
     pub xdg_shell_state: XdgShellState,
@@ -1342,7 +1348,7 @@ impl State {
                 }
             }
 
-            if self.niri.config.borrow().input.keyboard.track_layout == TrackLayout::Window {
+            if self.niri.current_keyboard.track_layout == TrackLayout::Window {
                 let current_layout = keyboard.with_xkb_state(self, |context| {
                     let xkb = context.xkb().lock().unwrap();
                     xkb.active_layout()
@@ -1386,7 +1392,7 @@ impl State {
     }
 
     /// Loads the xkb keymap from a file config setting.
-    fn set_xkb_file(&mut self, xkb_file: String) -> anyhow::Result<()> {
+    pub(crate) fn set_xkb_file(&mut self, xkb_file: String) -> anyhow::Result<()> {
         let xkb_file = PathBuf::from(xkb_file);
         let xkb_file = expand_home(&xkb_file)
             .context("failed to expand ~")?
@@ -1412,7 +1418,15 @@ impl State {
     }
 
     fn load_xkb_file(&mut self) {
-        let xkb_file = self.niri.config.borrow().input.keyboard.xkb.file.clone();
+        let xkb_file = self
+            .niri
+            .config
+            .borrow()
+            .input
+            .fallback_keyboard()
+            .xkb
+            .file
+            .clone();
         if let Some(xkb_file) = xkb_file {
             if let Err(err) = self.set_xkb_file(xkb_file) {
                 warn!("error loading xkb_file: {err:?}");
@@ -1504,19 +1518,30 @@ impl State {
         }
 
         // We need &mut self to reload the xkb config, so just store it here.
-        if config.input.keyboard.xkb != old_config.input.keyboard.xkb {
-            reload_xkb = Some(config.input.keyboard.xkb.clone());
+        let default_keyboard = config.input.fallback_keyboard();
+        let old_default_keyboard = old_config.input.fallback_keyboard();
+        if default_keyboard.xkb != old_default_keyboard.xkb {
+            reload_xkb = Some(default_keyboard.xkb.clone());
         }
 
         // Reload the repeat info.
-        if config.input.keyboard.repeat_rate != old_config.input.keyboard.repeat_rate
-            || config.input.keyboard.repeat_delay != old_config.input.keyboard.repeat_delay
+        if default_keyboard.repeat_rate != old_default_keyboard.repeat_rate
+            || default_keyboard.repeat_delay != old_default_keyboard.repeat_delay
         {
             let keyboard = self.niri.seat.get_keyboard().unwrap();
             keyboard.change_repeat_info(
-                config.input.keyboard.repeat_rate.into(),
-                config.input.keyboard.repeat_delay.into(),
+                default_keyboard.repeat_rate.into(),
+                default_keyboard.repeat_delay.into(),
             );
+        }
+
+        // Per-device keyboard configs changed: drop the resolved-config cache (it was built
+        // against the old config) and reset the tracked active keyboard to the fallback so the
+        // next keystroke from any device re-resolves its config from scratch, picking up
+        // new/changed/removed `keyboard "name" { }` blocks right away.
+        if config.input.keyboards != old_config.input.keyboards {
+            self.niri.keyboard_device_cache.clear();
+            self.niri.current_keyboard = default_keyboard;
         }
 
         if config.input.touchpad != old_config.input.touchpad
@@ -2241,7 +2266,7 @@ impl State {
 
         {
             let config = self.niri.config.borrow();
-            if config.input.keyboard.xkb != Xkb::default() {
+            if config.input.fallback_keyboard().xkb != Xkb::default() {
                 trace!("ignoring locale1 xkb change because niri config has xkb settings");
                 return;
             }
@@ -2401,10 +2426,11 @@ impl Niri {
         let single_pixel_buffer_state = SinglePixelBufferState::new::<State>(&display_handle);
 
         let mut seat: Seat<State> = seat_state.new_wl_seat(&display_handle, backend.seat_name());
+        let default_keyboard = config_.input.fallback_keyboard();
         let keyboard = match seat.add_keyboard(
-            config_.input.keyboard.xkb.to_xkb_config(),
-            config_.input.keyboard.repeat_delay.into(),
-            config_.input.keyboard.repeat_rate.into(),
+            default_keyboard.xkb.to_xkb_config(),
+            default_keyboard.repeat_delay.into(),
+            default_keyboard.repeat_rate.into(),
         ) {
             Err(err) => {
                 if let smithay::input::keyboard::Error::BadKeymap = err {
@@ -2414,14 +2440,14 @@ impl Niri {
                 }
                 seat.add_keyboard(
                     Default::default(),
-                    config_.input.keyboard.repeat_delay.into(),
-                    config_.input.keyboard.repeat_rate.into(),
+                    default_keyboard.repeat_delay.into(),
+                    default_keyboard.repeat_rate.into(),
                 )
                 .unwrap()
             }
             Ok(keyboard) => keyboard,
         };
-        if config_.input.keyboard.numlock {
+        if default_keyboard.numlock {
             let mut modifier_state = keyboard.modifier_state();
             modifier_state.num_lock = true;
             keyboard.set_modifier_state(modifier_state);
@@ -2546,6 +2572,8 @@ impl Niri {
             devices: HashSet::new(),
             tablets: HashMap::new(),
             touch: HashSet::new(),
+            current_keyboard: default_keyboard,
+            keyboard_device_cache: HashMap::new(),
 
             compositor_state,
             xdg_shell_state,


### PR DESCRIPTION
## Summary

Adds the ability to configure keyboard settings (xkb layout, repeat rate/delay, numlock) per physical keyboard device, e.g. a different layout on an external keyboard than on a laptop's built-in one. Closes part of #371 (the keyboard piece specifically; touchpad/mouse/etc. per-device config is still not covered by this PR).

```kdl
input {
    keyboard {
        xkb {
            layout "br"
        }
    }

    keyboard "My External Keyboard" {
        xkb {
            layout "us"
        }
    }
}
```

Run `niri msg keyboard-layouts` or check `libinput list-devices` / `/proc/bus/input/devices` to find a device's exact name.

Named keyboard blocks inherit any setting they don't specify from the unnamed block in the same `input` section (so you don't need to repeat `repeat-rate`/`numlock`/etc. in every block), then fall back to the regular defaults.

## Background

This picks up where #417 left off — same underlying idea (there's no way to have more than one active Wayland keymap per seat, so per-device config means re-resolving and re-applying the config for whichever device most recently sent a key event), but rebased on current `main` and adjusted where the codebase has moved on since 2024:

- `Input::keyboards: Vec<Keyboard>` replaces the resolve-independently approach from #417 with cascading resolution: named blocks inherit from the unnamed block in the same section rather than always falling back to bare defaults for anything unset.
- Config reload now clears the per-device resolved-config cache and resets the tracked active keyboard to the fallback when `input.keyboards` changes, so edits take effect on the next keystroke instead of being masked by stale cached per-device configs (this was left as a known gap in #417's review).
- `xkb.file` (raw keymap file override) is honored per-device too, going through the existing `set_xkb_file` path instead of always falling through to the rules-based `XkbConfig` path.
- Bind key repeat and the a11y repeat-delay heuristic now use the currently tracked keyboard's repeat settings instead of always the fallback keyboard's.
- Device name matching is case-insensitive, per review feedback on #417.

## Known limitation

`track-layout "window"` combined with multiple configured keyboards has the same open question raised on #417: per-surface layout tracking currently stores one `KeyboardLayout` per surface, not one per (keyboard, surface) pair, so switching between two `Window`-tracked keyboards and expecting independent per-keyboard-per-window layout memory isn't fully correct. This doesn't affect the common case of keyboards each having a single fixed layout (`track-layout` defaults to `Global`, which is unaffected), or of only the fallback keyboard using `Window` tracking. Flagging this here rather than trying to redesign per-surface layout tracking in this PR — happy to follow up if that's wanted.

XWayland clients generally see one process-wide X11 keymap, so per-keyboard layouts may not be reflected correctly in X11-only clients (noted in the wiki docs).

## Testing

- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --check` all pass.
- Manually tested on a real tty/udev session with two physical keyboards (a laptop's built-in keyboard on `br` and an external keyboard named via a `keyboard "..."` block on `us`): typing on each keyboard produces the correct layout's characters, confirming the device is resolved correctly and the keymap switches on keystroke as expected.