### PR TITLE
commit-on-modifier-release recent windows enhancement

### DIFF
--- a/docs/wiki/Configuration:-Recent-Windows.md
+++ b/docs/wiki/Configuration:-Recent-Windows.md
@@ -10,6 +10,7 @@ Here is an outline of the available settings and their default values:
 recent-windows {
     // off
     debounce-ms 750
+    // commit-on-modifier-release
 
     open-delay-ms 150
 
@@ -62,6 +63,20 @@ recent-windows {
     // Commit windows to the recent windows list as soon as they're focused,
     // with no debounce delay.
     debounce-ms 0
+}
+```
+
+### `commit-on-modifier-release`
+
+<sup>Since: next release</sup>
+
+When set, releasing modifier keys becomes the signal for committing a pending window to the recent windows list, and is used instead of `debounce-ms`.
+
+This is meant for keyboard navigation under a held modifier, e.g. <kbd>Mod</kbd><kbd>L</kbd> bound to `focus-column-right`. With this option on, you can hold <kbd>Mod</kbd> and tap through several windows or change direction freely, and nothing gets committed to the recent windows list until you let go of <kbd>Mod</kbd>. `debounce-ms` still applies as a fallback for focus changes that aren't accompanied by a held modifier, such as [`focus-follows-mouse`](./Configuration:-Input.md#focus-follows-mouse) or focus changes requested over IPC.
+
+```kdl
+recent-windows {
+    commit-on-modifier-release
 }
 ```
 

--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -2329,6 +2329,7 @@ mod tests {
             recent_windows: RecentWindows {
                 on: false,
                 debounce_ms: 750,
+                commit_on_modifier_release: false,
                 open_delay_ms: 150,
                 highlight: MruHighlight {
                     active_color: Color {

--- a/niri-config/src/recent_windows.rs
+++ b/niri-config/src/recent_windows.rs
@@ -3,13 +3,14 @@ use std::collections::HashSet;
 use knuffel::errors::DecodeError;
 use smithay::input::keyboard::Keysym;
 
-use crate::utils::{expect_only_children, MergeWith};
+use crate::utils::{expect_only_children, Flag, MergeWith};
 use crate::{Action, Bind, Color, FloatOrInt, Key, Modifiers, Trigger};
 
 #[derive(Debug, PartialEq)]
 pub struct RecentWindows {
     pub on: bool,
     pub debounce_ms: u16,
+    pub commit_on_modifier_release: bool,
     pub open_delay_ms: u16,
     pub highlight: MruHighlight,
     pub previews: MruPreviews,
@@ -21,6 +22,7 @@ impl Default for RecentWindows {
         RecentWindows {
             on: true,
             debounce_ms: 750,
+            commit_on_modifier_release: false,
             open_delay_ms: 150,
             highlight: MruHighlight::default(),
             previews: MruPreviews::default(),
@@ -37,6 +39,8 @@ pub struct RecentWindowsPart {
     pub off: bool,
     #[knuffel(child, unwrap(argument))]
     pub debounce_ms: Option<u16>,
+    #[knuffel(child)]
+    pub commit_on_modifier_release: Option<Flag>,
     #[knuffel(child, unwrap(argument))]
     pub open_delay_ms: Option<u16>,
     #[knuffel(child)]
@@ -55,7 +59,7 @@ impl MergeWith<RecentWindowsPart> for RecentWindows {
         }
 
         merge_clone!((self, part), debounce_ms, open_delay_ms);
-        merge!((self, part), highlight, previews);
+        merge!((self, part), commit_on_modifier_release, highlight, previews);
 
         if let Some(part) = &part.binds {
             // Remove existing binds matching any new bind.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -537,6 +537,32 @@ impl State {
                     }
                 }
 
+                // Allows keyboard navigation when a modifier is held down not to affect
+                // the recent windows list, thereby skipping any intermediate windows
+                // to a particular destination window from affecting the list.
+                if !this.niri.window_mru_ui.is_open()
+                    && this
+                        .niri
+                        .config
+                        .borrow()
+                        .recent_windows
+                        .commit_on_modifier_release
+                {
+                    let mod_down = modifiers.contains(mod_key.to_modifiers());
+                    if mod_down {
+                        if this.niri.mru_nav_anchor.is_none() {
+                            if let Some(focus) = this.niri.layout.focus() {
+                                let id = focus.id();
+                                this.niri.mru_nav_anchor = Some(id);
+                            }
+                        }
+                    } else if this.niri.mru_nav_anchor.is_some() {
+                        // Modifier key released: commit the anchor window, i.e. the
+                        // window that was focused when the modifier was first pressed
+                        this.niri.mru_nav_commit_anchor();
+                    }
+                }
+
                 if pressed && raw == Some(Keysym::Escape) {
                     // Cancel certain grabs on Escape.
                     let pointer = this.niri.seat.get_pointer().unwrap();
@@ -586,7 +612,11 @@ impl State {
 
                     // Interaction with the active window, immediately update the active window's
                     // focus timestamp without waiting for a possible pending MRU lock-in delay.
-                    this.niri.mru_apply_keyboard_commit();
+                    // This is not applied when using commit-on-modifier-release and the modifier
+                    // key is currently held down.
+                    if this.niri.mru_nav_anchor.is_none() {
+                        this.niri.mru_apply_keyboard_commit();
+                    }
                 }
 
                 res
@@ -914,8 +944,11 @@ impl State {
                     .max_by_key(|win| win.get_focus_timestamp())
                     .map(|win| win.window.clone())
                 {
-                    // Commit current focus so repeated focus-window-previous works as expected.
-                    self.niri.mru_apply_keyboard_commit();
+                    // Only commit the window if we are not currently navigating
+                    // between windows
+                    if self.niri.mru_nav_anchor.is_none() {
+                        self.niri.mru_apply_keyboard_commit();
+                    }
 
                     self.focus_window(&window);
                 }
@@ -2359,7 +2392,14 @@ impl State {
                     self.niri.window_mru_ui.advance(direction, filter);
                     self.niri.queue_redraw_mru_output();
                 } else if self.niri.config.borrow().recent_windows.on {
-                    self.niri.mru_apply_keyboard_commit();
+                    // The picker UI is it's own self-contained navigation session,
+                    // so we should commit any in-progress modifier-held navigation
+                    // at this point.
+                    if self.niri.mru_nav_anchor.is_some() {
+                        self.niri.mru_nav_commit_anchor();
+                    } else {
+                        self.niri.mru_apply_keyboard_commit();
+                    }
 
                     let config = self.niri.config.borrow();
                     let scope = scope.unwrap_or(self.niri.window_mru_ui.scope());

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -395,6 +395,7 @@ pub struct Niri {
 
     pub window_mru_ui: WindowMruUi,
     pub pending_mru_commit: Option<PendingMruCommit>,
+    pub mru_nav_anchor: Option<MappedId>,
 
     pub pick_window: Option<async_channel::Sender<Option<MappedId>>>,
     pub pick_color: Option<async_channel::Sender<Option<niri_ipc::PickedColor>>>,
@@ -632,7 +633,7 @@ impl CastTarget {
 #[derive(Debug)]
 pub struct PendingMruCommit {
     id: MappedId,
-    token: RegistrationToken,
+    token: Option<RegistrationToken>,
     stamp: Duration,
 }
 
@@ -1297,8 +1298,25 @@ impl State {
                     let debounce = self.niri.config.borrow().recent_windows.debounce_ms;
                     let debounce = Duration::from_millis(u64::from(debounce));
 
+                    // Prevent debounce from firing if we are using commit-on-modifier-release.
+                    let in_nav_session = self.niri.mru_nav_anchor.is_some();
+
                     if mapped.get_focus_timestamp().is_none() || debounce.is_zero() {
                         mapped.set_focus_timestamp(stamp);
+                    } else if in_nav_session {
+                        // Don't commit, but rather replace the pending window, and clear
+                        // an existing timer
+                        if let Some(PendingMruCommit { token, .. }) =
+                            self.niri.pending_mru_commit.replace(PendingMruCommit {
+                                id: mapped.id(),
+                                token: None,
+                                stamp,
+                            })
+                        {
+                            if let Some(token) = token {
+                                self.niri.event_loop.remove(token);
+                            }
+                        }
                     } else {
                         let timer = Timer::from_duration(debounce);
 
@@ -1313,11 +1331,13 @@ impl State {
                         if let Some(PendingMruCommit { token, .. }) =
                             self.niri.pending_mru_commit.replace(PendingMruCommit {
                                 id: mapped.id(),
-                                token: focus_token,
+                                token: Some(focus_token),
                                 stamp,
                             })
                         {
-                            self.niri.event_loop.remove(token);
+                            if let Some(token) = token {
+                                self.niri.event_loop.remove(token);
+                            }
                         }
                     }
                 }
@@ -2636,6 +2656,7 @@ impl Niri {
 
             window_mru_ui,
             pending_mru_commit: None,
+            mru_nav_anchor: None,
 
             pick_window: None,
             pick_color: None,
@@ -6479,7 +6500,9 @@ impl Niri {
         let Some(pending) = self.pending_mru_commit.take() else {
             return;
         };
-        self.event_loop.remove(pending.token);
+        if let Some(token) = pending.token {
+            self.event_loop.remove(token);
+        }
 
         if let Some(window) = self
             .layout
@@ -6488,6 +6511,46 @@ impl Niri {
             .find(|w| w.id() == pending.id)
         {
             window.set_focus_timestamp(pending.stamp);
+        }
+    }
+
+    /// Complete a modifier-held keyboard navigation session.
+    ///
+    /// Commits the pending destination window (if any), then explicitly makes the window that
+    /// was focused when the session began (`mru_nav_anchor`) rank as "previous" by giving it a
+    /// timestamp just behind the destination's — regardless of how many windows were passed
+    /// through in between, or which bind/feature was used to move between them.
+    pub fn mru_nav_commit_anchor(&mut self) {
+        let Some(anchor) = self.mru_nav_anchor.take() else {
+            return;
+        };
+
+        self.mru_apply_keyboard_commit();
+
+        let Some(dest) = self.layout.focus().map(|mapped| mapped.id()) else {
+            return;
+        };
+        if dest == anchor {
+            return;
+        }
+
+        let Some(dest_stamp) = self
+            .layout
+            .focus()
+            .and_then(|mapped| mapped.get_focus_timestamp())
+        else {
+            return;
+        };
+        let anchor_stamp = dest_stamp.saturating_sub(Duration::from_millis(1));
+
+        if let Some(window) = self
+            .layout
+            .workspaces_mut()
+            .flat_map(|ws| ws.windows_mut())
+            .find(|w| w.id() == anchor)
+        {
+            // Mark the anchor as the previous window accessed
+            window.set_focus_timestamp(anchor_stamp);
         }
     }
 


### PR DESCRIPTION
This PR adds a new config option called `commit-on-modifier-release` that implements the functionality suggested in this [discussion](https://github.com/niri-wm/niri/discussions/3319).

When enabled, this option supersedes `debounce-ms` while the modifier key is held down. This allows users to freely navigate around their windows without any of the intermediate focused windows being committed as the most recently used window. Only when the modifier key is released is the currently focused window made the most recently used one, and the window from which navigation started, the `anchor`, correctly made the window previously used.