### PR TITLE
Fix #1457: Clean up layer surfaces when removing outputs

### DIFF
--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2932,9 +2932,20 @@ impl Niri {
     }
 
     pub fn remove_output(&mut self, output: &Output) {
-        for layer in layer_map_for_output(output).layers() {
+        let mut layer_map = layer_map_for_output(output);
+        let layers = layer_map.layers().cloned().collect::<Vec<_>>();
+        for layer in layers {
             layer.layer_surface().send_close();
+
+            layer_map.unmap_layer(&layer);
+            self.unmapped_layer_surfaces.remove(layer.wl_surface());
+            self.mapped_layer_surfaces.remove(&layer);
+
+            if self.layer_shell_on_demand_focus.as_ref() == Some(&layer) {
+                self.layer_shell_on_demand_focus = None;
+            }
         }
+        drop(layer_map);
 
         self.layout.remove_output(output);
         self.global_space.unmap_output(output);

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -392,6 +392,12 @@ impl Window {
 }
 
 impl LayerSurface {
+    pub fn destroy(&self) {
+        self.viewport.destroy();
+        self.layer_surface.destroy();
+        self.surface.destroy();
+    }
+
     pub fn commit(&self) {
         self.surface.commit();
     }

--- a/src/tests/remove_output.rs
+++ b/src/tests/remove_output.rs
@@ -1,3 +1,8 @@
+use smithay::desktop::layer_map_for_output;
+use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::Layer;
+use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::KeyboardInteractivity;
+
+use super::client::LayerConfigureProps;
 use super::*;
 
 #[test]
@@ -31,4 +36,86 @@ fn set_fullscreen_on_removed_output_does_not_panic() {
     let window = f.client(id).window(&surface);
     window.set_fullscreen(Some(&wl_output));
     f.double_roundtrip(id);
+}
+
+#[test]
+fn remove_output_cleans_up_layer_surfaces() {
+    let mut f = Fixture::new();
+    f.add_output(1, (1920, 1080));
+    f.add_output(2, (1280, 720));
+
+    let id = f.add_client();
+    f.double_roundtrip(id);
+    let surviving_wl_output = f.client(id).output("headless-1");
+    let wl_output = f.client(id).output("headless-2");
+
+    let surviving_layer =
+        f.client(id)
+            .create_layer(Some(&surviving_wl_output), Layer::Top, "surviving");
+    let surviving_surface = surviving_layer.surface.clone();
+    surviving_layer.set_configure_props(LayerConfigureProps {
+        size: Some((100, 100)),
+        ..Default::default()
+    });
+    surviving_layer.commit();
+    f.double_roundtrip(id);
+
+    let surviving_layer = f.client(id).layer(&surviving_surface);
+    surviving_layer.attach_new_buffer();
+    surviving_layer.set_size(100, 100);
+    surviving_layer.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    let layer = f
+        .client(id)
+        .create_layer(Some(&wl_output), Layer::Top, "removed");
+    let surface = layer.surface.clone();
+    layer.set_configure_props(LayerConfigureProps {
+        size: Some((100, 100)),
+        kb_interactivity: Some(KeyboardInteractivity::OnDemand),
+        ..Default::default()
+    });
+    layer.commit();
+    f.double_roundtrip(id);
+
+    let layer = f.client(id).layer(&surface);
+    layer.attach_new_buffer();
+    layer.set_size(100, 100);
+    layer.ack_last_and_commit();
+    f.double_roundtrip(id);
+
+    let unmapped_layer = f
+        .client(id)
+        .create_layer(Some(&wl_output), Layer::Top, "unmapped");
+    let unmapped_surface = unmapped_layer.surface.clone();
+    f.double_roundtrip(id);
+
+    assert_eq!(f.niri().mapped_layer_surfaces.len(), 2);
+    assert_eq!(f.niri().unmapped_layer_surfaces.len(), 1);
+    assert!(f.niri().layer_shell_on_demand_focus.is_some());
+
+    let output = f.niri_output(2);
+    f.niri().remove_output(&output);
+
+    let niri = f.niri();
+    assert_eq!(niri.mapped_layer_surfaces.len(), 1);
+    assert!(niri
+        .mapped_layer_surfaces
+        .keys()
+        .any(|layer| layer.namespace() == "surviving"));
+    assert!(niri.unmapped_layer_surfaces.is_empty());
+    assert!(niri.layer_shell_on_demand_focus.is_none());
+    assert_eq!(layer_map_for_output(&output).layers().count(), 0);
+
+    f.double_roundtrip(id);
+
+    assert!(!f.client(id).layer(&surviving_surface).close_requested);
+    assert!(f.client(id).layer(&surface).close_requested);
+    assert!(f.client(id).layer(&unmapped_surface).close_requested);
+
+    f.client(id).layer(&surface).destroy();
+    f.client(id).layer(&unmapped_surface).destroy();
+    f.double_roundtrip(id);
+
+    assert_eq!(f.niri().mapped_layer_surfaces.len(), 1);
 }


### PR DESCRIPTION
## What changed

When an output was removed, Niri sent its layer surfaces `closed` and then removed the output from the layout. If a client destroyed a layer afterward, `layer_destroyed()` could no longer find its `LayerMap`, so the corresponding `MappedLayer` and buffer remained in `mapped_layer_surfaces` indefinitely.

Clean up the output's Smithay layer map plus Niri's mapped, unmapped, and on-demand-focus tracking before removing the output from the layout. Later client destruction remains safe, and layers on other outputs are left alone.

Fixes #1457. 

## Regression coverage

The client/server test creates mapped layers on two outputs, plus an unmapped and on-demand-focused layer on the output being removed. It verifies selective immediate cleanup, `closed` delivery only to affected layers, and safe late client destruction.

On unpatched `dd75865f`, the test fails at the cleanup invariant with 2 mapped layers remaining instead of 1. With this change, it passes.

## Validation

- `cargo test --all --exclude niri-visual-tests -- --nocapture`
- `cargo clippy --all --all-targets`
- `cargo fmt --all -- --check` using the flake's nightly rustfmt
- `nix flake check`

I also ran a minimal fullscreen Quickshell background layer under patched nested Niri and used a temporary local harness to perform 20 real output remove/add cycles. The harness was removed before committing. After the first and twentieth cycles (plus a 15-second cleanup grace period), the compositor's DRM counters were identical:

| Counter | Cycle 1 | Cycle 20 |
| --- | ---: | ---: |
| total | 114608 KiB | 114608 KiB |
| shared | 80 MiB | 80 MiB |
| resident | 114592 KiB | 114592 KiB |

The layer was mapped normally after the final restore. The unfixed reproducer accumulated approximately 38912 KiB per cycle.

Detailed reproduction and investigation: https://github.com/samuela/nixos-config/issues/10

## Matched A/B measurement (DRM-backed VM)

I also ran a matched A/B experiment in a single QEMU virtio-gpu guest running Niri's real TTY/DRM backend (no KVM needed; it runs under TCG with llvmpipe software EGL). The same synthetic layer-shell client (a fullscreen background layer backed by an explicit 2560x1600 DMA-BUF of 15.625 MiB, recreated fresh after every output restore like a shell's per-screen surface) performs 10 output off/on cycles against unpatched `dd75865f` and then against this PR (`ecb95377`) in the same guest with identical timing; the only difference is the compositor binary.

Unpatched Niri retains one stale `MappedLayer` per cycle: 10 stale layers after 10 cycles, each still holding its 15.625 MiB DMA-BUF payload, for 156.25 MiB retained in total. With this PR, zero stale layers and zero retained bytes at every cycle.

![Retained stale DMA-BUF payload (top) and stale layer-surface count (bottom) per output off/on cycle, unpatched vs fixed](https://gist.githubusercontent.com/samuela/780868e1fb7122d2866fbae4d946a576/raw/leak-before-after.png)

The full harness (VM test definition, collector, synthetic client), the env-gated instrumentation patch applied identically to both revisions (not part of this PR), the raw CSVs, and the compositor logs are published here: https://gist.github.com/samuela/780868e1fb7122d2866fbae4d946a576.

Since kernel-side DRM memory accounting is not observable on the virtio path, the plot shows compositor-side retention (stale layer surfaces and their exact buffer payload), which on real hardware is the GPU-backed shared memory accumulation documented in the postmortem linked above.
