### PR TITLE
Clean up renderer caches when no frames are rendered

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use niri_config::{Config, ModKey};
 use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::backend::renderer::Renderer;
 use smithay::output::Output;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 
@@ -55,6 +56,24 @@ impl OutputId {
 }
 
 impl Backend {
+    /// Reclaim dead imports even when no output is being rendered.
+    ///
+    /// Importing a client buffer does not require a frame. In particular, a
+    /// client may create and destroy dmabufs while DPMS is off or all outputs
+    /// are unplugged. Leaving cleanup to frame completion pins their EGLImages
+    /// (and backing GPU/system memory) until the next rendered frame.
+    pub fn cleanup_texture_cache(&mut self) {
+        if let Self::Tty(tty) = self {
+            tty.cleanup_texture_cache();
+        } else {
+            self.with_primary_renderer(|renderer| {
+                if let Err(err) = renderer.cleanup_texture_cache() {
+                    warn!(?err, "error cleaning up renderer texture cache");
+                }
+            });
+        }
+    }
+
     pub fn init(&mut self, niri: &mut Niri) {
         let _span = tracy_client::span!("Backend::init");
         match self {

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -31,8 +31,8 @@ use smithay::backend::egl::{EGLDevice, EGLDisplay};
 use smithay::backend::libinput::{LibinputInputBackend, LibinputSessionInterface};
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::backend::renderer::multigpu::gbm::GbmGlesBackend;
-use smithay::backend::renderer::multigpu::{GpuManager, MultiFrame, MultiRenderer};
-use smithay::backend::renderer::{DebugFlags, ImportDma, ImportEgl, RendererSuper};
+use smithay::backend::renderer::multigpu::{ApiDevice, GpuManager, MultiFrame, MultiRenderer};
+use smithay::backend::renderer::{DebugFlags, ImportDma, ImportEgl, Renderer, RendererSuper};
 use smithay::backend::session::libseat::LibSeatSession;
 use smithay::backend::session::{Event as SessionEvent, Session};
 use smithay::backend::udev::{self, UdevBackend, UdevEvent};
@@ -1849,6 +1849,28 @@ impl Tty {
             .single_renderer(&self.primary_render_node)
             .ok()?;
         Some(f(renderer.as_gles_renderer()))
+    }
+
+    pub fn cleanup_texture_cache(&mut self) {
+        let devices = match self.gpu_manager.devices_mut() {
+            Ok(devices) => devices,
+            Err(err) => {
+                warn!(
+                    ?err,
+                    "error enumerating renderers for texture cache cleanup"
+                );
+                return;
+            }
+        };
+
+        // Imports can reside on a non-primary GPU. Clean every device, and do
+        // not let an error on one prevent cleanup of the remaining devices.
+        for device in devices {
+            let node = *device.node();
+            if let Err(err) = device.renderer_mut().cleanup_texture_cache() {
+                warn!(?node, ?err, "error cleaning up renderer texture cache");
+            }
+        }
     }
 
     pub fn render(

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -2458,6 +2458,11 @@ impl Niri {
                 Timer::from_duration(Duration::from_secs(1)),
                 |_, _, state| {
                     state.niri.send_frame_callbacks_on_fallback_timer();
+                    // Cache maintenance must not depend on frame production:
+                    // there may be no active outputs, but clients can still
+                    // import and destroy buffers. Only dead entries are freed;
+                    // live surface textures and frame callback policy stay intact.
+                    state.backend.cleanup_texture_cache();
                     TimeoutAction::ToDuration(Duration::from_secs(1))
                 },
             )

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,5 +9,6 @@ mod floating;
 mod fullscreen;
 mod layer_shell;
 mod remove_output;
+mod renderer_cleanup;
 mod transactions;
 mod window_opening;

--- a/src/tests/renderer_cleanup.rs
+++ b/src/tests/renderer_cleanup.rs
@@ -1,0 +1,84 @@
+use std::time::{Duration, Instant};
+
+use niri_config::Config;
+use smithay::backend::allocator::Fourcc;
+use smithay::backend::renderer::ImportMem;
+
+use super::server::Server;
+
+fn texture_exists(server: &mut Server, id: u32) -> bool {
+    server
+        .state
+        .backend
+        .with_primary_renderer(|renderer| {
+            renderer
+                .with_context(|gl| unsafe { gl.IsTexture(id) != 0 })
+                .unwrap()
+        })
+        .unwrap()
+}
+
+fn wait_for_cleanup(server: &mut Server, id: u32) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while texture_exists(server, id) && Instant::now() < deadline {
+        server
+            .event_loop
+            .dispatch(Duration::from_millis(100), &mut server.state)
+            .unwrap();
+        server.state.refresh_and_flush_clients();
+    }
+    assert!(
+        !texture_exists(server, id),
+        "texture was not reclaimed without a frame"
+    );
+}
+
+fn check_cleanup(monitors_off: bool) {
+    let mut server = Server::new(Config::default());
+    server.state.backend.headless().add_renderer().unwrap();
+    if monitors_off {
+        let state = &mut server.state;
+        state
+            .backend
+            .headless()
+            .add_output(&mut state.niri, 1, (1280, 720));
+        state.niri.deactivate_monitors(&mut state.backend);
+    }
+
+    let (live, dead_id) = server
+        .state
+        .backend
+        .with_primary_renderer(|renderer| {
+            let live = renderer
+                .import_memory(&[255; 4], Fourcc::Abgr8888, (1, 1).into(), false)
+                .unwrap();
+            let dead = renderer
+                .import_memory(&[255; 4], Fourcc::Abgr8888, (1, 1).into(), false)
+                .unwrap();
+            let dead_id = dead.tex_id();
+            drop(dead);
+            (live, dead_id)
+        })
+        .unwrap();
+
+    // Drop queues GL destruction; it cannot delete the object immediately.
+    assert!(texture_exists(&mut server, dead_id));
+    wait_for_cleanup(&mut server, dead_id);
+    let live_id = live.tex_id();
+    assert!(texture_exists(&mut server, live_id));
+
+    // Maintenance must keep running, not just clean up once after power-off.
+    drop(live);
+    assert!(texture_exists(&mut server, live_id));
+    wait_for_cleanup(&mut server, live_id);
+}
+
+#[test]
+fn egl_cleanup_without_outputs() {
+    check_cleanup(false);
+}
+
+#[test]
+fn egl_cleanup_with_monitors_off() {
+    check_cleanup(true);
+}

--- a/src/tests/renderer_cleanup/README.md
+++ b/src/tests/renderer_cleanup/README.md
@@ -1,0 +1,45 @@
+# linux-dmabuf cleanup reproducer
+
+`dmabuf-churn.c` imports distinct 1024x1024 GBM buffers into niri and destroys
+their Wayland buffers. It creates no surfaces and requests no frame callbacks.
+This exercises the cached EGLImage path in addition to the automated EGL
+tests' deferred texture destruction path.
+
+Build with Wayland, wayland-protocols, wayland-scanner, GBM, and a C compiler:
+
+```sh
+protocols=$(pkg-config --variable=pkgdatadir wayland-protocols)
+protocol=$protocols/stable/linux-dmabuf/linux-dmabuf-v1.xml
+if [ ! -f "$protocol" ]; then
+    protocol=$protocols/unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml
+fi
+wayland-scanner client-header "$protocol" /tmp/linux-dmabuf-client.h
+wayland-scanner private-code "$protocol" /tmp/linux-dmabuf-protocol.c
+cc -Wall -Wextra -O2 -I/tmp src/tests/renderer_cleanup/dmabuf-churn.c \
+    /tmp/linux-dmabuf-protocol.c $(pkg-config --cflags --libs wayland-client gbm) \
+    -o /tmp/dmabuf-churn
+```
+
+Use a disposable niri instance with the matching `WAYLAND_DISPLAY` and
+`NIRI_SOCKET`. Select its GPU's render node below. The example imports
+512 MiB cumulatively and temporarily powers off that instance's outputs:
+
+```sh
+niri msg action power-off-monitors
+/tmp/dmabuf-churn /dev/dri/renderD128 128 100
+sleep 4
+# Inspect niri's GPU allocation here, before turning outputs back on.
+niri msg action power-on-monitors
+```
+
+With the fix, the destroyed imports are reclaimed while the outputs remain
+off. Without it, the tested AMDGPU instance retained the 512 MiB until it
+rendered again. Process RSS does not account for these GPU allocations; use
+DRM fdinfo or GPU tooling. Do not sum duplicate fdinfo entries with the same
+DRM device/client ID.
+
+An optional fourth argument keeps all imported buffers alive for that many
+seconds before destroying them. For example, `32 10 6` should retain 128 MiB
+for six seconds, then reclaim it without requiring a frame. The automated
+`egl_cleanup_*` tests also check that live textures survive maintenance and
+that subsequent ticks reclaim resources dropped later.

--- a/src/tests/renderer_cleanup/dmabuf-churn.c
+++ b/src/tests/renderer_cleanup/dmabuf-churn.c
@@ -1,0 +1,117 @@
+#define _POSIX_C_SOURCE 200809L
+#include <errno.h>
+#include <fcntl.h>
+#include <gbm.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include "linux-dmabuf-client.h"
+
+static struct zwp_linux_dmabuf_v1 *dmabuf;
+static int result;
+static int keep_buffers;
+static int kept_count;
+static struct wl_buffer *kept[1024];
+
+static void global(void *data, struct wl_registry *registry, uint32_t id,
+                   const char *interface, uint32_t version) {
+    (void)data;
+    if (strcmp(interface, "zwp_linux_dmabuf_v1") == 0)
+        dmabuf = wl_registry_bind(registry, id, &zwp_linux_dmabuf_v1_interface,
+                                  version < 3 ? version : 3);
+}
+static void global_remove(void *data, struct wl_registry *registry, uint32_t id) {
+    (void)data; (void)registry; (void)id;
+}
+static const struct wl_registry_listener registry_listener = {global, global_remove};
+static void format(void *data, struct zwp_linux_dmabuf_v1 *obj, uint32_t f) {
+    (void)data; (void)obj; (void)f;
+}
+static void modifier(void *data, struct zwp_linux_dmabuf_v1 *obj, uint32_t f,
+                     uint32_t hi, uint32_t lo) {
+    (void)data; (void)obj; (void)f; (void)hi; (void)lo;
+}
+static const struct zwp_linux_dmabuf_v1_listener dmabuf_listener = {format, modifier};
+static void created(void *data, struct zwp_linux_buffer_params_v1 *params,
+                    struct wl_buffer *buffer) {
+    (void)data; (void)params;
+    /* Never attach: no presentation or frame callback can clean this import. */
+    if (keep_buffers)
+        kept[kept_count++] = buffer;
+    else
+        wl_buffer_destroy(buffer);
+    result = 1;
+}
+static void failed(void *data, struct zwp_linux_buffer_params_v1 *params) {
+    (void)data; (void)params;
+    result = -1;
+}
+static const struct zwp_linux_buffer_params_v1_listener params_listener = {created, failed};
+
+int main(int argc, char **argv) {
+    if (argc != 4 && argc != 5) {
+        fprintf(stderr, "usage: %s RENDER_NODE COUNT INTERVAL_MS [HOLD_SECONDS]\n", argv[0]);
+        return 2;
+    }
+    int count = atoi(argv[2]), interval = atoi(argv[3]);
+    int hold_seconds = argc == 5 ? atoi(argv[4]) : 0;
+    if (count < 1 || count > 1024 || interval < 10 || interval > 1000) return 2;
+    if (hold_seconds < 0 || hold_seconds > 60) return 2;
+    keep_buffers = hold_seconds > 0;
+    struct wl_display *display = wl_display_connect(NULL);
+    if (!display) { perror("wl_display_connect"); return 1; }
+    struct wl_registry *registry = wl_display_get_registry(display);
+    wl_registry_add_listener(registry, &registry_listener, NULL);
+    if (wl_display_roundtrip(display) < 0 || !dmabuf) {
+        fprintf(stderr, "linux-dmabuf unavailable\n"); return 1;
+    }
+    zwp_linux_dmabuf_v1_add_listener(dmabuf, &dmabuf_listener, NULL);
+    if (wl_display_roundtrip(display) < 0) return 1;
+    int device_fd = open(argv[1], O_RDWR | O_CLOEXEC);
+    if (device_fd < 0) { perror("open render node"); return 1; }
+    struct gbm_device *device = gbm_create_device(device_fd);
+    if (!device) { fprintf(stderr, "gbm_create_device failed\n"); return 1; }
+    const uint32_t width = 1024, height = 1024;
+    struct timespec delay = {interval / 1000, (interval % 1000) * 1000000L};
+    for (int i = 0; i < count; ++i) {
+        struct gbm_bo *bo = gbm_bo_create(device, width, height, GBM_FORMAT_XRGB8888,
+                                         GBM_BO_USE_RENDERING | GBM_BO_USE_LINEAR);
+        if (!bo) { perror("gbm_bo_create"); return 1; }
+        int fd = gbm_bo_get_fd(bo);
+        if (fd < 0) { perror("gbm_bo_get_fd"); return 1; }
+        uint64_t mod = gbm_bo_get_modifier(bo);
+        struct zwp_linux_buffer_params_v1 *params = zwp_linux_dmabuf_v1_create_params(dmabuf);
+        zwp_linux_buffer_params_v1_add_listener(params, &params_listener, NULL);
+        zwp_linux_buffer_params_v1_add(params, fd, 0, 0, gbm_bo_get_stride(bo), mod >> 32, mod);
+        result = 0;
+        zwp_linux_buffer_params_v1_create(params, width, height, GBM_FORMAT_XRGB8888, 0);
+        close(fd);
+        while (!result && wl_display_dispatch(display) >= 0) {}
+        zwp_linux_buffer_params_v1_destroy(params);
+        gbm_bo_destroy(bo);
+        if (result != 1 || wl_display_roundtrip(display) < 0) {
+            fprintf(stderr, "import failed at %d\n", i); return 1;
+        }
+        nanosleep(&delay, NULL);
+    }
+    if (keep_buffers) {
+        printf("holding %d live buffers (%u MiB total)\n", kept_count, kept_count * 4);
+        fflush(stdout);
+        struct timespec hold = {hold_seconds, 0};
+        while (nanosleep(&hold, &hold) < 0 && errno == EINTR) {}
+        for (int i = 0; i < kept_count; ++i)
+            wl_buffer_destroy(kept[i]);
+        if (wl_display_roundtrip(display) < 0) return 1;
+    }
+    printf("imported and destroyed %d buffers (%u MiB total)\n", count, count * 4);
+    gbm_device_destroy(device);
+    close(device_fd);
+    zwp_linux_dmabuf_v1_destroy(dmabuf);
+    wl_registry_destroy(registry);
+    wl_display_disconnect(display);
+    return 0;
+}


### PR DESCRIPTION
Clients can import and destroy linux-dmabuf buffers without rendering a frame. With monitors powered off, dead imports remain in the renderer cache, retaining their backing memory until rendering resumes. This reproduces the accumulation-and-release pattern reported in #3295.

Run `Renderer::cleanup_texture_cache()` from the existing one-second fallback timer. The TTY backend visits all GPU renderers, continuing if one fails; winit and headless use their primary renderer. Cleanup retains live resources and does not change frame callback policy.

Two EGL regression tests exercise the real timer with no outputs and with monitors off. They check deferred texture deletion, preservation of live textures, and cleanup on later ticks. Both fail without the fix and pass with it. A standalone linux-dmabuf client and reproduction instructions cover the cached EGLImage path separately.

Validation:

- `cargo test --locked --all --exclude niri-visual-tests`: passed (197 compositor tests, plus config, IPC, and doc tests).
- Nightly rustfmt check, Clippy with `-D warnings` (excluding niri-visual-tests), and `cargo check --locked --no-default-features`: passed.
- RX 7900 XTX, nested winit backend, upstream `dd75865f` versus this patch: 128 destroyed 4 MiB imports left GPU allocation at 581 MiB from a 69 MiB baseline without the fix. With the fix it returned to 69 MiB while outputs remained off. A live 128 MiB batch survived three cleanup ticks and was reclaimed after destruction.
- The same fix backported to the installed version was also tested on the DRM backend, including a 4 GiB import run and physical hotplug events. Exact-upstream runtime A/B above used winit; multi-GPU hardware was not tested.

Prepared with AI assistance; commands and runtime checks were executed locally.
