### PR TITLE
feat: implement ext-image-copy-capture for outputs and cursors

### DIFF
--- a/docs/wiki/Screencasting.md
+++ b/docs/wiki/Screencasting.md
@@ -7,7 +7,7 @@ You can screencast both monitors and individual windows.
 In order to use it, you need a working D-Bus session, pipewire, `xdg-desktop-portal-gnome`, and [running niri as a session](./Getting-Started.md) (i.e. through `niri-session` or from a display manager).
 On widely used distros this should all "just work".
 
-Alternatively, you can use tools that rely on the `wlr-screencopy` protocol, which niri also supports.
+Alternatively, you can use tools that rely on the `ext-image-copy-capture` protocol, or the older `wlr-screencopy`, both of which niri also supports.
 
 There are several features in niri designed for screencasting.
 Let's take a look!

--- a/docs/wiki/Security-Model.md
+++ b/docs/wiki/Security-Model.md
@@ -14,7 +14,8 @@ For instance:
 
 Anything with access to niri's Wayland socket can, among other things:
 
-- Record the user's screen via [wlr-screencopy](https://wayland.app/protocols/wlr-screencopy-unstable-v1).
+- Record the user's screen via [ext-image-copy-capture](https://wayland.app/protocols/ext-image-copy-capture-v1) or [wlr-screencopy](https://wayland.app/protocols/wlr-screencopy-unstable-v1).
+- Track the cursor's image and position via [ext-image-copy-capture](https://wayland.app/protocols/ext-image-copy-capture-v1).
 - Emulate input via [wlr-virtual-pointer](https://wayland.app/protocols/wlr-virtual-pointer-unstable-v1) and [virtual-keyboard](https://wayland.app/protocols/virtual-keyboard-unstable-v1).
 - Get the user's clipboard contents via [wlr-data-control](https://wayland.app/protocols/ext-data-control-v1).
 - Create arbitrary fullscreen surfaces through [wlr-layer-shell](https://wayland.app/protocols/wlr-layer-shell-unstable-v1) that can steal the user's input, pretend to be a password entry, or lock the user out of their session.

--- a/niri-ipc/src/lib.rs
+++ b/niri-ipc/src/lib.rs
@@ -1579,6 +1579,13 @@ pub enum CastKind {
     /// Only wlr-screencopy with damage tracking is reported here. Screencopy without damage is
     /// treated as a regular screenshot and not reported as a screencast.
     WlrScreencopy,
+    /// ext-image-copy-capture protocol screencast.
+    ///
+    /// Tools like wayvnc, wl-mirror, and the xdg-desktop-portal-wlr portal.
+    ///
+    /// A client capturing both an output and the cursor creates two sessions, which are reported
+    /// as two `Cast`s sharing one [`session_id`](Cast::session_id).
+    ExtImageCopyCapture,
 }
 
 /// Target of a screencast.

--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Context as _;
 use niri_config::OutputName;
 use smithay::backend::allocator::dmabuf::Dmabuf;
+use smithay::backend::drm::DrmNode;
 use smithay::backend::egl::native::EGLSurfacelessDisplay;
 use smithay::backend::egl::{EGLContext, EGLDisplay};
 use smithay::backend::renderer::element::RenderElementStates;
@@ -125,6 +126,10 @@ impl Headless {
         f: impl FnOnce(&mut GlesRenderer) -> T,
     ) -> Option<T> {
         self.renderer.as_mut().map(f)
+    }
+
+    pub fn primary_render_node(&mut self) -> Option<DrmNode> {
+        None
     }
 
     pub fn render(&mut self, niri: &mut Niri, output: &Output) -> RenderResult {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use niri_config::{Config, ModKey};
 use smithay::backend::allocator::dmabuf::Dmabuf;
+use smithay::backend::drm::DrmNode;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::output::Output;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
@@ -80,6 +81,18 @@ impl Backend {
             Backend::Tty(tty) => tty.with_primary_renderer(f),
             Backend::Winit(winit) => winit.with_primary_renderer(f),
             Backend::Headless(headless) => headless.with_primary_renderer(f),
+        }
+    }
+
+    /// DRM render node of the primary renderer, if it has one.
+    ///
+    /// This is the node clients should allocate dma-bufs on for the primary renderer to import
+    /// and render into them directly.
+    pub fn primary_render_node(&mut self) -> Option<DrmNode> {
+        match self {
+            Backend::Tty(tty) => tty.primary_render_node(),
+            Backend::Winit(winit) => winit.primary_render_node(),
+            Backend::Headless(headless) => headless.primary_render_node(),
         }
     }
 

--- a/src/backend/tty.rs
+++ b/src/backend/tty.rs
@@ -1851,6 +1851,14 @@ impl Tty {
         Some(f(renderer.as_gles_renderer()))
     }
 
+    pub fn primary_render_node(&mut self) -> Option<DrmNode> {
+        // Only meaningful while the primary renderer exists.
+        self.gpu_manager
+            .single_renderer(&self.primary_render_node)
+            .ok()
+            .map(|_| self.primary_render_node)
+    }
+
     pub fn render(
         &mut self,
         niri: &mut Niri,

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Context as _;
 use niri_config::{Config, OutputName};
 use smithay::backend::allocator::dmabuf::Dmabuf;
+use smithay::backend::drm::DrmNode;
 use smithay::backend::egl::EGLDevice;
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -222,6 +223,16 @@ impl Winit {
         f: impl FnOnce(&mut GlesRenderer) -> T,
     ) -> Option<T> {
         Some(f(self.backend.renderer()))
+    }
+
+    pub fn primary_render_node(&mut self) -> Option<DrmNode> {
+        // Winit creates a single EGL display, so querying the device from it is fine here, unlike
+        // on the TTY backend (see Tty::primary_render_node()).
+        let display = self.backend.renderer().egl_context().display();
+        EGLDevice::device_for_display(display)
+            .ok()?
+            .try_get_render_node()
+            .ok()?
     }
 
     pub fn render(&mut self, niri: &mut Niri, output: &Output) -> RenderResult {

--- a/src/handlers/image_copy_capture.rs
+++ b/src/handlers/image_copy_capture.rs
@@ -1,0 +1,439 @@
+use std::time::Duration;
+
+use smithay::backend::allocator::dmabuf::Dmabuf;
+use smithay::backend::allocator::{Buffer as _, Fourcc, Modifier};
+use smithay::backend::drm::DrmNode;
+use smithay::backend::renderer::damage::OutputDamageTracker;
+use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::backend::renderer::sync::SyncPoint;
+use smithay::output::{Output, WeakOutput};
+use smithay::reexports::calloop::generic::Generic;
+use smithay::reexports::calloop::{Interest, LoopHandle, Mode, PostAction};
+use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
+use smithay::reexports::wayland_server::protocol::wl_pointer::WlPointer;
+use smithay::reexports::wayland_server::protocol::wl_shm;
+use smithay::utils::{
+    Buffer as BufferCoords, Logical, Physical, Point, Rectangle, Scale, Size, Transform,
+};
+use smithay::wayland::dmabuf::get_dmabuf;
+use smithay::wayland::image_capture_source::{
+    ImageCaptureSource, ImageCaptureSourceHandler, OutputCaptureSourceHandler,
+    OutputCaptureSourceState,
+};
+use smithay::wayland::image_copy_capture::{
+    BufferConstraints, CaptureFailureReason, CursorSession, CursorSessionRef, DmabufConstraints,
+    Frame, FrameRef, ImageCopyCaptureHandler, ImageCopyCaptureState, Session, SessionRef,
+};
+use smithay::wayland::shm;
+
+use crate::cursor::{RenderCursor, XCursor};
+use crate::niri::{Niri, State};
+use crate::utils::{CastSessionId, CastStreamId};
+
+/// Output capture session.
+pub struct ImageCopySession {
+    pub session: Session,
+    pub damage_tracker: OutputDamageTracker,
+    /// Frame waiting for output damage.
+    pub pending_frame: Option<Frame>,
+    /// Cast session id, shared with the cursor session of the same source.
+    pub session_id: CastSessionId,
+    /// Cast stream id, unique to this session.
+    pub stream_id: CastStreamId,
+}
+
+/// Cursor capture session of an output.
+pub struct ImageCopyCursorSession {
+    pub session: CursorSession,
+    /// Damage to the cursor image (i.e., not movement).
+    pub damage_tracker: OutputDamageTracker,
+    /// Frame waiting for cursor image change.
+    pub pending_frame: Option<Frame>,
+    /// Cast session id, shared with the output session of the same source.
+    pub session_id: CastSessionId,
+    /// Cast stream id, unique to this session.
+    pub stream_id: CastStreamId,
+}
+
+/// Cast session id of an image capture source.
+///
+/// Stored on the source so that the output session and the corresponding cursor
+/// session are reported as two streams of a single cast session.
+fn source_session_id(source: &ImageCaptureSource) -> CastSessionId {
+    source.user_data().insert_if_missing(CastSessionId::next);
+    *source.user_data().get::<CastSessionId>().unwrap()
+}
+
+/// Output captured by a session, or `None` if it's gone (sessions can outlive
+/// their output).
+pub fn source_output(source: &ImageCaptureSource) -> Option<Output> {
+    source.user_data().get::<WeakOutput>()?.upgrade()
+}
+
+/// Buffer constraints for capturing an output.
+///
+/// `render_node` is the primary renderer's DRM render node (see
+/// `Backend::primary_render_node()`), and only shm will be supported without
+/// one. It is required since querying it from the EGL context fails for the TTY
+/// backend: since Mesa 23.3 and until at least 26.1.8, `_eglGetGbmDisplay()`
+/// clears the display's EGLDevice once a second EGLDisplay is created for the
+/// same GBM device, which the TTY backend does during initialization. See
+/// https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/44351.
+pub fn output_capture_constraints(
+    renderer: &GlesRenderer,
+    render_node: Option<DrmNode>,
+    output: &Output,
+) -> Option<BufferConstraints> {
+    let mode = output.current_mode()?;
+    let size = Size::<i32, BufferCoords>::from((mode.size.w, mode.size.h));
+
+    let dma = (|| {
+        let node = render_node?;
+        let egl = renderer.egl_context();
+
+        // Offer all formats the renderer can draw into to avoid unnecessary
+        // conversions, preserving the original order (many clients depend on
+        // the order being stable to select the same format when renegotiating).
+        let mut formats: Vec<(Fourcc, Vec<Modifier>)> = Vec::new();
+        for format in egl.dmabuf_render_formats().iter() {
+            match formats.iter_mut().find(|(code, _)| *code == format.code) {
+                Some((_, modifiers)) => modifiers.push(format.modifier),
+                None => formats.push((format.code, vec![format.modifier])),
+            }
+        }
+        if formats.is_empty() {
+            return None;
+        }
+
+        // Put Xrgb8888 and Argb8888 first since some clients always take the
+        // first advertised format (e.g. wl-mirror, grim).
+        formats.sort_by_key(|(code, _)| match code {
+            Fourcc::Xrgb8888 => 0,
+            Fourcc::Argb8888 => 1,
+            _ => 2,
+        });
+
+        Some(DmabufConstraints { node, formats })
+    })();
+
+    Some(BufferConstraints {
+        size,
+        shm: vec![wl_shm::Format::Xrgb8888],
+        dma,
+    })
+}
+
+/// Buffer constraints for capturing the cursor of an output. Argb8888 since it has alpha.
+pub fn cursor_capture_constraints(niri: &Niri, output: &Output) -> BufferConstraints {
+    BufferConstraints {
+        size: cursor_capture_size(niri, output),
+        shm: vec![wl_shm::Format::Argb8888],
+        dma: None,
+    }
+}
+
+/// Size the cursor renders at on this output.
+fn cursor_capture_size(niri: &Niri, output: &Output) -> Size<i32, BufferCoords> {
+    let int_scale = output.current_scale().integer_scale();
+    let scale = Scale::from(output.current_scale().fractional_scale());
+
+    let size: Size<i32, Physical> = match niri.cursor_manager.get_render_cursor(int_scale) {
+        RenderCursor::Hidden => Size::from((0, 0)),
+        RenderCursor::Surface { surface, .. } => {
+            let bbox = smithay::desktop::utils::bbox_from_surface_tree(&surface, (0, 0));
+            bbox.to_f64().to_physical_precise_up(scale).size
+        }
+        RenderCursor::Named {
+            scale: buffer_scale,
+            cursor,
+            ..
+        } => {
+            // All frames are the same size since CursorManager::load_xcursor()
+            // picks one size and rejects frames which differ.
+            let (_idx, frame) = cursor.frame(niri.start_time.elapsed().as_millis() as u32);
+            // The image is loaded at the integer scale but drawn at the fractional one, so it
+            // ends up smaller than its own buffer whenever the two differ.
+            let logical = Size::<f64, Logical>::from((
+                f64::from(frame.width) / f64::from(buffer_scale),
+                f64::from(frame.height) / f64::from(buffer_scale),
+            ));
+            logical.to_physical_precise_ceil(scale)
+        }
+    };
+
+    // Fall back to the nominal cursor size when the cursor is currently hidden or has no
+    // buffer, so that the session always has valid constraints.
+    if size.is_empty() {
+        let fallback = i32::from(niri.config.borrow().cursor.xcursor_size) * int_scale;
+        return Size::from((fallback, fallback));
+    }
+
+    Size::from((size.w, size.h))
+}
+
+/// Cursor hotspot in capture buffer coordinates.
+pub fn cursor_capture_hotspot(niri: &Niri, output: &Output) -> Point<i32, BufferCoords> {
+    let int_scale = output.current_scale().integer_scale();
+    let scale = Scale::from(output.current_scale().fractional_scale());
+
+    let hotspot: Point<i32, Physical> = match niri.cursor_manager.get_render_cursor(int_scale) {
+        RenderCursor::Hidden => Point::from((0, 0)),
+        RenderCursor::Surface { surface, hotspot } => {
+            // The tree is shifted to put its bounding box at the origin in
+            // render_cursor_for_capture(), so shift the hotspot too.
+            let bbox = smithay::desktop::utils::bbox_from_surface_tree(&surface, (0, 0));
+            (hotspot - bbox.loc)
+                .to_f64()
+                .to_physical_precise_round(scale)
+        }
+        RenderCursor::Named {
+            scale: buffer_scale,
+            cursor,
+            ..
+        } => {
+            let (_idx, frame) = cursor.frame(niri.start_time.elapsed().as_millis() as u32);
+            // Same rescaling as in cursor_capture_size().
+            XCursor::hotspot(frame)
+                .to_logical(buffer_scale)
+                .to_f64()
+                .to_physical_precise_round(scale)
+        }
+    };
+
+    Point::from((hotspot.x, hotspot.y))
+}
+
+pub enum CaptureBuffer {
+    Dma(Dmabuf),
+    Shm,
+}
+
+/// Checks a frame's buffer for compatibility with the render helpers.
+///
+/// Smithay only validates buffers against the protocol constraints, which allow
+/// a client to attach a larger buffer than asked for, but the render helpers
+/// need an exact match, and checking them here allows mismatches to be reported
+/// to the client.
+pub fn capture_buffer(
+    buffer: &WlBuffer,
+    size: Size<i32, BufferCoords>,
+    format: wl_shm::Format,
+) -> Option<CaptureBuffer> {
+    if let Ok(dmabuf) = get_dmabuf(buffer) {
+        let size_matches = dmabuf.width() == size.w as u32 && dmabuf.height() == size.h as u32;
+        return size_matches.then(|| CaptureBuffer::Dma(dmabuf.clone()));
+    }
+
+    // Stride and pool placement are defined by the client, but the format and
+    // dimensions need to match.
+    let matches = shm::with_buffer_contents(buffer, |_ptr, _len, data| {
+        data.format == format && data.width == size.w && data.height == size.h
+    })
+    .unwrap_or(false);
+    matches.then_some(CaptureBuffer::Shm)
+}
+
+/// Finishes a frame, waiting for `sync_point` first if the render is still in flight.
+///
+/// Like `Screencopy::submit_after_sync()`.
+pub fn frame_success_after_sync<T>(
+    frame: Frame,
+    transform: Transform,
+    damage: Vec<Rectangle<i32, BufferCoords>>,
+    presented: Duration,
+    sync_point: Option<SyncPoint>,
+    event_loop: &LoopHandle<'static, T>,
+) {
+    let Some(sync_fd) = sync_point.and_then(|sync| sync.export()) else {
+        frame.success(transform, damage, presented);
+        return;
+    };
+
+    let mut pending = Some((frame, damage));
+    let source = Generic::new(sync_fd, Interest::READ, Mode::OneShot);
+    let res = event_loop.insert_source(source, move |_, _, _| {
+        let (frame, damage) = pending.take().unwrap();
+        frame.success(transform, damage, presented);
+        Ok(PostAction::Remove)
+    });
+    if let Err(err) = res {
+        // The client will retry (smithay sends an Unknown error when Drop is
+        // called on the Frame).
+        warn!("error waiting for image copy capture sync point: {err}");
+    }
+}
+
+impl ImageCaptureSourceHandler for State {}
+
+impl OutputCaptureSourceHandler for State {
+    fn output_capture_source_state(&mut self) -> &mut OutputCaptureSourceState {
+        &mut self.niri.output_capture_source_state
+    }
+
+    fn output_source_created(&mut self, source: ImageCaptureSource, output: &Output) {
+        source.user_data().insert_if_missing(|| output.downgrade());
+    }
+}
+
+impl ImageCopyCaptureHandler for State {
+    fn image_copy_capture_state(&mut self) -> &mut ImageCopyCaptureState {
+        &mut self.niri.image_copy_capture_state
+    }
+
+    fn capture_constraints(&mut self, source: &ImageCaptureSource) -> Option<BufferConstraints> {
+        let output = source_output(source)?;
+        if !self.niri.output_state.contains_key(&output) {
+            return None;
+        }
+
+        let render_node = self.backend.primary_render_node();
+        self.backend
+            .with_primary_renderer(|renderer| {
+                output_capture_constraints(renderer, render_node, &output)
+            })
+            .flatten()
+    }
+
+    fn cursor_capture_constraints(
+        &mut self,
+        source: &ImageCaptureSource,
+        _pointer: &WlPointer,
+    ) -> Option<BufferConstraints> {
+        let output = source_output(source)?;
+        if !self.niri.output_state.contains_key(&output) {
+            return None;
+        }
+
+        Some(cursor_capture_constraints(&self.niri, &output))
+    }
+
+    fn new_session(&mut self, session: Session) {
+        // Will be updated with the output properties before capture.
+        let damage_tracker = OutputDamageTracker::new((0, 0), 1.0, Transform::Normal);
+        let session_id = source_session_id(&session.source());
+        self.niri.image_copy_sessions.push(ImageCopySession {
+            session,
+            damage_tracker,
+            pending_frame: None,
+            session_id,
+            stream_id: CastStreamId::next(),
+        });
+    }
+
+    fn new_cursor_session(&mut self, session: CursorSession) {
+        // Will be updated with the output properties before capture.
+        let damage_tracker = OutputDamageTracker::new((0, 0), 1.0, Transform::Normal);
+        let session_id = source_session_id(&session.source());
+        self.niri
+            .image_copy_cursor_sessions
+            .push(ImageCopyCursorSession {
+                session,
+                damage_tracker,
+                pending_frame: None,
+                session_id,
+                stream_id: CastStreamId::next(),
+            });
+        // Send the initial cursor position and hotspot.
+        self.niri.refresh_image_copy_cursor_sessions();
+    }
+
+    fn frame(&mut self, session: &SessionRef, frame: Frame) {
+        let Some(s) = self
+            .niri
+            .image_copy_sessions
+            .iter_mut()
+            .find(|s| s.session == *session)
+        else {
+            frame.fail(CaptureFailureReason::Unknown);
+            return;
+        };
+
+        // A session may only have one frame object in flight at a time, a
+        // second one is a duplicate_frame protocol error. Smithay doesn't check
+        // itself it (create_frame pushes onto active_frames unconditionally)
+        // and doesn't expose the session object for us to post_error() on, so
+        // fail the frame rather than leak it.
+        if s.pending_frame.is_some() {
+            warn!("client created a second frame while one was still in flight"); // client bug
+            frame.fail(CaptureFailureReason::Unknown);
+            return;
+        }
+        s.pending_frame = Some(frame);
+
+        // The frame is captured on the next redraw with damage.
+        if let Some(output) = source_output(&session.source()) {
+            // The output may be gone already (the global lingers).
+            if self.niri.output_exists(&output) {
+                self.niri.queue_redraw(&output);
+            }
+        }
+    }
+
+    fn cursor_frame(&mut self, session: &CursorSessionRef, frame: Frame) {
+        let Some(s) = self
+            .niri
+            .image_copy_cursor_sessions
+            .iter_mut()
+            .find(|s| s.session == *session)
+        else {
+            frame.fail(CaptureFailureReason::Unknown);
+            return;
+        };
+
+        // Same as above.
+        if s.pending_frame.is_some() {
+            warn!("client created a second cursor frame while one was still in flight");
+            frame.fail(CaptureFailureReason::Unknown);
+            return;
+        }
+        s.pending_frame = Some(frame);
+
+        // The frame is captured on the next redraw when the cursor image changes.
+        if let Some(output) = source_output(&session.source()) {
+            // The output may be gone already (the global lingers).
+            if self.niri.output_exists(&output) {
+                self.niri.queue_redraw(&output);
+            }
+        }
+    }
+
+    fn frame_aborted(&mut self, frame: FrameRef) {
+        for s in &mut self.niri.image_copy_sessions {
+            if s.pending_frame.as_deref() == Some(&frame) {
+                s.pending_frame = None;
+            }
+        }
+        for s in &mut self.niri.image_copy_cursor_sessions {
+            if s.pending_frame.as_deref() == Some(&frame) {
+                s.pending_frame = None;
+            }
+        }
+    }
+
+    fn session_destroyed(&mut self, session: SessionRef) {
+        let sessions = &mut self.niri.image_copy_sessions;
+        if let Some(idx) = sessions.iter().position(|s| s.session == session) {
+            let s = sessions.remove(idx);
+            if let Some(frame) = s.pending_frame {
+                // Like wlroots.
+                frame.fail(CaptureFailureReason::Stopped);
+            }
+        }
+        self.niri.image_copy_capture_state.cleanup();
+    }
+
+    fn cursor_session_destroyed(&mut self, session: CursorSessionRef) {
+        // FIXME: this doesn't get called by smithay when the underlying
+        // ext_image_copy_capture_session_v1 is destroyed, only when the
+        // ext_image_copy_capture_cursor_session_v1 is destroyed
+        let sessions = &mut self.niri.image_copy_cursor_sessions;
+        if let Some(idx) = sessions.iter().position(|s| s.session == session) {
+            let s = sessions.remove(idx);
+            if let Some(frame) = s.pending_frame {
+                // Like wlroots.
+                frame.fail(CaptureFailureReason::Stopped);
+            }
+        }
+        self.niri.image_copy_capture_state.cleanup();
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 pub mod background_effect;
 mod compositor;
+pub mod image_copy_capture;
 mod layer_shell;
 mod xdg_shell;
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -751,6 +751,7 @@ fn print_cast(cast: &Cast) {
     let kind = match cast.kind {
         CastKind::PipeWire => "PipeWire",
         CastKind::WlrScreencopy => "wlr-screencopy",
+        CastKind::ExtImageCopyCapture => "ext-image-copy-capture",
     };
     println!("  Kind: {kind}");
 

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -31,6 +31,7 @@ use smithay::utils::SERIAL_COUNTER;
 use smithay::wayland::shell::wlr_layer::{KeyboardInteractivity, Layer};
 
 use crate::backend::IpcOutputMap;
+use crate::handlers::image_copy_capture;
 use crate::input::pick_window_grab::PickWindowGrab;
 use crate::layout::workspace::WorkspaceId;
 use crate::niri::State;
@@ -903,6 +904,47 @@ impl State {
                     };
                     events.push(Event::CastStartedOrChanged { cast });
                 }
+            }
+        }
+
+        // Check ext-image-copy-capture casts.
+        //
+        // Unlike wlr-screencopy, a session is an explicit protocol object, so
+        // the cast lifetime is tied to it. Dead sessions are already dropped by
+        // refresh_image_copy_capture(), which runs before this.
+        let output_sessions = self
+            .niri
+            .image_copy_sessions
+            .iter()
+            .map(|s| (s.session_id, s.stream_id, s.session.source()));
+        let cursor_sessions = self
+            .niri
+            .image_copy_cursor_sessions
+            .iter()
+            .map(|s| (s.session_id, s.stream_id, s.session.source()));
+        for (session_id, stream_id, source) in output_sessions.chain(cursor_sessions) {
+            let Some(output) = image_copy_capture::source_output(&source) else {
+                continue;
+            };
+
+            let stream_id = stream_id.get();
+            seen.insert(stream_id);
+
+            if !state.casts.contains_key(&stream_id) {
+                let cast = niri_ipc::Cast {
+                    session_id: session_id.get(),
+                    stream_id,
+                    kind: niri_ipc::CastKind::ExtImageCopyCapture,
+                    target: niri_ipc::CastTarget::Output {
+                        name: output.name(),
+                    },
+                    is_dynamic_target: false,
+                    is_active: true,
+                    // FIXME: smithay doesn't expose the client of a image-copy-capture session.
+                    pid: None,
+                    pw_node_id: None,
+                };
+                events.push(Event::CastStartedOrChanged { cast });
             }
         }
 

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -70,8 +70,8 @@ use smithay::reexports::wayland_server::protocol::wl_shm;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::{Client, Display, DisplayHandle, Resource};
 use smithay::utils::{
-    ClockSource, IsAlive as _, Logical, Monotonic, Physical, Point, Rectangle, Scale, Size,
-    Transform, SERIAL_COUNTER,
+    Buffer as BufferCoords, ClockSource, IsAlive as _, Logical, Monotonic, Physical, Point,
+    Rectangle, Scale, Size, Transform, SERIAL_COUNTER,
 };
 use smithay::wayland::background_effect::BackgroundEffectState;
 use smithay::wayland::compositor::{
@@ -83,6 +83,10 @@ use smithay::wayland::dmabuf::DmabufState;
 use smithay::wayland::fractional_scale::FractionalScaleManagerState;
 use smithay::wayland::idle_inhibit::IdleInhibitManagerState;
 use smithay::wayland::idle_notify::IdleNotifierState;
+use smithay::wayland::image_capture_source::{
+    ImageCaptureSource, ImageCaptureSourceState, OutputCaptureSourceState,
+};
+use smithay::wayland::image_copy_capture::{CaptureFailureReason, ImageCopyCaptureState};
 use smithay::wayland::input_method::InputMethodManagerState;
 use smithay::wayland::keyboard_shortcuts_inhibit::{
     KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
@@ -129,6 +133,9 @@ use crate::dbus::gnome_shell_introspect::{self, IntrospectToNiri, NiriToIntrospe
 #[cfg(feature = "dbus")]
 use crate::dbus::gnome_shell_screenshot::{NiriToScreenshot, ScreenshotToNiri};
 use crate::frame_clock::FrameClock;
+use crate::handlers::image_copy_capture::{
+    self as image_copy_capture_impl, CaptureBuffer, ImageCopyCursorSession, ImageCopySession,
+};
 use crate::handlers::{configure_lock_surface, XDG_ACTIVATION_TOKEN_TIMEOUT};
 use crate::input::pick_color_grab::PickColorGrab;
 use crate::input::scroll_swipe_gesture::ScrollSwipeGesture;
@@ -272,6 +279,13 @@ pub struct Niri {
     pub tablets: HashMap<input::Device, TabletData>,
     pub touch: HashSet<input::Device>,
 
+    /// Output capture sessions. Kept out of the protocol state because each one needs a damage
+    /// tracker and is handled in the redraw loop.
+    pub image_copy_sessions: Vec<ImageCopySession>,
+
+    /// Cursor capture sessions, same as above.
+    pub image_copy_cursor_sessions: Vec<ImageCopyCursorSession>,
+
     // Smithay state.
     pub compositor_state: CompositorState,
     pub xdg_shell_state: XdgShellState,
@@ -282,6 +296,9 @@ pub struct Niri {
     pub foreign_toplevel_state: ForeignToplevelManagerState,
     pub ext_workspace_state: ExtWorkspaceManagerState,
     pub screencopy_state: ScreencopyManagerState,
+    pub image_capture_source_state: ImageCaptureSourceState,
+    pub output_capture_source_state: OutputCaptureSourceState,
+    pub image_copy_capture_state: ImageCopyCaptureState,
     pub output_management_state: OutputManagementManagerState,
     pub viewporter_state: ViewporterState,
     pub background_effect_state: BackgroundEffectState,
@@ -822,6 +839,8 @@ impl State {
         self.refresh_pointer_contents();
         foreign_toplevel::refresh(self);
         ext_workspace::refresh(self);
+        self.refresh_image_copy_capture();
+        self.niri.refresh_image_copy_cursor_sessions();
 
         #[cfg(feature = "xdp-gnome-screencast")]
         self.niri.refresh_mapped_cast_outputs();
@@ -839,6 +858,94 @@ impl State {
         // Needs to be called after updating the keyboard focus.
         #[cfg(feature = "dbus")]
         self.niri.refresh_a11y();
+    }
+
+    /// Stop sessions whose source is gone and sync buffer constraints. Runs as
+    /// part of every refresh so constraints are correct before redrawing and so
+    /// missing sources aren't missed.
+    pub fn refresh_image_copy_capture(&mut self) {
+        if self.niri.image_copy_sessions.is_empty()
+            && self.niri.image_copy_cursor_sessions.is_empty()
+        {
+            return;
+        }
+
+        let _span = tracy_client::span!("State::refresh_image_copy_capture");
+
+        // Dropping a session sends `stopped` and fails all of its pending frames.
+        fn live_output(niri: &Niri, source: &ImageCaptureSource) -> Option<Output> {
+            image_copy_capture_impl::source_output(source)
+                .filter(|output| niri.output_state.contains_key(output))
+        }
+
+        let mut sessions = mem::take(&mut self.niri.image_copy_sessions);
+        sessions.retain_mut(|s| {
+            let Some(output) = live_output(&self.niri, &s.session.source()) else {
+                return false;
+            };
+
+            // This runs once per event loop iteration, and building the full
+            // constraints is expensive. We only compare the size, so a change
+            // in the dmabuf formats or device alone doesn't matter to us here
+            // (and if it does, polling is not the way to check for it).
+            let Some(mode) = output.current_mode() else {
+                return false;
+            };
+            let size = Size::<i32, BufferCoords>::from((mode.size.w, mode.size.h));
+            if s.session.current_constraints().map(|c| c.size) == Some(size) {
+                return true;
+            }
+
+            // The size changed, so build the full constraints and send them to the client below.
+            let render_node = self.backend.primary_render_node();
+            let constraints = self
+                .backend
+                .with_primary_renderer(|renderer| {
+                    image_copy_capture_impl::output_capture_constraints(
+                        renderer,
+                        render_node,
+                        &output,
+                    )
+                })
+                .flatten();
+            let Some(constraints) = constraints else {
+                return false;
+            };
+
+            // Cannot capture a frame for outdated constraints, so fail it
+            // before sending the new constraints (otherwise clients which
+            // re-negotiate on failure may miss the new `done`).
+            if let Some(frame) = s.pending_frame.take() {
+                frame.fail(CaptureFailureReason::BufferConstraints);
+            }
+            s.session.update_constraints(constraints);
+
+            true
+        });
+        // This shouldn't be possible since sessions are only added from the
+        // ImageCopyCaptureHandler callbacks, which run in dispatch_clients()
+        // (i.e., not in here), but append just in case it ever changes...
+        if !self.niri.image_copy_sessions.is_empty() {
+            error!("session added while refreshing image-copy-capture sessions");
+            sessions.append(&mut self.niri.image_copy_sessions);
+        }
+        self.niri.image_copy_sessions = sessions;
+
+        // Cursor session constraints are refreshed in refresh_image_copy_cursor_sessions().
+        let mut cursor_sessions = mem::take(&mut self.niri.image_copy_cursor_sessions);
+        cursor_sessions.retain(|s| live_output(&self.niri, &s.session.source()).is_some());
+        // This shouldn't be possible since sessions are only added from the
+        // ImageCopyCaptureHandler callbacks, which run in dispatch_clients()
+        // (i.e., not in here), but append just in case it ever changes...
+        if !self.niri.image_copy_cursor_sessions.is_empty() {
+            error!("session added while refreshing image-copy-capture sessions");
+            cursor_sessions.append(&mut self.niri.image_copy_cursor_sessions);
+        }
+        self.niri.image_copy_cursor_sessions = cursor_sessions;
+
+        // Don't leak dead sessions (they take memory and smithay scans them
+        // every time).
+        self.niri.image_copy_capture_state.cleanup();
     }
 
     fn notify_blocker_cleared(&mut self) {
@@ -2367,6 +2474,15 @@ impl Niri {
         output_management_state.on_config_changed(config_.outputs.clone());
         let screencopy_state =
             ScreencopyManagerState::new::<State, _>(&display_handle, client_is_unrestricted);
+        let image_capture_source_state = ImageCaptureSourceState::new();
+        let output_capture_source_state = OutputCaptureSourceState::new_with_filter::<State, _>(
+            &display_handle,
+            client_is_unrestricted,
+        );
+        let image_copy_capture_state = ImageCopyCaptureState::new_with_filter::<State, _>(
+            &display_handle,
+            client_is_unrestricted,
+        );
         let viewporter_state = ViewporterState::new::<State>(&display_handle);
         let background_effect_state = BackgroundEffectState::new::<State>(&display_handle);
         let xdg_foreign_state = XdgForeignState::new::<State>(&display_handle);
@@ -2552,6 +2668,11 @@ impl Niri {
             ext_workspace_state,
             output_management_state,
             screencopy_state,
+            image_capture_source_state,
+            output_capture_source_state,
+            image_copy_capture_state,
+            image_copy_sessions: Vec::new(),
+            image_copy_cursor_sessions: Vec::new(),
             viewporter_state,
             background_effect_state,
             xdg_foreign_state,
@@ -4730,6 +4851,8 @@ impl Niri {
             }
 
             self.render_for_screencopy_with_damage(renderer, output);
+            self.render_for_image_copy_capture(renderer, output, target_presentation_time);
+            self.render_for_image_copy_cursor_capture(renderer, output, target_presentation_time);
         });
     }
 
@@ -5410,6 +5533,393 @@ impl Niri {
         res
     }
 
+    pub fn render_for_image_copy_capture(
+        &mut self,
+        renderer: &mut GlesRenderer,
+        output: &Output,
+        target_presentation_time: Duration,
+    ) {
+        let Some(mode) = output.current_mode() else {
+            return;
+        };
+
+        let _span = tracy_client::span!("Niri::render_for_image_copy_capture");
+
+        let size = mode.size;
+        let scale: Scale<f64> = output.current_scale().fractional_scale().into();
+        let transform = output.current_transform();
+
+        // Sessions with a single output only differ by whether they capture the
+        // cursor, so at most two renders are needed regardless of how many
+        // clients are capturing.
+        let mut cached_elements: [Option<Vec<_>>; 2] = [None, None];
+
+        let mut sessions = mem::take(&mut self.image_copy_sessions);
+        for s in &mut sessions {
+            // Cheapest check first.
+            if s.pending_frame.is_none() {
+                continue;
+            }
+
+            let Some(s_output) = image_copy_capture_impl::source_output(&s.session.source()) else {
+                continue;
+            };
+            if s_output != *output {
+                continue;
+            }
+
+            // Recreate the damage tracker if the output changed.
+            let OutputModeSource::Static {
+                size: last_size,
+                scale: last_scale,
+                transform: last_transform,
+            } = s.damage_tracker.mode().clone()
+            else {
+                unreachable!("damage tracker must have static mode");
+            };
+            if size != last_size || scale != last_scale || transform != last_transform {
+                s.damage_tracker = OutputDamageTracker::new(size, scale, transform);
+            }
+
+            let draw_cursor = s.session.draw_cursor();
+            let cached = &mut cached_elements[usize::from(draw_cursor)];
+            let elements = cached.get_or_insert_with(|| {
+                let ctx = RenderCtx {
+                    renderer: &mut *renderer,
+                    target: RenderTarget::ScreenCapture,
+                    xray: None,
+                };
+                let mut elements = Vec::new();
+                self.render(ctx, output, draw_cursor, &mut |elem| {
+                    elements.push(elem);
+                });
+                elements
+            });
+
+            let (damage, states) = s.damage_tracker.damage_output(1, elements).unwrap();
+            let Some(damage) = damage else {
+                // No damage, capture the frame later.
+                continue;
+            };
+
+            // Convert from Physical coordinates back to Buffer coordinates.
+            let physical_size = transform.transform_size(size);
+            let damage: Vec<Rectangle<i32, BufferCoords>> = damage
+                .iter()
+                .map(|dmg| {
+                    dmg.to_logical(1)
+                        .to_buffer(1, transform.invert(), &physical_size.to_logical(1))
+                })
+                .collect();
+
+            let frame = s.pending_frame.take().unwrap();
+            let buffer = frame.buffer();
+            let buffer_size = Size::<i32, BufferCoords>::from((size.w, size.h));
+            let capture_buffer = image_copy_capture_impl::capture_buffer(
+                &buffer,
+                buffer_size,
+                wl_shm::Format::Xrgb8888,
+            );
+            let Some(capture_buffer) = capture_buffer else {
+                frame.fail(CaptureFailureReason::BufferConstraints);
+                // Report full damage next time.
+                s.damage_tracker = OutputDamageTracker::new(size, scale, transform);
+                continue;
+            };
+
+            let res = match capture_buffer {
+                CaptureBuffer::Dma(dmabuf) => {
+                    render_to_dmabuf(renderer, &mut s.damage_tracker, dmabuf, elements, states)
+                        .map(Some)
+                }
+                CaptureBuffer::Shm => render_to_shm(
+                    renderer,
+                    &mut s.damage_tracker,
+                    &buffer,
+                    wl_shm::Format::Xrgb8888,
+                    elements,
+                    states,
+                )
+                .map(|()| None),
+            };
+
+            match res {
+                Ok(sync) => {
+                    image_copy_capture_impl::frame_success_after_sync(
+                        frame,
+                        transform,
+                        damage,
+                        target_presentation_time,
+                        sync,
+                        &self.event_loop,
+                    );
+                }
+                Err(err) => {
+                    warn!("error rendering for image copy capture: {err:?}");
+                    frame.fail(CaptureFailureReason::Unknown);
+                    // Report full damage next time.
+                    s.damage_tracker = OutputDamageTracker::new(size, scale, transform);
+                }
+            }
+        }
+
+        // This shouldn't be possible since sessions are only added from the
+        // ImageCopyCaptureHandler callbacks, which run in dispatch_clients()
+        // (i.e., not in here), but append just in case it ever changes...
+        if !self.image_copy_sessions.is_empty() {
+            error!("session added while rendering image-copy-capture frame");
+            sessions.append(&mut self.image_copy_sessions);
+        }
+        self.image_copy_sessions = sessions;
+    }
+
+    pub fn render_for_image_copy_cursor_capture(
+        &mut self,
+        renderer: &mut GlesRenderer,
+        output: &Output,
+        target_presentation_time: Duration,
+    ) {
+        let _span = tracy_client::span!("Niri::render_for_image_copy_cursor_capture");
+
+        let scale: Scale<f64> = output.current_scale().fractional_scale().into();
+
+        // The cursor render is the same for all sessions on the output.
+        let mut cached_elements = None;
+
+        let mut sessions = mem::take(&mut self.image_copy_cursor_sessions);
+        for s in &mut sessions {
+            if s.pending_frame.is_none() {
+                continue;
+            }
+            let Some(s_output) = image_copy_capture_impl::source_output(&s.session.source()) else {
+                continue;
+            };
+            if s_output != *output {
+                continue;
+            }
+
+            // The constraints are kept up to date with the cursor image size in
+            // refresh_image_copy_cursor_sessions, which also fails pending frames on change.
+            let Some(constraints) = s.session.current_constraints() else {
+                let frame = s.pending_frame.take().unwrap();
+                frame.fail(CaptureFailureReason::BufferConstraints);
+                continue;
+            };
+            let size = Size::<i32, Physical>::from((constraints.size.w, constraints.size.h));
+
+            // Recreate the damage tracker if the cursor buffer size or output scale changed.
+            let OutputModeSource::Static {
+                size: last_size,
+                scale: last_scale,
+                ..
+            } = s.damage_tracker.mode().clone()
+            else {
+                unreachable!("damage tracker must have static mode");
+            };
+            if size != last_size || scale != last_scale {
+                s.damage_tracker = OutputDamageTracker::new(size, scale, Transform::Normal);
+            }
+
+            let elements = cached_elements
+                .get_or_insert_with(|| self.render_cursor_for_capture(renderer, output));
+
+            let (damage, states) = s.damage_tracker.damage_output(1, elements).unwrap();
+            if damage.is_none() {
+                // No change, capture the frame later.
+                continue;
+            }
+
+            let frame = s.pending_frame.take().unwrap();
+            let buffer = frame.buffer();
+            let capture_buffer = image_copy_capture_impl::capture_buffer(
+                &buffer,
+                constraints.size,
+                wl_shm::Format::Argb8888,
+            );
+            if !matches!(capture_buffer, Some(CaptureBuffer::Shm)) {
+                frame.fail(CaptureFailureReason::BufferConstraints);
+                // Report full damage next time.
+                s.damage_tracker = OutputDamageTracker::new(size, scale, Transform::Normal);
+                continue;
+            }
+
+            let res = render_to_shm(
+                renderer,
+                &mut s.damage_tracker,
+                &buffer,
+                wl_shm::Format::Argb8888,
+                elements,
+                states,
+            );
+            match res {
+                Ok(()) => {
+                    let full_damage = vec![Rectangle::from_size(constraints.size)];
+                    frame.success(Transform::Normal, full_damage, target_presentation_time);
+                }
+                Err(err) => {
+                    warn!("error rendering for cursor capture: {err:?}");
+                    frame.fail(CaptureFailureReason::Unknown);
+                    // Report full damage next time.
+                    s.damage_tracker = OutputDamageTracker::new(size, scale, Transform::Normal);
+                }
+            }
+        }
+
+        // This shouldn't be possible since sessions are only added from the
+        // ImageCopyCaptureHandler callbacks, which run in dispatch_clients()
+        // (i.e., not in here), but append just in case it ever changes...
+        if !self.image_copy_cursor_sessions.is_empty() {
+            error!("session added while rendering image-copy-capture frame");
+            sessions.append(&mut self.image_copy_cursor_sessions);
+        }
+        self.image_copy_cursor_sessions = sessions;
+    }
+
+    pub fn render_cursor_for_capture(
+        &self,
+        renderer: &mut GlesRenderer,
+        output: &Output,
+    ) -> Vec<PointerRenderElements<GlesRenderer>> {
+        let int_scale = output.current_scale().integer_scale();
+        let output_scale = Scale::from(output.current_scale().fractional_scale());
+
+        let mut elements = Vec::new();
+        match self.cursor_manager.get_render_cursor(int_scale) {
+            RenderCursor::Hidden => (),
+            RenderCursor::Surface { surface, .. } => {
+                // Subsurfaces can extend above or to the left of the root surface, so shift the
+                // tree to put its bounding box at the origin. The hotspot is shifted to match in
+                // cursor_capture_hotspot().
+                let bbox = smithay::desktop::utils::bbox_from_surface_tree(&surface, (0, 0));
+                let loc = Point::<i32, Logical>::from((-bbox.loc.x, -bbox.loc.y))
+                    .to_f64()
+                    .to_physical_precise_round(output_scale);
+                push_elements_from_surface_tree(
+                    renderer,
+                    &surface,
+                    loc,
+                    output_scale,
+                    1.,
+                    Kind::Cursor,
+                    &mut |elem| elements.push(elem.into()),
+                );
+            }
+            RenderCursor::Named {
+                icon,
+                scale,
+                cursor,
+            } => {
+                let (idx, _frame) = cursor.frame(self.start_time.elapsed().as_millis() as u32);
+                let texture = self.cursor_texture_cache.get(icon, scale, &cursor, idx);
+                match MemoryRenderBufferRenderElement::from_buffer(
+                    renderer,
+                    Point::<f64, _>::from((0., 0.)),
+                    &texture,
+                    None,
+                    None,
+                    None,
+                    Kind::Cursor,
+                ) {
+                    Ok(element) => elements.push(element.into()),
+                    Err(err) => {
+                        warn!("error importing a cursor texture: {err:?}");
+                    }
+                }
+            }
+        }
+
+        elements
+    }
+
+    /// Sends cursor position, hotspot and size to cursor sessions independently
+    /// of the cursor image.
+    pub fn refresh_image_copy_cursor_sessions(&mut self) {
+        if self.image_copy_cursor_sessions.is_empty() {
+            return;
+        }
+
+        let _span = tracy_client::span!("Niri::refresh_image_copy_cursor_sessions");
+
+        let pointer_pos = self
+            .tablet_cursor_location
+            .unwrap_or_else(|| self.seat.get_pointer().unwrap().current_location());
+
+        let mut sessions = mem::take(&mut self.image_copy_cursor_sessions);
+        for s in &mut sessions {
+            let Some(output) = image_copy_capture_impl::source_output(&s.session.source()) else {
+                s.session.set_cursor_pos(None);
+                continue;
+            };
+            let Some(geo) = self.global_space.output_geometry(&output) else {
+                s.session.set_cursor_pos(None);
+                continue;
+            };
+            let Some(mode) = output.current_mode() else {
+                s.session.set_cursor_pos(None);
+                continue;
+            };
+
+            let scale = Scale::from(output.current_scale().fractional_scale());
+
+            // Update the constraints if the cursor image size changed.
+            let constraints = image_copy_capture_impl::cursor_capture_constraints(self, &output);
+            let cursor_size = constraints.size;
+            let size_changed = s
+                .session
+                .current_constraints()
+                .is_none_or(|c| (c.size.w, c.size.h) != (constraints.size.w, constraints.size.h));
+            if size_changed {
+                // Cannot capture a frame for outdated constraints, so fail it
+                // before sending the new constraints (otherwise clients which
+                // re-negotiate on failure may miss the new `done`).
+                if let Some(frame) = s.pending_frame.take() {
+                    frame.fail(CaptureFailureReason::BufferConstraints);
+                }
+                s.session.update_constraints(constraints);
+            }
+
+            let hotspot = image_copy_capture_impl::cursor_capture_hotspot(self, &output);
+            s.session.set_cursor_hotspot((hotspot.x, hotspot.y));
+
+            // Unlike frame damage, the position is in transformed buffer coordinates, i.e. the
+            // displayed orientation, so the output transform is not undone here. This matches
+            // wlroots.
+            let pos: Point<i32, Physical> =
+                (pointer_pos - geo.loc.to_f64()).to_physical_precise_round(scale);
+
+            // Cursors are considered to have entered if any part of the image
+            // intersects the output, not just the hotspot, so the position may
+            // be negative or past the edge.
+            //
+            // The imagecopy protocol specifies this interpretation
+            // specifically, even though it differs from wl_pointer.enter,
+            // including the coordinates being outside the output bounds. This
+            // is also how wlroots implements it.
+            //
+            // This intentionally differs from how PipeWire casts work since PW
+            // requires the pointer to be within the output bounds, but this
+            // isn't relevant (or wanted) for the imagecopy protocol.
+            let hotspot = Point::<i32, Physical>::from((hotspot.x, hotspot.y));
+            let image = Rectangle::new(pos - hotspot, Size::from((cursor_size.w, cursor_size.h)));
+            let output_rect =
+                Rectangle::from_size(output.current_transform().transform_size(mode.size));
+            if self.pointer_visibility.is_visible() && image.overlaps(output_rect) {
+                // not geo.to_f64().contains(pointer_pos)
+                s.session.set_cursor_pos(Some(Point::from((pos.x, pos.y))));
+            } else {
+                s.session.set_cursor_pos(None);
+            }
+        }
+        // This shouldn't be possible since sessions are only added from the
+        // ImageCopyCaptureHandler callbacks, which run in dispatch_clients()
+        // (i.e., not in here), but append just in case it ever changes...
+        if !self.image_copy_cursor_sessions.is_empty() {
+            error!("session added while rendering image-copy-capture frame");
+            sessions.append(&mut self.image_copy_cursor_sessions);
+        }
+        self.image_copy_cursor_sessions = sessions;
+    }
+
     fn damage_screencopy_internal<'a>(
         output: &Output,
         elements: &[impl Element],
@@ -5456,8 +5966,15 @@ impl Niri {
                 Some(sync)
             }
             ScreencopyBuffer::Shm(wl_buffer) => {
-                render_to_shm(renderer, damage_tracker, wl_buffer, elements, states)
-                    .context("error rendering to screencopy shm buffer")?;
+                render_to_shm(
+                    renderer,
+                    damage_tracker,
+                    wl_buffer,
+                    wl_shm::Format::Xrgb8888,
+                    elements,
+                    states,
+                )
+                .context("error rendering to screencopy shm buffer")?;
                 None
             }
         };

--- a/src/render_helpers/mod.rs
+++ b/src/render_helpers/mod.rs
@@ -1,6 +1,6 @@
 use std::ptr;
 
-use anyhow::{ensure, Context as _};
+use anyhow::{bail, ensure, Context as _};
 use niri_config::BlockOutFrom;
 use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::allocator::{Buffer, Fourcc};
@@ -301,6 +301,7 @@ pub fn render_to_shm(
     renderer: &mut GlesRenderer,
     damage_tracker: &mut OutputDamageTracker,
     buffer: &WlBuffer,
+    format: wl_shm::Format,
     elements: &[impl RenderElement<GlesRenderer>],
     states: RenderElementStates,
 ) -> anyhow::Result<()> {
@@ -309,11 +310,15 @@ pub fn render_to_shm(
     // buffers besides this one... buffer_data is the one we want.
     shm::with_buffer_contents_mut(buffer, |pool, pool_len, buffer_data| {
         let (size, _scale, _transform) = damage_tracker.mode().try_into().unwrap();
-        let fourcc = Fourcc::Xrgb8888;
+        let fourcc = match format {
+            wl_shm::Format::Xrgb8888 => Fourcc::Xrgb8888,
+            wl_shm::Format::Argb8888 => Fourcc::Argb8888,
+            _ => bail!("unsupported shm format: {format:?}"),
+        };
 
         ensure!(
             // The buffer prefers pixels in little endian ...
-            buffer_data.format == wl_shm::Format::Xrgb8888
+            buffer_data.format == format
                 && buffer_data.width == size.w
                 && buffer_data.height == size.h,
             "invalid buffer format or size"


### PR DESCRIPTION
Implement ext-image-copy-capture with output/cursor capture sources, and shm/dma buffers.

I've been using this (along with #4548) daily since mid-June, with RealVNC via [`xwlrvnc`](https://github.com/pgaskin/xwlrvnc), and wayvnc.

I've also tested it with grim, lamco-rdp-server, and briefly with wl-screencopy.

I've tested various output layouts and DPI settings, on both real TTYs and winit.

Compared to #3942, this one doesn't implement window capture, but it implements cursor capture, correctly handles sandboxing (i.e., `client_is_unrestricted`), properly handles BufferConstraints (the other one breaks with many actual clients), and properly cleans up stale sessions.

In addition, I've optimized it to not re-render more than necessary, even with multiple capture sessions.

includes #4553 (merge that one first)
partially replaces #3942
closes #1558