### PR TITLE
layout: Keep focus on a dialog when focus-follows-mouse crosses its parent

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1496,6 +1496,15 @@ impl<W: LayoutElement> Layout<W> {
     }
 
     pub fn should_trigger_focus_follows_mouse_on(&self, window: &W::Id) -> bool {
+        // A dialog keeps the focus while the pointer crosses its parent. The parent is the
+        // window the dialog is about and is usually blocked by it, so moving from the dialog
+        // over the parent is on the way somewhere rather than a request to type into the
+        // parent. Taking the focus there would strand keyboard input on a window that cannot
+        // accept it until the dialog is dismissed.
+        if self.focused_window_is_descendant_of(window) {
+            return false;
+        }
+
         // During an animation, it's easy to trigger focus-follows-mouse on the previous workspace,
         // especially when clicking to switch workspace on a bar of some kind. This cancels the
         // workspace switch, which is annoying and not intended.
@@ -1528,6 +1537,32 @@ impl<W: LayoutElement> Layout<W> {
         }
 
         ws_idx == mon.active_workspace_idx
+    }
+
+    /// Returns whether the focused window is a child of `window`, directly or through other
+    /// children (a dialog of a dialog).
+    fn focused_window_is_descendant_of(&self, window: &W::Id) -> bool {
+        let Some(focus) = self.focus() else {
+            return false;
+        };
+
+        let mut child = focus;
+        // The parent chain is no longer than the window list. The bound only guards against a
+        // loop, which Smithay rejects when the parent is set.
+        for _ in 0..self.windows().count() {
+            let Some(parent) = self
+                .windows()
+                .map(|(_, win)| win)
+                .find(|win| child.is_child_of(win))
+            else {
+                return false;
+            };
+            if parent.id() == window {
+                return true;
+            }
+            child = parent;
+        }
+        false
     }
 
     pub fn activate_window(&mut self, window: &W::Id) {

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -1655,6 +1655,51 @@ fn check_ops_with_options(
 }
 
 #[test]
+fn focus_follows_mouse_keeps_focus_on_dialog() {
+    let mut layout = check_ops([
+        Op::AddOutput(1),
+        Op::AddWindow {
+            params: TestWindowParams::new(1),
+        },
+        Op::AddWindow {
+            params: TestWindowParams {
+                parent_id: Some(1),
+                is_floating: true,
+                ..TestWindowParams::new(2)
+            },
+        },
+        Op::AddWindow {
+            params: TestWindowParams {
+                parent_id: Some(2),
+                is_floating: true,
+                ..TestWindowParams::new(3)
+            },
+        },
+        Op::AddWindow {
+            params: TestWindowParams::new(4),
+        },
+    ]);
+
+    // With a dialog focused, neither its parent nor its grandparent takes the focus from it;
+    // an unrelated window does.
+    layout.activate_window(&3);
+    assert!(!layout.should_trigger_focus_follows_mouse_on(&2));
+    assert!(!layout.should_trigger_focus_follows_mouse_on(&1));
+    assert!(layout.should_trigger_focus_follows_mouse_on(&4));
+
+    layout.activate_window(&2);
+    assert!(!layout.should_trigger_focus_follows_mouse_on(&1));
+    assert!(layout.should_trigger_focus_follows_mouse_on(&3));
+    assert!(layout.should_trigger_focus_follows_mouse_on(&4));
+
+    // With the parent focused, its dialogs take the focus as any window does.
+    layout.activate_window(&1);
+    assert!(layout.should_trigger_focus_follows_mouse_on(&2));
+    assert!(layout.should_trigger_focus_follows_mouse_on(&3));
+    assert!(layout.should_trigger_focus_follows_mouse_on(&4));
+}
+
+#[test]
 fn operations_dont_panic() {
     if std::env::var_os("RUN_SLOW_TESTS").is_none() {
         eprintln!("ignoring slow test");


### PR DESCRIPTION
Fixes focus-follows-mouse taking the focus away from a dialog when the pointer crosses the dialog's parent.

## Problem

A dialog is centred on its parent, so with `focus-follows-mouse` the pointer crosses the parent on almost every trip to and from the dialog. The parent then takes the focus, the dialog drops to its backdrop state, and keyboard input goes to a window that a modal dialog is blocking. Every dialog needs a click before Enter or Escape work.

To reproduce on 26.04 and current main with `input { focus-follows-mouse }`, open a GTK3 window and from it a modal `Gtk.MessageDialog` with `transient_for` set. The dialog opens focused. Move the pointer from the dialog over the parent. The parent takes the focus. This happens with native Wayland and with X11 clients through xwayland-satellite alike.

## Change

`Layout::should_trigger_focus_follows_mouse_on()` returns `false` when the focused window is a child of the hovered window, directly or through further children, using `LayoutElement::is_child_of()`. Nothing else changes. Clicking the parent still focuses it, and with the parent focused its dialogs take the focus as any window does. The walk up the parent chain is bounded by the window count as a guard. Smithay already rejects a parent that would form a loop.

niri does not implement `xdg_dialog_v1`, so whether a child is modal is unknown and the parent relation is the available signal. A non modal child, a tool or preferences window for instance, therefore keeps the focus while the pointer crosses its main window as well, which seems the right default since the child is the window in use. Smithay provides `xdg_dialog_v1` in `wayland::shell::xdg::dialog`, so the rule can be narrowed to modal children later if wanted.

## Testing

The layout test `focus_follows_mouse_keeps_focus_on_dialog` covers a direct child, a grandchild, an unrelated window and the parent itself being focused. The full test suite and clippy pass.

Tested by hand in a nested niri with `focus-follows-mouse`, a GTK3 parent and a modal `MessageDialog`, moving the pointer with a `zwlr_virtual_pointer_v1` client from the dialog across the parent and back. Stock 26.04 logs `dialog focus-out` then `parent focus-in` as the pointer crosses the parent. With this change the dialog keeps the focus, also with the pointer parked deep in the parent, a click on the parent focuses the parent, and a third unrelated window still takes the focus when hovered. The same holds with `GDK_BACKEND=x11` through xwayland-satellite.
