### PR TITLE
feat: have concurrent holds timed separately

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -420,15 +420,8 @@ impl State {
         let time = Event::time_msec(&event);
         let pressed = event.state() == KeyState::Pressed;
 
-        // Stop bind key repeat on any release. This won't work 100% correctly in cases like:
-        // 1. Press Mod
-        // 2. Press Left (repeat starts)
-        // 3. Press PgDown (new repeat starts)
-        // 4. Release Left (PgDown repeat stops)
-        // But it's good enough for now.
-        // FIXME: handle this properly.
         if !pressed {
-            if let Some(token) = self.niri.bind_repeat_timer.take() {
+            if let Some(token) = self.niri.bind_repeat_timers.remove(&event.key_code()) {
                 self.niri.event_loop.remove(token);
             }
         }
@@ -475,6 +468,25 @@ impl State {
                 let modified = keysym.modified_sym();
                 let raw = keysym.raw_latin_sym_or_raw_current_sym();
                 let modifiers = modifiers_from_state(*mods);
+
+                // Existing repeats no longer match when the modifier state changes.
+                if matches!(
+                    modified,
+                    Keysym::Shift_L
+                        | Keysym::Shift_R
+                        | Keysym::Control_L
+                        | Keysym::Control_R
+                        | Keysym::Alt_L
+                        | Keysym::Alt_R
+                        | Keysym::Super_L
+                        | Keysym::Super_R
+                        | Keysym::ISO_Level3_Shift
+                        | Keysym::ISO_Level5_Shift
+                ) {
+                    for (_, token) in this.niri.bind_repeat_timers.drain() {
+                        this.niri.event_loop.remove(token);
+                    }
+                }
 
                 // After updating XKB state from accessibility-grabbed keys, return right away and
                 // don't handle them.
@@ -601,16 +613,15 @@ impl State {
 
         self.handle_bind(bind.clone());
 
-        self.start_key_repeat(bind);
+        self.start_key_repeat(event.key_code(), bind);
     }
 
-    fn start_key_repeat(&mut self, bind: Bind) {
+    fn start_key_repeat(&mut self, key_code: Keycode, bind: Bind) {
         if !bind.repeat {
             return;
         }
 
-        // Stop the previous key repeat if any.
-        if let Some(token) = self.niri.bind_repeat_timer.take() {
+        if let Some(token) = self.niri.bind_repeat_timers.remove(&key_code) {
             self.niri.event_loop.remove(token);
         }
 
@@ -635,7 +646,7 @@ impl State {
             })
             .unwrap();
 
-        self.niri.bind_repeat_timer = Some(token);
+        self.niri.bind_repeat_timers.insert(key_code, token);
     }
 
     fn hide_cursor_if_needed(&mut self) {
@@ -5275,6 +5286,33 @@ mod tests {
 
     use super::*;
     use crate::animation::Clock;
+    use crate::tests::Fixture;
+
+    #[test]
+    fn bind_repeats_are_tracked_per_key() {
+        let mut fixture = Fixture::new();
+        let state = fixture.niri_state();
+        let bind = |keysym| Bind {
+            key: Key {
+                trigger: Trigger::Keysym(keysym),
+                modifiers: Modifiers::COMPOSITOR | Modifiers::SHIFT,
+            },
+            action: Action::MoveWindowDown,
+            repeat: true,
+            cooldown: None,
+            allow_when_locked: false,
+            allow_inhibiting: false,
+            hotkey_overlay_title: None,
+        };
+        let down = Keycode::from(Keysym::Down.raw() + 8);
+        let right = Keycode::from(Keysym::Right.raw() + 8);
+
+        state.start_key_repeat(down, bind(Keysym::Down));
+        state.start_key_repeat(right, bind(Keysym::Right));
+
+        assert!(state.niri.bind_repeat_timers.contains_key(&down));
+        assert!(state.niri.bind_repeat_timers.contains_key(&right));
+    }
 
     #[test]
     fn bindings_suppress_keys() {

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -329,7 +329,7 @@ pub struct Niri {
     /// Button codes of the mouse buttons to suppress.
     pub suppressed_buttons: HashSet<u32>,
     pub bind_cooldown_timers: HashMap<Key, RegistrationToken>,
-    pub bind_repeat_timer: Option<RegistrationToken>,
+    pub bind_repeat_timers: HashMap<Keycode, RegistrationToken>,
     pub keyboard_focus: KeyboardFocus,
     pub layer_shell_on_demand_focus: Option<LayerSurface>,
     pub idle_inhibiting_surfaces: HashSet<WlSurface>,
@@ -2585,7 +2585,7 @@ impl Niri {
             suppressed_keys: HashSet::new(),
             suppressed_buttons: HashSet::new(),
             bind_cooldown_timers: HashMap::new(),
-            bind_repeat_timer: Option::default(),
+            bind_repeat_timers: HashMap::new(),
             presentation_state,
             security_context_state,
             gamma_control_manager_state,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,4 @@
-use fixture::Fixture;
+pub(crate) use fixture::Fixture;
 
 mod client;
 mod fixture;


### PR DESCRIPTION
fixes the `FIXME` comment in `src/input/mod.rs`:

original problem i faced was if im holding mod+shift+down (to move the window down) and mod+shift+right (to move the window right), it moves it down once, then moves it to the right while held down, even though i wanted it to move diagonally.

possibly unrelated but unavoidable change in `src/tests/mod.rs`: couldnt run tests without it

new test case was done with partial help from ai, figured this is worth a test case

also video

https://github.com/user-attachments/assets/4480b017-6f40-4f2f-a981-aa113b0edc26

