### PR TITLE
feat: add ignore-client-size window rule

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1804,6 +1804,7 @@ mod tests {
                     min_height: None,
                     max_width: None,
                     max_height: None,
+                    ignore_client_size: None,
                     focus_ring: BorderRule {
                         off: true,
                         on: false,

--- a/niri-config/src/window_rule.rs
+++ b/niri-config/src/window_rule.rs
@@ -44,6 +44,8 @@ pub struct WindowRule {
     pub max_width: Option<u16>,
     #[knuffel(child, unwrap(argument))]
     pub max_height: Option<u16>,
+    #[knuffel(child, unwrap(argument))]
+    pub ignore_client_size: Option<bool>,
 
     #[knuffel(child, default)]
     pub focus_ring: BorderRule,

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -1219,11 +1219,7 @@ impl LayoutElement for Mapped {
     }
 
     fn requested_size(&self) -> Option<Size<i32, Logical>> {
-        if self.rules.ignore_client_size {
-            None
-        } else {
-            self.toplevel().with_pending_state(|state| state.size)
-        }
+        self.toplevel().with_pending_state(|state| state.size)
     }
 
     fn expected_size(&self) -> Option<Size<i32, Logical>> {

--- a/src/window/mapped.rs
+++ b/src/window/mapped.rs
@@ -1219,7 +1219,11 @@ impl LayoutElement for Mapped {
     }
 
     fn requested_size(&self) -> Option<Size<i32, Logical>> {
-        self.toplevel().with_pending_state(|state| state.size)
+        if self.rules.ignore_client_size {
+            None
+        } else {
+            self.toplevel().with_pending_state(|state| state.size)
+        }
     }
 
     fn expected_size(&self) -> Option<Size<i32, Logical>> {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -82,6 +82,9 @@ pub struct ResolvedWindowRules {
     /// Extra bound on the maximum window height.
     pub max_height: Option<u16>,
 
+    /// Ignore client-provided size limits
+    pub ignore_client_size: bool,
+
     /// Focus ring overrides.
     pub focus_ring: BorderRule,
     /// Window border overrides.
@@ -269,6 +272,9 @@ impl ResolvedWindowRules {
                 if let Some(x) = rule.max_height {
                     resolved.max_height = Some(x);
                 }
+                if let Some(x) = rule.ignore_client_size {
+                    resolved.ignore_client_size = x;
+                }
 
                 resolved.focus_ring.merge_with(&rule.focus_ring);
                 resolved.border.merge_with(&rule.border);
@@ -318,6 +324,13 @@ impl ResolvedWindowRules {
     }
 
     pub fn apply_min_size(&self, min_size: Size<i32, Logical>) -> Size<i32, Logical> {
+        if self.ignore_client_size {
+            return Size::new(
+                self.min_width.unwrap_or(0).into(),
+                self.min_height.unwrap_or(0).into(),
+            );
+        }
+
         let mut size = min_size;
 
         if let Some(x) = self.min_width {
@@ -331,6 +344,13 @@ impl ResolvedWindowRules {
     }
 
     pub fn apply_max_size(&self, max_size: Size<i32, Logical>) -> Size<i32, Logical> {
+        if self.ignore_client_size {
+            return Size::new(
+                self.max_width.unwrap_or(0).into(),
+                self.max_height.unwrap_or(0).into(),
+            );
+        }
+
         let mut size = max_size;
 
         if let Some(x) = self.max_width {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -396,10 +396,20 @@ impl ResolvedWindowRules {
             let current = guard.current();
             (current.min_size, current.max_size)
         });
-        let (min_size, max_size) = self.apply_min_max_size(min_size, max_size);
+
+        let (min_height, max_height) = if self.ignore_client_size {
+            if let (Some(min_height), Some(max_height)) = (self.min_height, self.max_height) {
+                (min_height.into(), max_height.into())
+            } else {
+                (min_size.h, max_size.h)
+            }
+        } else {
+            let (min_size, max_size) = self.apply_min_max_size(min_size, max_size);
+            (min_size.h, max_size.h)
+        };
 
         // We open fixed-height windows as floating.
-        min_size.h > 0 && min_size.h == max_size.h
+        min_height > 0 && min_height == max_height
     }
 }
 


### PR DESCRIPTION
Allows ignoring the client-provided minimum and maximum sizes via `window-rule { ignore-client-size true }`.