### PR TITLE
render_to_shm: follow the buffer's stride and pool offset

### DIFF
--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -305,7 +305,9 @@ pub fn render_to_shm(
     states: RenderElementStates,
 ) -> anyhow::Result<()> {
     let _span = tracy_client::span!();
-    shm::with_buffer_contents_mut(buffer, |shm_buffer, shm_len, buffer_data| {
+    // The pointer and length are the client's entire pool, which may hold other
+    // buffers besides this one... buffer_data is the one we want.
+    shm::with_buffer_contents_mut(buffer, |pool, pool_len, buffer_data| {
         let (size, _scale, _transform) = damage_tracker.mode().try_into().unwrap();
         let fourcc = Fourcc::Xrgb8888;
 
@@ -313,10 +315,26 @@ pub fn render_to_shm(
             // The buffer prefers pixels in little endian ...
             buffer_data.format == wl_shm::Format::Xrgb8888
                 && buffer_data.width == size.w
-                && buffer_data.height == size.h
-                && buffer_data.stride == size.w * 4
-                && shm_len == buffer_data.stride as usize * buffer_data.height as usize,
+                && buffer_data.height == size.h,
             "invalid buffer format or size"
+        );
+
+        // The client chooses the stride and may pad rows, so only the first
+        // row_len bytes can be used here.
+        let row_len = size.w as usize * 4;
+        let height = size.h as usize;
+        let offset = usize::try_from(buffer_data.offset).context("negative buffer offset")?;
+        let stride = usize::try_from(buffer_data.stride).context("negative buffer stride")?;
+
+        // This should have already been validated by wl_shm, and a pool can
+        // only grow, but check again just in case.
+        let end = stride
+            .checked_mul(height.saturating_sub(1))
+            .and_then(|len| len.checked_add(row_len))
+            .and_then(|len| len.checked_add(offset));
+        ensure!(
+            stride >= row_len && end.is_some_and(|end| end <= pool_len),
+            "buffer does not fit in its shm pool"
         );
 
         let mut texture =
@@ -342,9 +360,22 @@ pub fn render_to_shm(
             .map_texture(&mapping)
             .context("error mapping texture")?;
 
+        ensure!(bytes.len() >= row_len * height, "short texture mapping");
+
         unsafe {
             let _span = tracy_client::span!("copy_nonoverlapping");
-            ptr::copy_nonoverlapping(bytes.as_ptr(), shm_buffer.cast(), shm_len);
+            let dst = pool.add(offset);
+            if stride == row_len {
+                ptr::copy_nonoverlapping(bytes.as_ptr(), dst, row_len * height);
+            } else {
+                for y in 0..height {
+                    ptr::copy_nonoverlapping(
+                        bytes.as_ptr().add(y * row_len),
+                        dst.add(y * stride),
+                        row_len,
+                    );
+                }
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Don't assume we have a single tightly packed buffer of `stride=width*4` at the beginning of the pool.

Clients can pad rows, and have multiple buffers in a pool.

This PR fixes this by properly accounting for the offset and copying one row at a time.

Without this, screencopy clients (and ext-image-copy-capture in the near future) may break with "invalid buffer format or size".

I've been using this since mid-June as part of #4554.

closes #4519 (which is an incomplete version of this)