### PR TITLE
feat(input): add configurable three-finger drag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ fastrand = "2.5.0"
 futures-util = { version = "0.3.33", default-features = false, features = ["std", "io"] }
 git-version = "0.3.9"
 glam = "0.33"
-input = { version = "0.10.0", features = ["libinput_1_21"] }
+input = { version = "0.10.0", features = ["libinput_1_28"] }
 keyframe = { version = "1.1.1", default-features = false }
 libc = "0.2.189"
 libdisplay-info = "0.3.0"

--- a/niri-config/src/input.rs
+++ b/niri-config/src/input.rs
@@ -21,6 +21,7 @@ pub struct Input {
     pub warp_mouse_to_focus: Option<WarpMouseToFocus>,
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
     pub workspace_auto_back_and_forth: bool,
+    pub gesture_swipe_fingers: Option<u32>,
     pub mod_key: Option<ModKey>,
     pub mod_key_nested: Option<ModKey>,
 }
@@ -49,6 +50,8 @@ pub struct InputPart {
     pub focus_follows_mouse: Option<FocusFollowsMouse>,
     #[knuffel(child)]
     pub workspace_auto_back_and_forth: Option<Flag>,
+    #[knuffel(child, unwrap(argument))]
+    pub gesture_swipe_fingers: Option<u32>,
     #[knuffel(child, unwrap(argument, str))]
     pub mod_key: Option<ModKey>,
     #[knuffel(child, unwrap(argument, str))]
@@ -78,6 +81,7 @@ impl MergeWith<InputPart> for Input {
             (self, part),
             warp_mouse_to_focus,
             focus_follows_mouse,
+            gesture_swipe_fingers,
             mod_key,
             mod_key_nested,
         );
@@ -197,6 +201,8 @@ pub struct Touchpad {
     pub drag: Option<bool>,
     #[knuffel(child)]
     pub drag_lock: bool,
+    #[knuffel(child, unwrap(argument, str))]
+    pub three_finger_drag: Option<ThreeFingerDrag>,
     #[knuffel(child)]
     pub natural_scroll: bool,
     #[knuffel(child, unwrap(argument, str))]
@@ -289,6 +295,23 @@ pub struct Trackball {
     pub left_handed: bool,
     #[knuffel(child)]
     pub middle_emulation: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThreeFingerDrag {
+    Disabled,
+    EnabledThreeFinger,
+    EnabledFourFinger,
+}
+
+impl From<ThreeFingerDrag> for input::ThreeFingerDragState {
+    fn from(value: ThreeFingerDrag) -> Self {
+        match value {
+            ThreeFingerDrag::Disabled => Self::Disabled,
+            ThreeFingerDrag::EnabledThreeFinger => Self::EnabledThreeFinger,
+            ThreeFingerDrag::EnabledFourFinger => Self::EnabledFourFinger,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -448,6 +471,21 @@ impl FromStr for ModKey {
             "iso_level3_shift" | "mod5" => Ok(Self::IsoLevel3Shift),
             "iso_level5_shift" | "mod3" => Ok(Self::IsoLevel5Shift),
             _ => Err(miette!("invalid Mod key: {s}")),
+        }
+    }
+}
+
+impl FromStr for ThreeFingerDrag {
+    type Err = miette::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "disabled" => Ok(Self::Disabled),
+            "3fg" => Ok(Self::EnabledThreeFinger),
+            "4fg" => Ok(Self::EnabledFourFinger),
+            _ => Err(miette!(
+                r#"invalid three-finger drag mode, can be "disabled", "3fg", or "4fg""#
+            )),
         }
     }
 }

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -699,6 +699,7 @@ mod tests {
                     dwt
                     dwtp
                     drag true
+                    three-finger-drag "3fg"
                     click-method "clickfinger"
                     accel-speed 0.2
                     accel-profile "flat"
@@ -758,6 +759,7 @@ mod tests {
                 warp-mouse-to-focus
                 focus-follows-mouse
                 workspace-auto-back-and-forth
+                gesture-swipe-fingers 4
 
                 mod-key "Mod5"
                 mod-key-nested "Super"
@@ -1021,6 +1023,9 @@ mod tests {
                         true,
                     ),
                     drag_lock: false,
+                    three_finger_drag: Some(
+                        EnabledThreeFinger,
+                    ),
                     natural_scroll: false,
                     click_method: Some(
                         Clickfinger,
@@ -1162,6 +1167,9 @@ mod tests {
                     },
                 ),
                 workspace_auto_back_and_forth: true,
+                gesture_swipe_fingers: Some(
+                    4,
+                ),
                 mod_key: Some(
                     IsoLevel3Shift,
                 ),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3935,7 +3935,14 @@ impl State {
             return;
         }
 
-        if event.fingers() == 3 {
+        let gesture_swipe_fingers = self
+            .niri
+            .config
+            .borrow()
+            .input
+            .gesture_swipe_fingers
+            .unwrap_or(3);
+        if event.fingers() == gesture_swipe_fingers {
             self.niri.gesture_swipe_3f_cumulative = Some((0., 0.));
 
             // We handled this event.
@@ -4890,6 +4897,13 @@ pub fn apply_libinput_settings(config: &niri_config::Input, device: &mut input::
         } else {
             let default = device.config_tap_default_drag_enabled();
             let _ = device.config_tap_set_drag_enabled(default);
+        }
+
+        if let Some(three_finger_drag) = c.three_finger_drag {
+            let _ = device.config_3fg_drag_set_enabled(three_finger_drag.into());
+        } else {
+            let default = device.config_3fg_drag_get_default_enabled();
+            let _ = device.config_3fg_drag_set_enabled(default);
         }
 
         if let Some(accel_profile) = c.accel_profile {


### PR DESCRIPTION
Add configurable three- or four-finger touchpad dragging, with an adjustable swipe-finger count to avoid gesture conflicts.