### PR TITLE
feat(output): add hardware color matrix (DRM CTM) support

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1191,6 +1191,7 @@ mod tests {
                                 _10,
                             ),
                         ),
+                        color_matrix: None,
                         mode: Some(
                             Mode {
                                 custom: false,
@@ -1237,6 +1238,7 @@ mod tests {
                         transform: Normal,
                         position: None,
                         max_bpc: None,
+                        color_matrix: None,
                         mode: Some(
                             Mode {
                                 custom: true,
@@ -1264,6 +1266,7 @@ mod tests {
                         transform: Normal,
                         position: None,
                         max_bpc: None,
+                        color_matrix: None,
                         mode: None,
                         modeline: Some(
                             Modeline {

--- a/niri-config/src/output.rs
+++ b/niri-config/src/output.rs
@@ -47,6 +47,18 @@ pub struct Modeline {
     pub vsync_polarity: niri_ipc::VSyncPolarity,
 }
 
+/// A 3x3 color matrix, stored row-major.
+///
+/// Applied as a hardware color transformation matrix (DRM CTM) to the output:
+///
+/// ```text
+/// | R' |   | m00 m01 m02 |   | R |
+/// | G' | = | m10 m11 m12 | x | G |
+/// | B' |   | m20 m21 m22 |   | B |
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ColorMatrix(pub [[f64; 3]; 3]);
+
 #[derive(knuffel::Decode, Debug, Clone, PartialEq)]
 pub struct Output {
     #[knuffel(child)]
@@ -61,6 +73,8 @@ pub struct Output {
     pub position: Option<Position>,
     #[knuffel(child, unwrap(argument))]
     pub max_bpc: Option<MaxBpc>,
+    #[knuffel(child)]
+    pub color_matrix: Option<ColorMatrix>,
     #[knuffel(child)]
     pub mode: Option<Mode>,
     #[knuffel(child)]
@@ -104,6 +118,7 @@ impl Default for Output {
             transform: Transform::Normal,
             position: None,
             max_bpc: None,
+            color_matrix: None,
             mode: None,
             modeline: None,
             variable_refresh_rate: None,
@@ -372,6 +387,70 @@ impl<S: ErrorSpan> knuffel::Decode<S> for Mode {
     }
 }
 
+impl<S: ErrorSpan> knuffel::Decode<S> for ColorMatrix {
+    fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+        if let Some(type_name) = &node.type_name {
+            ctx.emit_error(DecodeError::unexpected(
+                type_name,
+                "type name",
+                "no type name expected for this node",
+            ));
+        }
+
+        for child in node.children() {
+            ctx.emit_error(DecodeError::unexpected(
+                child,
+                "node",
+                format!("unexpected node `{}`", child.node_name.escape_default()),
+            ));
+        }
+
+        for prop in &node.properties {
+            ctx.emit_error(DecodeError::unexpected(
+                prop.0,
+                "property",
+                format!("unexpected property `{}`", (**prop.0).escape_default()),
+            ));
+        }
+
+        let mut coefficients: [f64; 9] = [0.0; 9];
+        let mut valid = true;
+        for (i, value) in node.arguments.iter().take(9).enumerate() {
+            match knuffel::traits::DecodeScalar::decode(value, ctx) {
+                Ok(v) => coefficients[i] = v,
+                Err(_) => valid = false,
+            }
+        }
+
+        if node.arguments.len() > 9 {
+            ctx.emit_error(DecodeError::unexpected(
+                &node.arguments[9].literal,
+                "argument",
+                "unexpected argument; exactly 9 coefficients expected",
+            ));
+        } else if node.arguments.len() < 9 {
+            ctx.emit_error(DecodeError::missing(
+                node,
+                "argument; exactly 9 coefficients expected",
+            ));
+        }
+
+        if valid && node.arguments.len() == 9 {
+            Ok(ColorMatrix([
+                [coefficients[0], coefficients[1], coefficients[2]],
+                [coefficients[3], coefficients[4], coefficients[5]],
+                [coefficients[6], coefficients[7], coefficients[8]],
+            ]))
+        } else {
+            Ok(ColorMatrix([
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]))
+        }
+    }
+}
+
 macro_rules! ensure {
     ($cond:expr, $ctx:expr, $span:expr, $fmt:literal $($arg:tt)* ) => {
         if !$cond {
@@ -540,6 +619,40 @@ mod tests {
     use insta::assert_debug_snapshot;
 
     use super::*;
+    use crate::Config;
+
+    #[test]
+    fn parse_color_matrix() {
+        let config = Config::parse_mem(
+            r#"
+            output "DP-1" {
+                color-matrix 0.2126 0.7152 0.0722 0.2126 0.7152 0.0722 0.2126 0.7152 0.0722
+            }
+            output "eDP-1" {
+                color-matrix 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0
+            }
+        "#,
+        )
+        .unwrap();
+        let outputs = &config.outputs.0;
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(
+            outputs[0].color_matrix,
+            Some(ColorMatrix([
+                [0.2126, 0.7152, 0.0722],
+                [0.2126, 0.7152, 0.0722],
+                [0.2126, 0.7152, 0.0722],
+            ])),
+        );
+        assert_eq!(
+            outputs[1].color_matrix,
+            Some(ColorMatrix([
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ])),
+        );
+    }
 
     #[test]
     fn parse_mode() {

--- a/niri-config/src/output.rs
+++ b/niri-config/src/output.rs
@@ -416,9 +416,23 @@ impl<S: ErrorSpan> knuffel::Decode<S> for ColorMatrix {
         let mut coefficients: [f64; 9] = [0.0; 9];
         let mut valid = true;
         for (i, value) in node.arguments.iter().take(9).enumerate() {
-            match knuffel::traits::DecodeScalar::decode(value, ctx) {
-                Ok(v) => coefficients[i] = v,
-                Err(_) => valid = false,
+            match &*value.literal {
+                knuffel::ast::Literal::Int(_) => match <i64 as knuffel::traits::DecodeScalar<S>>::decode(value, ctx) {
+                    Ok(v) => coefficients[i] = v as f64,
+                    Err(_) => valid = false,
+                },
+                knuffel::ast::Literal::Decimal(_) => match knuffel::traits::DecodeScalar::decode(value, ctx) {
+                    Ok(v) => coefficients[i] = v,
+                    Err(_) => valid = false,
+                },
+                _ => {
+                    ctx.emit_error(DecodeError::unexpected(
+                        &value.literal,
+                        "argument",
+                        "expected a number (integer or decimal)",
+                    ));
+                    valid = false;
+                }
             }
         }
 
@@ -631,11 +645,14 @@ mod tests {
             output "eDP-1" {
                 color-matrix 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0
             }
+            output "HDMI-A-1" {
+                color-matrix 0.2126 0.7152 0.0722 0 0 0 0 0 0
+            }
         "#,
         )
         .unwrap();
         let outputs = &config.outputs.0;
-        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs.len(), 3);
         assert_eq!(
             outputs[0].color_matrix,
             Some(ColorMatrix([
@@ -650,6 +667,15 @@ mod tests {
                 [1.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0],
                 [0.0, 0.0, 1.0],
+            ])),
+        );
+        // Regression: bare integer scalars (KDL ints) must be accepted alongside decimals.
+        assert_eq!(
+            outputs[2].color_matrix,
+            Some(ColorMatrix([
+                [0.2126, 0.7152, 0.0722],
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
             ])),
         );
     }

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1103,6 +1103,12 @@ pub enum OutputAction {
         #[cfg_attr(feature = "clap", arg())]
         max_bpc: MaxBpc,
     },
+    /// Set a hardware color matrix (DRM CTM) on the output.
+    ColorMatrix {
+        /// Color matrix to set, or "reset" to remove.
+        #[cfg_attr(feature = "clap", command(subcommand))]
+        matrix: ColorMatrixToSet,
+    },
 }
 
 /// Output mode to set.
@@ -1202,6 +1208,24 @@ pub struct VrrToSet {
     /// Only enable when the output shows a window matching the variable-refresh-rate window rule.
     #[cfg_attr(feature = "clap", arg(long))]
     pub on_demand: bool,
+}
+
+/// Output color matrix to set.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "clap", derive(clap::Subcommand))]
+#[cfg_attr(feature = "clap", command(subcommand_value_name = "MATRIX"))]
+#[cfg_attr(feature = "clap", command(subcommand_help_heading = "Matrix Values"))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub enum ColorMatrixToSet {
+    /// Reset the color matrix to identity (remove it from the output).
+    Reset,
+    /// Set the given 3x3 row-major color matrix coefficients.
+    #[cfg_attr(feature = "clap", command(name = "set"))]
+    Set {
+        /// The 9 coefficients of the 3x3 row-major matrix.
+        #[cfg_attr(feature = "clap", arg(num_args = 9))]
+        matrix: Vec<f64>,
+    },
 }
 
 /// Connected output.

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -1350,9 +1350,11 @@ impl Tty {
 
         // Reset the CTM in case it was set before, applying the configured value.
         let ctm = config.color_matrix.map(|m| m.0);
+        let mut ctm_applied = ctm.is_none();
         if let Some(ctm_props) = &mut ctm_props {
-            if let Err(err) = ctm_props.set_ctm(&device.drm, ctm) {
-                debug!("couldn't set color matrix: {err:?}");
+            match ctm_props.set_ctm(&device.drm, ctm) {
+                Ok(()) => ctm_applied = true,
+                Err(err) => debug!("couldn't set color matrix: {err:?}"),
             }
         }
 
@@ -1565,7 +1567,7 @@ impl Tty {
             gamma_props,
             pending_gamma_change: None,
             ctm_props,
-            current_ctm: ctm,
+            current_ctm: ctm.filter(|_| ctm_applied),
             vblank_frame: None,
             vblank_frame_name,
             time_since_presentation_plot_name,

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -379,6 +379,9 @@ struct Surface {
     gamma_props: Option<GammaProps>,
     /// Gamma change to apply upon session resume.
     pending_gamma_change: Option<Option<Vec<u16>>>,
+    ctm_props: Option<CtmProps>,
+    /// Color matrix currently applied to the surface.
+    current_ctm: Option<[[f64; 3]; 3]>,
     /// Tracy frame that goes from vblank to vblank.
     vblank_frame: Option<tracy_client::Frame>,
     /// Frame name for the VBlank frame.
@@ -706,6 +709,12 @@ impl Tty {
                         } else if let Some(gamma_props) = &surface.gamma_props {
                             if let Err(err) = gamma_props.restore_gamma(&device.drm) {
                                 warn!("error restoring gamma: {err:?}");
+                            }
+                        }
+
+                        if let Some(ctm_props) = &surface.ctm_props {
+                            if let Err(err) = ctm_props.restore_ctm(&device.drm) {
+                                warn!("error restoring color matrix: {err:?}");
                             }
                         }
                     }
@@ -1335,6 +1344,18 @@ impl Tty {
             debug!("couldn't reset gamma: {err:?}");
         }
 
+        let mut ctm_props = CtmProps::new(&device.drm, crtc)
+            .map_err(|err| debug!("couldn't get CTM properties: {err:?}"))
+            .ok();
+
+        // Reset the CTM in case it was set before, applying the configured value.
+        let ctm = config.color_matrix.map(|m| m.0);
+        if let Some(ctm_props) = &mut ctm_props {
+            if let Err(err) = ctm_props.set_ctm(&device.drm, ctm) {
+                debug!("couldn't set color matrix: {err:?}");
+            }
+        }
+
         let surface = device
             .drm
             .create_surface(crtc, mode, &[connector.handle()])?;
@@ -1543,6 +1564,8 @@ impl Tty {
             dmabuf_feedback,
             gamma_props,
             pending_gamma_change: None,
+            ctm_props,
+            current_ctm: ctm,
             vblank_frame: None,
             vblank_frame_name,
             time_since_presentation_plot_name,
@@ -2452,6 +2475,20 @@ impl Tty {
                     warn!("failed to get connector properties");
                 }
 
+                // Apply the configured color matrix, if it changed.
+                let ctm = config.color_matrix.map(|m| m.0);
+                if let Some(ctm_props) = &mut surface.ctm_props {
+                    if surface.current_ctm != ctm {
+                        match ctm_props.set_ctm(&device.drm, ctm) {
+                            Ok(()) => surface.current_ctm = ctm,
+                            Err(err) => warn!(
+                                "error applying color matrix to output {:?}: {err:?}",
+                                surface.name.connector
+                            ),
+                        }
+                    }
+                }
+
                 let change_mode = surface.compositor.pending_mode() != mode;
 
                 let vrr_enabled = surface.compositor.vrr_enabled();
@@ -2747,6 +2784,114 @@ impl GammaProps {
                 property::Value::Blob(blob).into(),
             )
             .context("error setting GAMMA_LUT")?;
+
+        Ok(())
+    }
+}
+
+struct CtmProps {
+    crtc: crtc::Handle,
+    ctm: property::Handle,
+    previous_blob: Option<NonZeroU64>,
+}
+
+impl CtmProps {
+    fn new(device: &DrmDevice, crtc: crtc::Handle) -> anyhow::Result<Self> {
+        let mut ctm = None;
+
+        let props = device
+            .get_properties(crtc)
+            .context("error getting properties")?;
+        for (prop, _) in props {
+            let Ok(info) = device.get_property(prop) else {
+                continue;
+            };
+
+            let Ok(name) = info.name().to_str() else {
+                continue;
+            };
+
+            if name == "CTM" {
+                ensure!(
+                    matches!(info.value_type(), property::ValueType::Blob),
+                    "wrong CTM value type"
+                );
+                ctm = Some(prop);
+            }
+        }
+
+        let ctm = ctm.context("missing CTM property")?;
+
+        Ok(Self {
+            crtc,
+            ctm,
+            previous_blob: None,
+        })
+    }
+
+    fn set_ctm(&mut self, device: &DrmDevice, ctm: Option<[[f64; 3]; 3]>) -> anyhow::Result<()> {
+        let _span = tracy_client::span!("CtmProps::set_ctm");
+
+        let blob = if let Some(ctm) = ctm {
+            #[allow(non_camel_case_types)]
+            #[repr(C)]
+            #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+            pub struct drm_color_ctm {
+                pub matrix: [u64; 9],
+            }
+
+            // Convert the coefficients to S31.32 fixed-point.
+            let mut matrix = [0u64; 9];
+            for (coeff, cell) in ctm.as_flattened().iter().zip(&mut matrix) {
+                *cell = (coeff * (1u64 << 32) as f64).round() as i64 as u64;
+            }
+            let mut data = [drm_color_ctm { matrix }];
+            let data = cast_slice_mut(&mut data);
+
+            let blob = drm_ffi::mode::create_property_blob(device.as_fd(), data)
+                .context("error creating property blob")?;
+            NonZeroU64::new(u64::from(blob.blob_id))
+        } else {
+            None
+        };
+
+        {
+            let _span = tracy_client::span!("set_property");
+
+            let blob = blob.map(NonZeroU64::get).unwrap_or(0);
+            device
+                .set_property(
+                    self.crtc,
+                    self.ctm,
+                    property::Value::Blob(blob).into(),
+                )
+                .context("error setting CTM")
+                .inspect_err(|_| {
+                    if blob != 0 {
+                        // Destroy the blob we just allocated.
+                        if let Err(err) = device.destroy_property_blob(blob) {
+                            warn!("error destroying CTM property blob: {err:?}");
+                        }
+                    }
+                })?;
+        }
+
+        if let Some(blob) = mem::replace(&mut self.previous_blob, blob) {
+            if let Err(err) = device.destroy_property_blob(blob.get()) {
+                warn!("error destroying previous CTM blob: {err:?}");
+            }
+        }
+
+        Ok(())
+    }
+
+    fn restore_ctm(&self, device: &DrmDevice) -> anyhow::Result<()> {
+        let _span = tracy_client::span!("CtmProps::restore_ctm");
+
+        let blob = self.previous_blob.map(NonZeroU64::get).unwrap_or(0);
+        device
+            .set_property(self.crtc, self.ctm, property::Value::Blob(blob).into())
+            .context("error setting CTM")?;
 
         Ok(())
     }

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -1946,6 +1946,27 @@ impl State {
                 }
             }
             niri_ipc::OutputAction::MaxBpc { max_bpc } => config.max_bpc = Some(MaxBpc(max_bpc)),
+            niri_ipc::OutputAction::ColorMatrix { matrix } => match matrix {
+                niri_ipc::ColorMatrixToSet::Reset => config.color_matrix = None,
+                niri_ipc::ColorMatrixToSet::Set { matrix } => {
+                    match <[f64; 9]>::try_from(matrix) {
+                        Ok([
+                            a, b, c, //
+                            d, e, f, //
+                            g, h, i,
+                        ]) => {
+                            config.color_matrix = Some(niri_config::output::ColorMatrix([
+                                [a, b, c], //
+                                [d, e, f], //
+                                [g, h, i],
+                            ]));
+                        }
+                        Err(matrix) => {
+                            warn!("ignoring invalid color matrix: expected 9 coefficients, got {}", matrix.len());
+                        }
+                    }
+                }
+            },
         });
 
         self.reload_output_config();


### PR DESCRIPTION
## Summary

Adds a `color-matrix` option to output config and a matching `niri msg output <name> color-matrix` IPC action, which program the DRM CRTC **CTM** property — a 3×3 color transformation matrix applied in the hardware scanout pipeline (degamma → CTM → gamma).

The CTM is the only hardware block that can do *cross-channel* color transformations. The per-channel gamma LUTs exposed through wlr-gamma-control cannot express things like luminance grayscale or red-monochrome rendering, because they map R→R, G→G, B→B independently and can never mix channels. With a CTM, green and blue content can be *converted* rather than destroyed — e.g. true luminance grayscale:

```kdl
output "DP-1" {
    // ITU-R BT.709 luminance → monochrome
    color-matrix 0.2126 0.7152 0.0722 0.2126 0.7152 0.0722 0.2126 0.7152 0.0722
}
```

or a red-monochrome (night reading) variant:

```kdl
output "DP-1" {
    color-matrix 0.2126 0.7152 0.0722 0 0 0 0 0 0
}
```

## Implementation

- **niri-config**: new `ColorMatrix` type with a manual `knuffel::Decode` impl taking exactly 9 coefficients (row-major), plus a `color-matrix` child on `Output`.
- **niri-ipc**: new `OutputAction::ColorMatrix` variant with `reset`/`set` subcommands (`ColorMatrixToSet`), following the `PositionToSet` clap pattern.
- **niri**: handles the new action in `apply_transient_output_config` (transient changes, forgotten on config reload).
- **tty backend**: `CtmProps` (mirroring `GammaProps`): discovers the CRTC `CTM` Blob property, tracks the previous blob for restoration (VT switch / session resume), converts coefficients to S31.32 fixed point (`round(f · 2³²)`), creates/commits property blobs, and destroys the old blob on replacement. Applied at surface creation (from config), on `on_output_config_changed` (config reload / `niri msg`), and restored on session resume.

## Notes

- Coefficients are clamped implicitly by the i64→u64 cast, matching the kernel's S31.32 semantics.
- The CTM composes with wlr-gamma-control: gamma LUTs are applied after the CTM, so tools like gammastep keep working.
- Works with any GPU exposing the CRTC CTM property (AMD DC GPUs, Intel).
- No smithay changes needed; the property is driven directly from niri like `GammaProps` already does.

## Testing

- `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets` (0 warnings), `cargo test --workspace` (insta snapshots updated for the new `Output` field).
- New unit test `output::tests::parse_color_matrix` verifying parsing of two outputs.
- `niri validate` manually verified: valid 9-coefficient matrices parse; wrong arg counts produce the expected decode errors.