### PR TITLE
input: release physical keys before sleep

### DIFF
--- a/src/dbus/freedesktop_login1.rs
+++ b/src/dbus/freedesktop_login1.rs
@@ -1,9 +1,21 @@
-use futures_util::StreamExt;
-use zbus::fdo;
-use zbus::names::InterfaceName;
+use futures_util::{select, StreamExt};
+
+#[zbus::proxy(
+    interface = "org.freedesktop.login1.Manager",
+    default_service = "org.freedesktop.login1",
+    default_path = "/org/freedesktop/login1"
+)]
+trait Login1Manager {
+    #[zbus(property)]
+    fn lid_closed(&self) -> zbus::Result<bool>;
+
+    #[zbus(signal)]
+    fn prepare_for_sleep(&self, start: bool) -> zbus::Result<()>;
+}
 
 pub enum Login1ToNiri {
     LidClosedChanged(bool),
+    PrepareForSleep(bool),
 }
 
 pub fn start(
@@ -13,92 +25,88 @@ pub fn start(
 
     let async_conn = conn.inner().clone();
     let future = async move {
-        let proxy = fdo::PropertiesProxy::new(
-            &async_conn,
-            "org.freedesktop.login1",
-            "/org/freedesktop/login1",
-        )
-        .await;
-        let proxy = match proxy {
+        let proxy = match Login1ManagerProxy::new(&async_conn).await {
             Ok(x) => x,
             Err(err) => {
-                warn!("error creating PropertiesProxy: {err:?}");
+                warn!("error creating login1 ManagerProxy: {err:?}");
                 return;
             }
         };
 
-        let mut props_changed = match proxy.receive_properties_changed().await {
+        let mut prepare_for_sleep = match proxy.receive_prepare_for_sleep().await {
             Ok(x) => x,
             Err(err) => {
-                warn!("error subscribing to PropertiesChanged: {err:?}");
+                warn!("error subscribing to PrepareForSleep: {err:?}");
+                return;
+            }
+        }
+        .fuse();
+        let mut lid_closed_changed = proxy.receive_lid_closed_changed().await.fuse();
+
+        let mut lid_closed = match proxy.lid_closed().await {
+            Ok(x) => x,
+            Err(err) => {
+                warn!("error receiving initial lid state: {err:?}");
                 return;
             }
         };
-
-        let props = proxy
-            .get_all(InterfaceName::try_from("org.freedesktop.login1.Manager").unwrap())
-            .await;
-        let mut props = match props {
-            Ok(x) => x,
-            Err(err) => {
-                warn!("error receiving initial properties: {err:?}");
-                return;
-            }
-        };
-
-        trace!("initial properties: {props:?}");
-
-        let mut lid_closed = props
-            .remove("LidClosed")
-            .and_then(|value| bool::try_from(value).ok())
-            .unwrap_or_default();
 
         if let Err(err) = to_niri.send(Login1ToNiri::LidClosedChanged(lid_closed)) {
             warn!("error sending initial lid state to niri: {err:?}");
             return;
         };
 
-        while let Some(signal) = props_changed.next().await {
-            let args = match signal.args() {
-                Ok(args) => args,
-                Err(err) => {
-                    warn!("error parsing PropertiesChanged args: {err:?}");
-                    return;
+        loop {
+            select! {
+                changed = lid_closed_changed.next() => {
+                    let Some(changed) = changed else {
+                        warn!("LidClosed property change stream ended");
+                        return;
+                    };
+                    let new_lid_closed = match changed.get().await {
+                        Ok(x) => x,
+                        Err(err) => {
+                            warn!("error receiving changed lid state: {err:?}");
+                            return;
+                        }
+                    };
+
+                    if new_lid_closed == lid_closed {
+                        continue;
+                    }
+
+                    lid_closed = new_lid_closed;
+                    if let Err(err) = to_niri.send(Login1ToNiri::LidClosedChanged(lid_closed)) {
+                        warn!("error sending message to niri: {err:?}");
+                        return;
+                    };
                 }
-            };
+                signal = prepare_for_sleep.next() => {
+                    let Some(signal) = signal else {
+                        warn!("PrepareForSleep signal stream ended");
+                        return;
+                    };
+                    let args = match signal.args() {
+                        Ok(args) => args,
+                        Err(err) => {
+                            warn!("error parsing PrepareForSleep args: {err:?}");
+                            return;
+                        }
+                    };
 
-            let mut new_lid_closed = lid_closed;
-            let mut changed = false;
-            for (name, value) in args.changed_properties() {
-                trace!("changed property: {name} => {value:?}");
-                if *name != "LidClosed" {
-                    continue;
+                    if let Err(err) = to_niri.send(Login1ToNiri::PrepareForSleep(args.start)) {
+                        warn!("error sending message to niri: {err:?}");
+                        return;
+                    }
                 }
-
-                new_lid_closed = bool::try_from(value).unwrap_or(new_lid_closed);
-                changed = true;
             }
-
-            if !changed {
-                continue;
-            }
-
-            if new_lid_closed == lid_closed {
-                continue;
-            }
-
-            lid_closed = new_lid_closed;
-            if let Err(err) = to_niri.send(Login1ToNiri::LidClosedChanged(lid_closed)) {
-                warn!("error sending message to niri: {err:?}");
-                return;
-            };
         }
     };
 
     let task = conn
         .inner()
         .executor()
-        .spawn(future, "monitor login1 property changes");
+        .spawn(future, "monitor login1 changes");
     task.detach();
 
     Ok(conn)

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -19,6 +19,8 @@ use smithay::backend::input::{
 };
 use smithay::backend::libinput::LibinputInputBackend;
 use smithay::input::dnd::DnDGrab;
+#[cfg(feature = "dbus")]
+use smithay::input::keyboard::KeyboardSource;
 use smithay::input::keyboard::{keysyms, FilterResult, Keysym, Layout, ModifiersState};
 use smithay::input::pointer::{
     AxisFrame, ButtonEvent, CursorIcon, CursorImageStatus, Focus, GestureHoldBeginEvent,
@@ -132,6 +134,17 @@ impl<D: SeatHandler + TabletSeatHandler> AnyStartData<D> {
 }
 
 impl State {
+    #[cfg(feature = "dbus")]
+    pub(crate) fn release_physical_keys(&mut self) {
+        if let Some(token) = self.niri.bind_repeat_timer.take() {
+            self.niri.event_loop.remove(token);
+        }
+        self.niri.suppressed_keys.clear();
+
+        let keyboard = self.niri.seat.get_keyboard().unwrap();
+        keyboard.release_source(self, KeyboardSource::MAIN);
+    }
+
     pub fn process_input_event<I: InputBackend + 'static>(&mut self, event: InputEvent<I>)
     where
         I::Device: 'static, // Needed for downcasting.

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2226,10 +2226,18 @@ impl State {
 
     #[cfg(feature = "dbus")]
     pub fn on_login1_msg(&mut self, msg: Login1ToNiri) {
-        let Login1ToNiri::LidClosedChanged(is_closed) = msg;
-
-        trace!("login1 lid {}", if is_closed { "closed" } else { "opened" });
-        self.set_lid_closed(is_closed);
+        match msg {
+            Login1ToNiri::LidClosedChanged(is_closed) => {
+                trace!("login1 lid {}", if is_closed { "closed" } else { "opened" });
+                self.set_lid_closed(is_closed);
+            }
+            Login1ToNiri::PrepareForSleep(start) => {
+                trace!("login1 preparing for sleep: {start}");
+                if start {
+                    self.release_physical_keys();
+                }
+            }
+        }
     }
 
     #[cfg(feature = "dbus")]

--- a/src/tests/keyboard.rs
+++ b/src/tests/keyboard.rs
@@ -1,0 +1,53 @@
+use calloop::timer::{TimeoutAction, Timer};
+use smithay::backend::input::{KeyState, Keycode};
+use smithay::input::keyboard::FilterResult;
+use smithay::utils::SERIAL_COUNTER;
+
+use super::Fixture;
+use crate::dbus::freedesktop_login1::Login1ToNiri;
+
+#[test]
+fn preparing_for_sleep_releases_physical_keys() {
+    let mut fixture = Fixture::new();
+    let keyboard = fixture.niri().seat.get_keyboard().unwrap();
+    let keycode = Keycode::from(28u32);
+
+    keyboard.input(
+        fixture.niri_state(),
+        keycode,
+        KeyState::Pressed,
+        SERIAL_COUNTER.next_serial(),
+        0,
+        |_, _, _| FilterResult::<()>::Forward,
+    );
+    fixture.niri().suppressed_keys.insert(keycode);
+    let token = fixture
+        .niri()
+        .event_loop
+        .insert_source(Timer::immediate(), |_, _, _| TimeoutAction::Drop)
+        .unwrap();
+    fixture.niri().bind_repeat_timer = Some(token);
+
+    fixture
+        .niri_state()
+        .on_login1_msg(Login1ToNiri::PrepareForSleep(false));
+    assert_eq!(keyboard.pressed_keys(), [keycode].into());
+
+    fixture
+        .niri_state()
+        .on_login1_msg(Login1ToNiri::PrepareForSleep(true));
+    assert!(keyboard.pressed_keys().is_empty());
+    assert!(fixture.niri().suppressed_keys.is_empty());
+    assert!(fixture.niri().bind_repeat_timer.is_none());
+
+    // The delayed physical release after resume is absorbed.
+    let _: Option<()> = keyboard.input(
+        fixture.niri_state(),
+        keycode,
+        KeyState::Released,
+        SERIAL_COUNTER.next_serial(),
+        0,
+        |_, _, _| panic!("duplicate release reached the input filter"),
+    );
+    assert!(keyboard.pressed_keys().is_empty());
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -7,6 +7,8 @@ mod server;
 mod animations;
 mod floating;
 mod fullscreen;
+#[cfg(feature = "dbus")]
+mod keyboard;
 mod layer_shell;
 mod remove_output;
 mod transactions;


### PR DESCRIPTION
## Summary

- subscribe to login1's `PrepareForSleep` signal
- release physical keyboard state before `user.slice` is frozen
- cancel compositor key repeat and clear suppressed keys during the reset
- add a regression test covering a delayed release after resume

This prevents clients from treating a key as held throughout suspend when its physical release is delivered only after resume.

Fixes #4509.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets`
- `cargo test --all --exclude niri-visual-tests -- --nocapture`
- checked no-default, DBus-only, and systemd-only feature builds
- completed seven real suspend/resume cycles with the previous one-second workaround disabled

## AI assistance

I used an AI coding assistant during investigation and implementation. I reviewed the resulting behavior and validated the patch locally with the automated and real suspend tests listed above.